### PR TITLE
Fix NoteRequestResponseWithRetry (Returns already freed/deleted rsp)

### DIFF
--- a/n_request.c
+++ b/n_request.c
@@ -161,6 +161,7 @@ bool NoteRequestWithRetry(J *req, uint32_t timeoutSeconds)
             // Free error response
             if (rsp != NULL) {
                 JDelete(rsp);
+                rsp = NULL;
             }
         } else {
 

--- a/n_request.c
+++ b/n_request.c
@@ -251,6 +251,7 @@ J *NoteRequestResponseWithRetry(J *req, uint32_t timeoutSeconds)
             // Free error response
             if (rsp != NULL) {
                 JDelete(rsp);
+                rsp = NULL;
             }
         } else {
 


### PR DESCRIPTION
NoteRequestResponseWithRetry will free rsp but still return rsp in the case when NoteTransaction returns an error and expiresMs is reached. The caller then tries to free rsp again which results in an error.

This change makes sure to set rsp to NULL whenever it is deleted to prevent this.

As @russelldeguzman pointed out, this also affects NoteRequestWithRetry. I've added the fix there too