### PR TITLE
Add initial unit testing.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,63 @@
+cmake_minimum_required(VERSION 3.4)
+
+if ("${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}") 
+    message(FATAL_ERROR "In-source builds are disabled.
+    Please create a build directory and use `cmake ..` inside it.
+    NOTE: cmake will now create CMakeCache.txt and CMakeFiles/*.
+          You must delete them, or cmake will refuse to work.")
+endif()
+
+project(note_c_tests)
+
+# Automatically ignore CMake build directory.
+if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
+    file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
+endif()
+
+# GoogleTest requires C++11.
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+find_package(GTest CONFIG REQUIRED)
+enable_testing()
+include(GoogleTest)
+
+get_filename_component(PARENT_DIR ../ ABSOLUTE)
+add_library(
+    note_c
+    ${PARENT_DIR}/n_atof.c
+    ${PARENT_DIR}/n_cjson.c
+    ${PARENT_DIR}/n_const.c
+    ${PARENT_DIR}/n_helpers.c
+    ${PARENT_DIR}/n_i2c.c
+    ${PARENT_DIR}/n_printf.c
+    ${PARENT_DIR}/n_serial.c
+    ${PARENT_DIR}/n_ua.c
+    ${PARENT_DIR}/n_b64.c
+    ${PARENT_DIR}/n_cjson_helpers.c
+    ${PARENT_DIR}/n_ftoa.c
+    ${PARENT_DIR}/n_hooks.c
+    ${PARENT_DIR}/n_md5.c
+    ${PARENT_DIR}/n_request.c
+    ${PARENT_DIR}/n_str.c
+)
+
+function(add_test TEST_NAME)
+    add_executable(
+        ${TEST_NAME}
+        ${TEST_NAME}.cpp
+    )
+    target_include_directories(
+        ${TEST_NAME} PRIVATE
+        ${PARENT_DIR}
+    )
+    target_link_libraries(
+        ${TEST_NAME}
+        note_c
+        GTest::gtest
+    )
+    gtest_discover_tests(${TEST_NAME})
+endfunction()
+
+add_test(n_request_test)
+add_test(n_hooks_test)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,18 @@
+# Overview
+
+This directory contains note-c unit tests written in C++ using GoogleTest.
+
+# Dependencies
+
+- [CMake](https://cmake.org/install), version 3.4+
+- [GoogleTest](https://github.com/google/googletest/tree/main/googletest)
+
+# Running the Tests
+
+```sh
+mkdir build
+cd build
+cmake ..
+make -j
+ctest
+```

--- a/tests/n_hooks_test.cpp
+++ b/tests/n_hooks_test.cpp
@@ -1,0 +1,54 @@
+#include <gtest/gtest.h>
+
+#include "note.h"
+#include "n_lib.h"
+
+namespace
+{
+
+TEST(NoteMallocTest, NullIfNoHook)
+{
+    uint8_t* buf = (uint8_t*)NoteMalloc(10);
+    EXPECT_EQ(buf, nullptr);
+}
+
+TEST(NoteMallocTest, NotNullIfHook)
+{
+    NoteSetFnDefault(malloc, free, NULL, NULL);
+    uint8_t* buf = (uint8_t*)NoteMalloc(10);
+    EXPECT_NE(buf, nullptr);
+    NoteFree(buf);
+}
+
+TEST(NoteDebugOutputTest, DebugInactive)
+{
+    EXPECT_FALSE(NoteIsDebugOutputActive());
+}
+
+size_t DebugOut(const char *msg)
+{
+    size_t result = 0;
+
+    if (msg) {
+        printf("%s\n", msg);
+        result = strlen(msg) + 1; // +1 for newline
+    }
+
+    return result;
+}
+
+TEST(NoteDebugOutputTest, DebugActive)
+{
+    NoteSetFnDebugOutput(DebugOut);
+    EXPECT_TRUE(NoteIsDebugOutputActive());
+}
+
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}
+

--- a/tests/n_request_test.cpp
+++ b/tests/n_request_test.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+
+#include "note.h"
+
+namespace
+{
+
+class Environment : public ::testing::Environment
+{
+public:
+    ~Environment() override {}
+
+    void SetUp() override
+    {
+        NoteSetFnDefault(malloc, free, NULL, NULL);
+    }
+
+    void TearDown() override {}
+};
+
+TEST(NoteNewRequestTest, NotNull)
+{
+    J *req = NoteNewRequest("hub.set");
+    EXPECT_NE(req, nullptr);
+    JDelete(req);
+}
+
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    testing::AddGlobalTestEnvironment(new Environment);
+
+    return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
This commit adds a couple very simple unit tests as a PoC. The tests use GoogleTest, which, to my knowledge, is the most mature and well-maintained open-source C++/C testing framework available. GTest supports mocking as well, which may come in handy when we start testing note-c functions that expect to interact with an actual Notecard. For now, the simple tests in this commit only exercise code that doesn't need a Notecard (e.g. allocating a creating a new Notecard request object).