### PR TITLE
Fixes links to other note-* repositories in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ For details on contributions we accept and the process for contributing, see our
 
 For additional Notecard SDKs and Libraries, see:
 
-* [note-arduino](note-arduino) for Arduino support
-* [note-python](note-python) for Python
-* [note-go](note-go) for Go
+* [note-arduino][note-arduino] for Arduino support
+* [note-python][note-python] for Python
+* [note-go][note-go] for Go
 
 ## To learn more about Blues Wireless, the Notecard and Notehub, see:
 


### PR DESCRIPTION
Fixing broken links in README to 
 - note-arduino
 - note-python
 - note-go

per customer request: https://secure.helpscout.net/conversation/1420777100/93?folderId=4096820

There was a syntax error using reference links.  Should be using [] not ()