### PR TITLE
Fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ For details on contributions we accept and the process for contributing, see our
 
 For additional Notecard SDKs and Libraries, see:
 
-* [note-arduino](note-arduino) for Arduino support
-* [note-python](note-python) for Python
-* [note-go](note-go) for Go
+* [note-arduino][note-arduino] for Arduino support
+* [note-python][note-python] for Python
+* [note-go][note-go] for Go
 
 ## To learn more about Blues Wireless, the Notecard and Notehub, see:
 


### PR DESCRIPTION
Fixes relative links that should be external.
For example, the note-arduino link was pointing to https://github.com/blues/note-c/blob/master/note-arduino instead of https://github.com/blues/note-arduino