### PR TITLE
Fixes call to JATON missing typecast (const char*)

### DIFF
--- a/n_helpers.c
+++ b/n_helpers.c
@@ -371,7 +371,7 @@ JNUMBER NoteGetEnvNumber(const char *variable, JNUMBER defaultVal) {
     char buf[32], buf2[32];;
 	snprintf(buf2, sizeof(buf2), "%f", defaultVal);
     NoteGetEnv(variable, buf2, buf, sizeof(buf));
-    return JAtoN(buf, NULL);
+    return JAtoN((const char*)buf, NULL);
 }
 
 //**************************************************************************/


### PR DESCRIPTION
 Functions declared using K&R syntax, the parameters used when the function is called must match the required data types in the function definition

 This was required to get note-c to compile with clang.

https://en.cppreference.com/w/c/language/function_declaration 