### PR TITLE
Add GitHub action to run unit tests with every PR.

### DIFF
--- a/.github/actions/run_unit_tests/Dockerfile
+++ b/.github/actions/run_unit_tests/Dockerfile
@@ -1,0 +1,42 @@
+# Container with dependencies necessary to run note-c unit tests.
+
+# Build development environment
+# $ docker build . --tag note_c_run_unit_tests
+
+# Launch development environment (mount source root as /note-c/)
+# $ docker run --rm --volume $(pwd)/../../../:/note-c/ --workdir /note-c/ note_c_run_unit_tests
+
+# POSIX compatible (Linux/Unix) base image.
+FROM debian:stable-slim
+
+# Install whatever dependencies we can via apt-get.
+RUN ["dash", "-c", "\
+    apt-get update --quiet \
+ && apt-get install --assume-yes --no-install-recommends --quiet \
+     build-essential \
+     ca-certificates \
+     curl \
+ && apt-get clean \
+ && apt-get purge \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+ "]
+
+# Download and install CMake v3.25.1. We need CMake v3.20+ in order to get the
+# ctest --test-dir option used by run_unit_tests.sh.
+RUN ["dash", "-c", "\
+    curl -LO https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-x86_64.tar.gz \
+ && tar xf cmake-3.25.1-linux-x86_64.tar.gz --strip-components=1 -C /usr \
+ && rm cmake-3.25.1-linux-x86_64.tar.gz \
+"]
+
+# Download and install Catch2 v3.2.1.
+RUN ["dash", "-c", "\
+    curl -LO https://github.com/catchorg/Catch2/archive/refs/tags/v3.2.1.tar.gz \
+ && tar xf v3.2.1.tar.gz \
+ && cd Catch2-3.2.1 \
+ && cmake -DCATCH_INSTALL_DOCS=0 -B build/ \
+ && cmake --build build/ --target install \
+ && rm -rf Catch2-3.2.1  v3.2.1.tar.gz \
+"]
+
+ENTRYPOINT ["./tests/scripts/run_unit_tests.sh"]

--- a/.github/actions/run_unit_tests/action.yml
+++ b/.github/actions/run_unit_tests/action.yml
@@ -1,0 +1,6 @@
+name: 'Run Unit Tests'
+author: 'Hayden Roche'
+description: 'Run unit tests inside Docker container.'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: note-c CI Pipeline
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  run_unit_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Run unit tests
+        uses: ./.github/actions/run_unit_tests

--- a/tests/scripts/run_unit_tests.sh
+++ b/tests/scripts/run_unit_tests.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_SRC_DIR="$SCRIPT_DIR/../.."
+
+if [ ! -f "$ROOT_SRC_DIR/CMakeLists.txt" ]; then
+    echo "Failed to find note-c root directory. (did the location of run_unit_tests.sh change?)"
+    exit 1
+fi
+
+pushd $ROOT_SRC_DIR $@ > /dev/null
+
+cmake -B build/
+if [ $? != 0 ]; then
+    echo "Failed to run CMake."
+    popd
+    exit 1
+fi
+
+cmake --build build/
+if [ $? != 0 ]; then
+    echo "Failed to build code."
+    popd
+    exit 1
+fi
+
+ctest --test-dir build/ --output-on-failure
+if [ $? != 0 ]; then
+    echo "ctest failed."
+    popd
+    exit 1
+fi
+
+echo "Tests passed."
+popd $@ > /dev/null 


### PR DESCRIPTION
~~I opted not to Dockerize this, in contrast to what's been done in note-arduino. The build already runs in a GitHub-provisioned VM, so the addition of a container inside that seems like overkill.~~

Zak and I talked, and I decided to go the Docker/container route in the end, for a few reasons:

1) No hidden dependencies. For example, the GitHub VMs come with CMake installed, among other packages we need. With the Dockerfile, we fully enumerate our dependencies, so nothing is implied or hidden.
2) Easier for developers to run the GitHub action locally. This is mainly due to 1: the container will set up whatever dependencies it needs; we don't need to install anything up front.
3) Easier to migrate to a different CI platform if we ever outgrow GitHub actions.

One key downside is that, for the moment, we're building the Docker image anew on every CI run. When we eventually get set up with a container registry (e.g. [Github's container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)), this problem will go away, as we'll be able to pull down images from the registry.