### PR TITLE
feat: NoteGetEnv() return bool, true if JSON response, no err.

### DIFF
--- a/n_helpers.c
+++ b/n_helpers.c
@@ -396,9 +396,12 @@ int NoteGetEnvInt(const char *variable, int defaultVal) {
     @param   defaultVal The variable value.
     @param   buf (out) The buffer in which to place the variable value.
     @param   buflen The length of the output buffer.
+    @returns true if there is no error (JSON response with no explicit error)
 */
 /**************************************************************************/
-void NoteGetEnv(const char *variable, const char *defaultVal, char *buf, uint32_t buflen) {
+bool NoteGetEnv(const char *variable, const char *defaultVal, char *buf, uint32_t buflen) {
+  
+    bool success = false;
     if (defaultVal == NULL)
         buf[0] = '\0';
     else
@@ -409,6 +412,7 @@ void NoteGetEnv(const char *variable, const char *defaultVal, char *buf, uint32_
         J *rsp = NoteRequestResponse(req);
         if (rsp != NULL) {
             if (!NoteResponseError(rsp)) {
+                success = true;
                 char *val = JGetString(rsp, "text");
                 if (val[0] != '\0')
                     strlcpy(buf, val, buflen);
@@ -416,6 +420,7 @@ void NoteGetEnv(const char *variable, const char *defaultVal, char *buf, uint32_
             NoteDeleteResponse(rsp);
         }
     }
+    return success;
 }
 
 //**************************************************************************/

--- a/note.h
+++ b/note.h
@@ -184,7 +184,7 @@ bool NoteLocationValid(char *errbuf, uint32_t errbuflen);
 bool NoteLocationValidST(char *errbuf, uint32_t errbuflen);
 int NoteGetEnvInt(const char *variable, int defaultVal);
 JNUMBER NoteGetEnvNumber(const char *variable, JNUMBER defaultVal);
-void NoteGetEnv(const char *variable, const char *defaultVal, char *buf, uint32_t buflen);
+bool NoteGetEnv(const char *variable, const char *defaultVal, char *buf, uint32_t buflen);
 bool NoteSetEnvDefault(const char *variable, char *buf);
 bool NoteSetEnvDefaultNumber(const char *variable, JNUMBER defaultVal);
 bool NoteSetEnvDefaultInt(const char *variable, int defaultVal);


### PR DESCRIPTION
Helpful if the Notecard host uses env var cacheing, because the host
must only cache the returned value if it is known that the Notecard
replied with either {} or with the env var value.