### PR TITLE
Edit README.md to fix typo referring to note-c as an Arduino library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 Doxyfile.bak
 latex/
 html/
+
+# VS Code workspace files
+*.code-workspace

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # note-c
 
-The note-arduino Arduino library for communicating with the
+The note-c C library for communicating with the
 [Blues Wireless][blues] Notecard via serial or I²C.
 
 This library allows you to control a Notecard by writing a C


### PR DESCRIPTION
Also, add *.code-workspace to .gitignore (VS Code workspace files).