### PR TITLE
Add a clang-format config file.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+---
+BasedOnStyle: Google
+IndentWidth: 4
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterFunction: true
+  BeforeElse: true

--- a/n_atof.c
+++ b/n_atof.c
@@ -18,18 +18,18 @@
  */
 
 #ifdef HAVE_STDLIB_H
-#   include <stdlib.h>
+#include <stdlib.h>
 #endif
 #include <ctype.h>
 
 #include "n_lib.h"
 
 #ifndef __STDC__
-# ifdef __GNUC__
-#  define const __const__
-# else
-#  define const
-# endif
+#ifdef __GNUC__
+#define const __const__
+#else
+#define const
+#endif
 #endif
 
 #ifndef TRUE
@@ -40,11 +40,12 @@
 #define NULL 0
 #endif
 
-#define MAX_EXPONENT 511    /* Largest possible base 10 exponent.  Any
-                                 * exponent larger than this will already
-                                 * produce underflow or overflow, so there's
-                                 * no need to worry about additional digits.
-                                 */
+#define MAX_EXPONENT                                 \
+    511 /* Largest possible base 10 exponent.  Any   \
+         * exponent larger than this will already    \
+         * produce underflow or overflow, so there's \
+         * no need to worry about additional digits. \
+         */
 
 /*
  *----------------------------------------------------------------------
@@ -68,41 +69,41 @@
  */
 
 JNUMBER
-JAtoN(string, endPtr)
-const char *string;         /* A decimal ASCII floating-point number,
-                                 * optionally preceded by white space.
-                                 * Must have form "-I.FE-X", where I is the
-                                 * integer part of the mantissa, F is the
-                                 * fractional part of the mantissa, and X
-                                 * is the exponent.  Either of the signs
-                                 * may be "+", "-", or omitted.  Either I
-                                 * or F may be omitted, or both.  The decimal
-                                 * point isn't necessary unless F is present.
-                                 * The "E" may actually be an "e".  E and X
-                                 * may both be omitted (but not just one).
-                                 */
-char **endPtr;              /* If non-NULL, store terminating character's
-                                 * address here. */
+JAtoN(string, endPtr) const
+    char *string; /* A decimal ASCII floating-point number,
+                   * optionally preceded by white space.
+                   * Must have form "-I.FE-X", where I is the
+                   * integer part of the mantissa, F is the
+                   * fractional part of the mantissa, and X
+                   * is the exponent.  Either of the signs
+                   * may be "+", "-", or omitted.  Either I
+                   * or F may be omitted, or both.  The decimal
+                   * point isn't necessary unless F is present.
+                   * The "E" may actually be an "e".  E and X
+                   * may both be omitted (but not just one).
+                   */
+char **endPtr;    /* If non-NULL, store terminating character's
+                   * address here. */
 {
     int sign, expSign = FALSE;
     JNUMBER fraction, dblExp;
     register const char *p;
     register int c;
-    int exp = 0;                /* Exponent read from "EX" field. */
-    int fracExp = 0;            /* Exponent that derives from the fractional
-                                 * part.  Under normal circumstatnces, it is
-                                 * the negative of the number of digits in F.
-                                 * However, if I is very long, the last digits
-                                 * of I get dropped (otherwise a long I with a
-                                 * large negative exponent could cause an
-                                 * unnecessary overflow on I alone).  In this
-                                 * case, fracExp is incremented one for each
-                                 * dropped digit. */
-    int mantSize;               /* Number of digits in mantissa. */
-    int decPt;                  /* Number of mantissa digits BEFORE decimal
-                                 * point. */
-    const char *pExp;           /* Temporarily holds location of exponent
-                                 * in string. */
+    int exp = 0;      /* Exponent read from "EX" field. */
+    int fracExp = 0;  /* Exponent that derives from the fractional
+                       * part.  Under normal circumstatnces, it is
+                       * the negative of the number of digits in F.
+                       * However, if I is very long, the last digits
+                       * of I get dropped (otherwise a long I with a
+                       * large negative exponent could cause an
+                       * unnecessary overflow on I alone).  In this
+                       * case, fracExp is incremented one for each
+                       * dropped digit. */
+    int mantSize;     /* Number of digits in mantissa. */
+    int decPt;        /* Number of mantissa digits BEFORE decimal
+                       * point. */
+    const char *pExp; /* Temporarily holds location of exponent
+                       * in string. */
 
     /*
      * Strip off leading blanks and check for a sign.
@@ -115,7 +116,8 @@ char **endPtr;              /* If non-NULL, store terminating character's
     if (*p == '-') {
         sign = TRUE;
         p += 1;
-    } else {
+    }
+    else {
         if (*p == '+') {
             p += 1;
         }
@@ -128,7 +130,7 @@ char **endPtr;              /* If non-NULL, store terminating character's
      */
 
     decPt = -1;
-    for (mantSize = 0; ; mantSize += 1) {
+    for (mantSize = 0;; mantSize += 1) {
         c = *p;
         if (c < '0' || c > '9') {
             if ((c != '.') || (decPt >= 0)) {
@@ -146,34 +148,37 @@ char **endPtr;              /* If non-NULL, store terminating character's
      * they can't affect the value anyway.
      */
 
-    pExp  = p;
+    pExp = p;
     p -= mantSize;
     if (decPt < 0) {
         decPt = mantSize;
-    } else {
-        mantSize -= 1;                  /* One of the digits was the point. */
+    }
+    else {
+        mantSize -= 1; /* One of the digits was the point. */
     }
     if (mantSize > 18) {
         fracExp = decPt - 18;
         mantSize = 18;
-    } else {
+    }
+    else {
         fracExp = decPt - mantSize;
     }
     if (mantSize == 0) {
         fraction = 0.0;
         p = string;
         goto done;
-    } else {
+    }
+    else {
         long frac1, frac2;
         frac1 = 0L;
-        for ( ; mantSize > 9; mantSize -= 1) {
+        for (; mantSize > 9; mantSize -= 1) {
             c = *p;
             p += 1;
             if (c == '.') {
                 c = *p;
                 p += 1;
             }
-            frac1 = 10*frac1 + (c - '0');
+            frac1 = 10 * frac1 + (c - '0');
         }
         frac2 = 0L;
         for (; mantSize > 0; mantSize -= 1) {
@@ -183,7 +188,7 @@ char **endPtr;              /* If non-NULL, store terminating character's
                 c = *p;
                 p += 1;
             }
-            frac2 = 10*frac2 + (c - '0');
+            frac2 = 10 * frac2 + (c - '0');
         }
         fraction = (1.0e9 * frac1) + frac2;
     }
@@ -198,7 +203,8 @@ char **endPtr;              /* If non-NULL, store terminating character's
         if (*p == '-') {
             expSign = TRUE;
             p += 1;
-        } else {
+        }
+        else {
             if (*p == '+') {
                 p += 1;
             }
@@ -211,7 +217,8 @@ char **endPtr;              /* If non-NULL, store terminating character's
     }
     if (expSign) {
         exp = fracExp - exp;
-    } else {
+    }
+    else {
         exp = fracExp + exp;
     }
 
@@ -225,7 +232,8 @@ char **endPtr;              /* If non-NULL, store terminating character's
     if (exp < 0) {
         expSign = TRUE;
         exp = -exp;
-    } else {
+    }
+    else {
         expSign = FALSE;
     }
     if (exp > MAX_EXPONENT) {
@@ -239,34 +247,34 @@ char **endPtr;              /* If non-NULL, store terminating character's
         /* exponents into floating-point numbers. */
         JNUMBER p10 = 0.0;
         switch (d) {
-        case 0:
-            p10 = 10.0;
-            break;
-        case 1:
-            p10 = 100.0;
-            break;
-        case 2:
-            p10 = 1.0e4;
-            break;
-        case 3:
-            p10 = 1.0e8;
-            break;
-        case 4:
-            p10 = 1.0e16;
-            break;
-        case 5:
-            p10 = 1.0e32;
-            break;
+            case 0:
+                p10 = 10.0;
+                break;
+            case 1:
+                p10 = 100.0;
+                break;
+            case 2:
+                p10 = 1.0e4;
+                break;
+            case 3:
+                p10 = 1.0e8;
+                break;
+            case 4:
+                p10 = 1.0e16;
+                break;
+            case 5:
+                p10 = 1.0e32;
+                break;
 #ifndef NOTE_FLOAT
-        case 6:
-            p10 = 1.0e64;
-            break;
-        case 7:
-            p10 = 1.0e128;
-            break;
-        case 8:
-            p10 = 1.0e256;
-            break;
+            case 6:
+                p10 = 1.0e64;
+                break;
+            case 7:
+                p10 = 1.0e128;
+                break;
+            case 8:
+                p10 = 1.0e256;
+                break;
 #endif
         }
         if (p10 == 0.0) {
@@ -278,13 +286,14 @@ char **endPtr;              /* If non-NULL, store terminating character's
     }
     if (expSign) {
         fraction /= dblExp;
-    } else {
+    }
+    else {
         fraction *= dblExp;
     }
 
 done:
     if (endPtr != NULL) {
-        *endPtr = (char *) p;
+        *endPtr = (char *)p;
     }
 
     if (sign) {

--- a/n_b64.c
+++ b/n_b64.c
@@ -80,28 +80,26 @@
  */
 
 #include <string.h>
+
 #include "n_lib.h"
 
 /* aaaack but it's fast and const should make it shared text page. */
 static const unsigned char pr2six[256] = {
     /* ASCII table */
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63,
-    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64,
-    64,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64, 64,
-    64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64
-};
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 62, 64, 64, 64, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+    61, 64, 64, 64, 64, 64, 64, 64, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+    11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64,
+    64, 64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
+    43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64};
 
 int JB64DecodeLen(const char *bufcoded)
 {
@@ -109,10 +107,11 @@ int JB64DecodeLen(const char *bufcoded)
     register const unsigned char *bufin;
     register int nprbytes;
 
-    bufin = (const unsigned char *) bufcoded;
-    while (pr2six[*(bufin++)] <= 63);
+    bufin = (const unsigned char *)bufcoded;
+    while (pr2six[*(bufin++)] <= 63)
+        ;
 
-    nprbytes = (bufin - (const unsigned char *) bufcoded) - 1;
+    nprbytes = (bufin - (const unsigned char *)bufcoded) - 1;
     nbytesdecoded = ((nprbytes + 3) / 4) * 3;
 
     return nbytesdecoded + 1;
@@ -125,21 +124,21 @@ int JB64Decode(char *bufplain, const char *bufcoded)
     register unsigned char *bufout;
     register int nprbytes;
 
-    bufin = (const unsigned char *) bufcoded;
-    while (pr2six[*(bufin++)] <= 63);
-    nprbytes = (bufin - (const unsigned char *) bufcoded) - 1;
+    bufin = (const unsigned char *)bufcoded;
+    while (pr2six[*(bufin++)] <= 63)
+        ;
+    nprbytes = (bufin - (const unsigned char *)bufcoded) - 1;
     nbytesdecoded = ((nprbytes + 3) / 4) * 3;
 
-    bufout = (unsigned char *) bufplain;
-    bufin = (const unsigned char *) bufcoded;
+    bufout = (unsigned char *)bufplain;
+    bufin = (const unsigned char *)bufcoded;
 
     while (nprbytes > 4) {
         *(bufout++) =
-            (unsigned char) (pr2six[*bufin] << 2 | pr2six[bufin[1]] >> 4);
+            (unsigned char)(pr2six[*bufin] << 2 | pr2six[bufin[1]] >> 4);
         *(bufout++) =
-            (unsigned char) (pr2six[bufin[1]] << 4 | pr2six[bufin[2]] >> 2);
-        *(bufout++) =
-            (unsigned char) (pr2six[bufin[2]] << 6 | pr2six[bufin[3]]);
+            (unsigned char)(pr2six[bufin[1]] << 4 | pr2six[bufin[2]] >> 2);
+        *(bufout++) = (unsigned char)(pr2six[bufin[2]] << 6 | pr2six[bufin[3]]);
         bufin += 4;
         nprbytes -= 4;
     }
@@ -147,15 +146,14 @@ int JB64Decode(char *bufplain, const char *bufcoded)
     /* Note: (nprbytes == 1) would be an error, so just ingore that case */
     if (nprbytes > 1) {
         *(bufout++) =
-            (unsigned char) (pr2six[*bufin] << 2 | pr2six[bufin[1]] >> 4);
+            (unsigned char)(pr2six[*bufin] << 2 | pr2six[bufin[1]] >> 4);
     }
     if (nprbytes > 2) {
         *(bufout++) =
-            (unsigned char) (pr2six[bufin[1]] << 4 | pr2six[bufin[2]] >> 2);
+            (unsigned char)(pr2six[bufin[1]] << 4 | pr2six[bufin[2]] >> 2);
     }
     if (nprbytes > 3) {
-        *(bufout++) =
-            (unsigned char) (pr2six[bufin[2]] << 6 | pr2six[bufin[3]]);
+        *(bufout++) = (unsigned char)(pr2six[bufin[2]] << 6 | pr2six[bufin[3]]);
     }
 
     *(bufout++) = '\0';
@@ -166,10 +164,7 @@ int JB64Decode(char *bufplain, const char *bufcoded)
 static const char basis_64[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-int JB64EncodeLen(int len)
-{
-    return ((len + 2) / 3 * 4) + 1;
-}
+int JB64EncodeLen(int len) { return ((len + 2) / 3 * 4) + 1; }
 
 int JB64Encode(char *encoded, const char *string, int len)
 {
@@ -179,8 +174,10 @@ int JB64Encode(char *encoded, const char *string, int len)
     p = encoded;
     for (i = 0; i < len - 2; i += 3) {
         *p++ = basis_64[(string[i] >> 2) & 0x3F];
-        *p++ = basis_64[((string[i] & 0x3) << 4) | ((int) (string[i + 1] & 0xF0) >> 4)];
-        *p++ = basis_64[((string[i + 1] & 0xF) << 2) | ((int) (string[i + 2] & 0xC0) >> 6)];
+        *p++ = basis_64[((string[i] & 0x3) << 4) |
+                        ((int)(string[i + 1] & 0xF0) >> 4)];
+        *p++ = basis_64[((string[i + 1] & 0xF) << 2) |
+                        ((int)(string[i + 2] & 0xC0) >> 6)];
         *p++ = basis_64[string[i + 2] & 0x3F];
     }
     if (i < len) {
@@ -188,8 +185,10 @@ int JB64Encode(char *encoded, const char *string, int len)
         if (i == (len - 1)) {
             *p++ = basis_64[((string[i] & 0x3) << 4)];
             *p++ = '=';
-        } else {
-            *p++ = basis_64[((string[i] & 0x3) << 4) | ((int) (string[i + 1] & 0xF0) >> 4)];
+        }
+        else {
+            *p++ = basis_64[((string[i] & 0x3) << 4) |
+                            ((int)(string[i + 1] & 0xF0) >> 4)];
             *p++ = basis_64[((string[i + 1] & 0xF) << 2)];
         }
         *p++ = '=';

--- a/n_cjson.c
+++ b/n_cjson.c
@@ -3,11 +3,10 @@
  *
  * Written by Ray Ozzie and Blues Inc. team.
  *
- * Portions Copyright (c) 2019 Blues Inc. MIT License. Use of this source code is
- * governed by licenses granted by the copyright holder including that found in
- * the
- * <a href="https://github.com/blues/note-c/blob/master/LICENSE">LICENSE</a>
- * file.
+ * Portions Copyright (c) 2019 Blues Inc. MIT License. Use of this source code
+ * is governed by licenses granted by the copyright holder including that found
+ * in the <a
+ * href="https://github.com/blues/note-c/blob/master/LICENSE">LICENSE</a> file.
  *
  * MODIFIED for use in notecard primarily by altering default memory allocator
  * and by renaming the functions so that they won't conflict with a developer's
@@ -49,21 +48,22 @@
 #pragma GCC visibility push(default)
 #endif
 #if defined(_MSC_VER)
-#pragma warning (push)
+#pragma warning(push)
 /* disable warning about single line comments in system headers */
-#pragma warning (disable : 4001)
+#pragma warning(disable : 4001)
 #endif
 
-#include <string.h>
-#include <stdio.h>
-#include <math.h>
-#include <stdlib.h>
-#include <limits.h>
 #include <ctype.h>
+#include <limits.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 // For Note, disable dependencies
 #undef ENABLE_LOCALES
-#define MINIMIZE_CLIB_DEPENDENCIES      1       // Use tiny but non-robust versions of conversions
+#define MINIMIZE_CLIB_DEPENDENCIES \
+    1  // Use tiny but non-robust versions of conversions
 
 #include "n_lib.h"
 
@@ -75,7 +75,7 @@
 #endif
 
 #if defined(_MSC_VER)
-#pragma warning (pop)
+#pragma warning(pop)
 #endif
 #ifdef __GNUC__
 #pragma GCC visibility pop
@@ -85,7 +85,7 @@ typedef struct {
     const unsigned char *json;
     size_t position;
 } error;
-static error global_error = { NULL, 0 };
+static error global_error = {NULL, 0};
 
 // Forwards
 void htoa16(uint16_t n, unsigned char *p);
@@ -93,7 +93,7 @@ static J *JNew_Item(void);
 
 N_CJSON_PUBLIC(const char *) JGetErrorPtr(void)
 {
-    return (const char*) (global_error.json + global_error.position);
+    return (const char *)(global_error.json + global_error.position);
 }
 
 N_CJSON_PUBLIC(char *) JGetStringValue(J *item)
@@ -105,18 +105,23 @@ N_CJSON_PUBLIC(char *) JGetStringValue(J *item)
     return item->valuestring;
 }
 
-/* This is a safeguard to prevent copy-pasters from using incompatible C and header files */
-#if (N_CJSON_VERSION_MAJOR != 1) || (N_CJSON_VERSION_MINOR != 7) || (N_CJSON_VERSION_PATCH != 7)
+/* This is a safeguard to prevent copy-pasters from using incompatible C and
+ * header files */
+#if (N_CJSON_VERSION_MAJOR != 1) || (N_CJSON_VERSION_MINOR != 7) || \
+    (N_CJSON_VERSION_PATCH != 7)
 #error J.h and J.c have different versions. Make sure that both have the same.
 #endif
 
-N_CJSON_PUBLIC(const char*) JVersion(void)
+N_CJSON_PUBLIC(const char *) JVersion(void)
 {
-    return STRINGIFY(N_CJSON_VERSION_MAJOR) "." STRINGIFY(N_CJSON_VERSION_MINOR) "." STRINGIFY(N_CJSON_VERSION_PATCH);
+    return STRINGIFY(N_CJSON_VERSION_MAJOR) "." STRINGIFY(
+        N_CJSON_VERSION_MINOR) "." STRINGIFY(N_CJSON_VERSION_PATCH);
 }
 
-/* Case insensitive string comparison, doesn't consider two NULL pointers equal though */
-static int case_insensitive_strcmp(const unsigned char *string1, const unsigned char *string2)
+/* Case insensitive string comparison, doesn't consider two NULL pointers equal
+ * though */
+static int case_insensitive_strcmp(const unsigned char *string1,
+                                   const unsigned char *string2)
 {
     if ((string1 == NULL) || (string2 == NULL)) {
         return 1;
@@ -126,7 +131,7 @@ static int case_insensitive_strcmp(const unsigned char *string1, const unsigned 
         return 0;
     }
 
-    for(; tolower(*string1) == tolower(*string2); (void)string1++, string2++) {
+    for (; tolower(*string1) == tolower(*string2); (void)string1++, string2++) {
         if (*string1 == '\0') {
             return 0;
         }
@@ -135,7 +140,7 @@ static int case_insensitive_strcmp(const unsigned char *string1, const unsigned 
     return tolower(*string1) - tolower(*string2);
 }
 
-static unsigned char* Jstrdup(const unsigned char* string)
+static unsigned char *Jstrdup(const unsigned char *string)
 {
     size_t length = 0;
     unsigned char *copy = NULL;
@@ -144,8 +149,8 @@ static unsigned char* Jstrdup(const unsigned char* string)
         return NULL;
     }
 
-    length = strlen((const char*)string) + sizeof("");
-    copy = (unsigned char*)_Malloc(length);
+    length = strlen((const char *)string) + sizeof("");
+    copy = (unsigned char *)_Malloc(length);
     if (copy == NULL) {
         return NULL;
     }
@@ -154,19 +159,13 @@ static unsigned char* Jstrdup(const unsigned char* string)
     return copy;
 }
 
-N_CJSON_PUBLIC(void *) JMalloc(size_t size)
-{
-    return _Malloc(size);
-}
-N_CJSON_PUBLIC(void) JFree(void *p)
-{
-    _Free(p);
-}
+N_CJSON_PUBLIC(void *) JMalloc(size_t size) { return _Malloc(size); }
+N_CJSON_PUBLIC(void) JFree(void *p) { _Free(p); }
 
 /* Internal constructor. */
 static J *JNew_Item()
 {
-    J* node = (J*)_Malloc(sizeof(J));
+    J *node = (J *)_Malloc(sizeof(J));
     if (node) {
         memset(node, '\0', sizeof(J));
     }
@@ -199,7 +198,7 @@ static unsigned char get_decimal_point(void)
 {
 #ifdef ENABLE_LOCALES
     struct lconv *lconv = localeconv();
-    return (unsigned char) lconv->decimal_point[0];
+    return (unsigned char)lconv->decimal_point[0];
 #else
     return '.';
 #endif
@@ -209,19 +208,25 @@ typedef struct {
     const unsigned char *content;
     size_t length;
     size_t offset;
-    size_t depth; /* How deeply nested (in arrays/objects) is the input at the current offset. */
+    size_t depth; /* How deeply nested (in arrays/objects) is the input at the
+                     current offset. */
 } parse_buffer;
 
-/* check if the given size is left to read in a given parse buffer (starting with 1) */
-#define can_read(buffer, size) ((buffer != NULL) && (((buffer)->offset + size) <= (buffer)->length))
+/* check if the given size is left to read in a given parse buffer (starting
+ * with 1) */
+#define can_read(buffer, size) \
+    ((buffer != NULL) && (((buffer)->offset + size) <= (buffer)->length))
 /* check if the buffer can be accessed at the given index (starting with 0) */
-#define can_access_at_index(buffer, index) ((buffer != NULL) && (((buffer)->offset + index) < (buffer)->length))
-#define cannot_access_at_index(buffer, index) (!can_access_at_index(buffer, index))
+#define can_access_at_index(buffer, index) \
+    ((buffer != NULL) && (((buffer)->offset + index) < (buffer)->length))
+#define cannot_access_at_index(buffer, index) \
+    (!can_access_at_index(buffer, index))
 /* get a pointer to the buffer at the position */
 #define buffer_at_offset(buffer) ((buffer)->content + (buffer)->offset)
 
-/* Parse the input text to generate a number, and populate the result into item. */
-static Jbool parse_number(J * const item, parse_buffer * const input_buffer)
+/* Parse the input text to generate a number, and populate the result into item.
+ */
+static Jbool parse_number(J *const item, parse_buffer *const input_buffer)
 {
     JNUMBER number = 0;
     unsigned char *after_end = NULL;
@@ -233,34 +238,36 @@ static Jbool parse_number(J * const item, parse_buffer * const input_buffer)
         return false;
     }
 
-    /* copy the number into a temporary buffer and replace '.' with the decimal point
-     * of the current locale (for strtod)
-     * This also takes care of '\0' not necessarily being available for marking the end of the input */
-    for (i = 0; (i < (sizeof(number_c_string) - 1)) && can_access_at_index(input_buffer, i); i++) {
+    /* copy the number into a temporary buffer and replace '.' with the decimal
+     * point of the current locale (for strtod) This also takes care of '\0' not
+     * necessarily being available for marking the end of the input */
+    for (i = 0; (i < (sizeof(number_c_string) - 1)) &&
+                can_access_at_index(input_buffer, i);
+         i++) {
         switch (buffer_at_offset(input_buffer)[i]) {
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
-        case '+':
-        case '-':
-        case 'e':
-        case 'E':
-            number_c_string[i] = buffer_at_offset(input_buffer)[i];
-            break;
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            case '+':
+            case '-':
+            case 'e':
+            case 'E':
+                number_c_string[i] = buffer_at_offset(input_buffer)[i];
+                break;
 
-        case '.':
-            number_c_string[i] = decimal_point;
-            break;
+            case '.':
+                number_c_string[i] = decimal_point;
+                break;
 
-        default:
-            goto loop_end;
+            default:
+                goto loop_end;
         }
     }
 loop_end:
@@ -268,9 +275,9 @@ loop_end:
 
     /* some platforms may not have locale support */
 #if !MINIMIZE_CLIB_DEPENDENCIES
-    number = strtod((const char*)number_c_string, (char**)&after_end);
+    number = strtod((const char *)number_c_string, (char **)&after_end);
 #else
-    number = JAtoN((const char*)number_c_string, (char**)&after_end);
+    number = JAtoN((const char *)number_c_string, (char **)&after_end);
 #endif
     if (number_c_string == after_end) {
         return false; /* parse_error */
@@ -281,9 +288,11 @@ loop_end:
     /* use saturation in case of overflow */
     if (number >= LONG_MAX) {
         item->valueint = LONG_MAX;
-    } else if (number <= LONG_MIN) {
+    }
+    else if (number <= LONG_MIN) {
         item->valueint = LONG_MIN;
-    } else {
+    }
+    else {
         item->valueint = (long int)number;
     }
 
@@ -293,7 +302,8 @@ loop_end:
     return true;
 }
 
-/* don't ask me, but the original JSetNumberValue returns an integer or JNUMBER */
+/* don't ask me, but the original JSetNumberValue returns an integer or JNUMBER
+ */
 N_CJSON_PUBLIC(JNUMBER) JSetNumberHelper(J *object, JNUMBER number)
 {
     if (object == NULL) {
@@ -301,9 +311,11 @@ N_CJSON_PUBLIC(JNUMBER) JSetNumberHelper(J *object, JNUMBER number)
     }
     if (number >= LONG_MAX) {
         object->valueint = LONG_MAX;
-    } else if (number <= LONG_MIN) {
+    }
+    else if (number <= LONG_MIN) {
         object->valueint = LONG_MIN;
-    } else {
+    }
+    else {
         object->valueint = (long int)number;
     }
 
@@ -320,7 +332,7 @@ typedef struct {
 } printbuffer;
 
 /* realloc printbuffer if necessary to have at least "needed" bytes more */
-static unsigned char* ensure(printbuffer * const p, size_t needed)
+static unsigned char *ensure(printbuffer *const p, size_t needed)
 {
     unsigned char *newbuffer = NULL;
     size_t newsize = 0;
@@ -353,15 +365,17 @@ static unsigned char* ensure(printbuffer * const p, size_t needed)
         /* overflow of int, use INT_MAX if possible */
         if (needed <= INT_MAX) {
             newsize = INT_MAX;
-        } else {
+        }
+        else {
             return NULL;
         }
-    } else {
+    }
+    else {
         newsize = needed * 2;
     }
 
     /* otherwise reallocate manually */
-    newbuffer = (unsigned char*)_Malloc(newsize);
+    newbuffer = (unsigned char *)_Malloc(newsize);
     if (!newbuffer) {
         _Free(p->buffer);
         p->length = 0;
@@ -379,8 +393,9 @@ static unsigned char* ensure(printbuffer * const p, size_t needed)
     return newbuffer + p->offset;
 }
 
-/* calculate the new length of the string in a printbuffer and update the offset */
-static void update_offset(printbuffer * const buffer)
+/* calculate the new length of the string in a printbuffer and update the offset
+ */
+static void update_offset(printbuffer *const buffer)
 {
     const unsigned char *buffer_pointer = NULL;
     if ((buffer == NULL) || (buffer->buffer == NULL)) {
@@ -388,11 +403,11 @@ static void update_offset(printbuffer * const buffer)
     }
     buffer_pointer = buffer->buffer + buffer->offset;
 
-    buffer->offset += strlen((const char*)buffer_pointer);
+    buffer->offset += strlen((const char *)buffer_pointer);
 }
 
 /* Render the number nicely from the given item into a string. */
-static Jbool print_number(const J * const item, printbuffer * const output_buffer)
+static Jbool print_number(const J *const item, printbuffer *const output_buffer)
 {
     if (item == NULL) {
         return false;
@@ -402,7 +417,8 @@ static Jbool print_number(const J * const item, printbuffer * const output_buffe
     JNUMBER d = item->valuenumber;
     int length = 0;
     size_t i = 0;
-    unsigned char number_buffer[JNTOA_MAX]; /* temporary buffer to print the number into */
+    unsigned char number_buffer[JNTOA_MAX]; /* temporary buffer to print the
+                                               number into */
     unsigned char decimal_point = get_decimal_point();
 
     if (output_buffer == NULL) {
@@ -411,22 +427,25 @@ static Jbool print_number(const J * const item, printbuffer * const output_buffe
 
     /* This checks for NaN and Infinity */
     if ((d * 0) != 0) {
-        char *nbuf = (char *) number_buffer;
+        char *nbuf = (char *)number_buffer;
         strcpy(nbuf, "null");
         length = strlen(nbuf);
-    } else {
+    }
+    else {
 #if !MINIMIZE_CLIB_DEPENDENCIES
         JNUMBER test;
-        /* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */
-        length = sprintf((char*)number_buffer, "%1.15g", d);
+        /* Try 15 decimal places of precision to avoid nonsignificant nonzero
+         * digits */
+        length = sprintf((char *)number_buffer, "%1.15g", d);
 
         /* Check whether the original double can be recovered */
-        if ((sscanf((char*)number_buffer, "%lg", &test) != 1) || ((JNUMBER)test != d)) {
+        if ((sscanf((char *)number_buffer, "%lg", &test) != 1) ||
+            ((JNUMBER)test != d)) {
             /* If not, print with 17 decimal places of precision */
-            length = sprintf((char*)number_buffer, "%1.17g", d);
+            length = sprintf((char *)number_buffer, "%1.17g", d);
         }
 #else
-        char *nbuf = (char *) number_buffer;
+        char *nbuf = (char *)number_buffer;
         JNtoA(d, nbuf, -1);
         length = strlen(nbuf);
 #endif
@@ -461,7 +480,7 @@ static Jbool print_number(const J * const item, printbuffer * const output_buffe
 }
 
 /* parse 4 digit hexadecimal number */
-static unsigned long parse_hex4(const unsigned char * const input)
+static unsigned long parse_hex4(const unsigned char *const input)
 {
     unsigned long int h = 0;
     size_t i = 0;
@@ -469,12 +488,15 @@ static unsigned long parse_hex4(const unsigned char * const input)
     for (i = 0; i < 4; i++) {
         /* parse digit */
         if ((input[i] >= '0') && (input[i] <= '9')) {
-            h += (unsigned int) input[i] - '0';
-        } else if ((input[i] >= 'A') && (input[i] <= 'F')) {
-            h += (unsigned int) 10 + input[i] - 'A';
-        } else if ((input[i] >= 'a') && (input[i] <= 'f')) {
-            h += (unsigned int) 10 + input[i] - 'a';
-        } else { /* invalid */
+            h += (unsigned int)input[i] - '0';
+        }
+        else if ((input[i] >= 'A') && (input[i] <= 'F')) {
+            h += (unsigned int)10 + input[i] - 'A';
+        }
+        else if ((input[i] >= 'a') && (input[i] <= 'f')) {
+            h += (unsigned int)10 + input[i] - 'a';
+        }
+        else { /* invalid */
             return 0;
         }
 
@@ -489,7 +511,9 @@ static unsigned long parse_hex4(const unsigned char * const input)
 
 /* converts a UTF-16 literal to UTF-8
  * A literal can be one or two sequences of the form \uXXXX */
-static unsigned char utf16_literal_to_utf8(const unsigned char * const input_pointer, const unsigned char * const input_end, unsigned char **output_pointer)
+static unsigned char utf16_literal_to_utf8(
+    const unsigned char *const input_pointer,
+    const unsigned char *const input_end, unsigned char **output_pointer)
 {
     long unsigned int codepoint = 0;
     unsigned long int first_code = 0;
@@ -536,10 +560,11 @@ static unsigned char utf16_literal_to_utf8(const unsigned char * const input_poi
             goto fail;
         }
 
-
         /* calculate the unicode codepoint from the surrogate pair */
-        codepoint = 0x10000 + (((first_code & 0x3FF) << 10) | (second_code & 0x3FF));
-    } else {
+        codepoint =
+            0x10000 + (((first_code & 0x3FF) << 10) | (second_code & 0x3FF));
+    }
+    else {
         sequence_length = 6; /* \uXXXX */
         codepoint = first_code;
     }
@@ -550,33 +575,41 @@ static unsigned char utf16_literal_to_utf8(const unsigned char * const input_poi
     if (codepoint < 0x80) {
         /* normal ascii, encoding 0xxxxxxx */
         utf8_length = 1;
-    } else if (codepoint < 0x800) {
+    }
+    else if (codepoint < 0x800) {
         /* two bytes, encoding 110xxxxx 10xxxxxx */
         utf8_length = 2;
         first_byte_mark = 0xC0; /* 11000000 */
-    } else if (codepoint < 0x10000) {
+    }
+    else if (codepoint < 0x10000) {
         /* three bytes, encoding 1110xxxx 10xxxxxx 10xxxxxx */
         utf8_length = 3;
         first_byte_mark = 0xE0; /* 11100000 */
-    } else if (codepoint <= 0x10FFFF) {
+    }
+    else if (codepoint <= 0x10FFFF) {
         /* four bytes, encoding 1110xxxx 10xxxxxx 10xxxxxx 10xxxxxx */
         utf8_length = 4;
         first_byte_mark = 0xF0; /* 11110000 */
-    } else {
+    }
+    else {
         /* invalid unicode codepoint */
         goto fail;
     }
 
     /* encode as utf8 */
-    for (utf8_position = (unsigned char)(utf8_length - 1); utf8_position > 0; utf8_position--) {
+    for (utf8_position = (unsigned char)(utf8_length - 1); utf8_position > 0;
+         utf8_position--) {
         /* 10xxxxxx */
-        (*output_pointer)[utf8_position] = (unsigned char)((codepoint | 0x80) & 0xBF);
+        (*output_pointer)[utf8_position] =
+            (unsigned char)((codepoint | 0x80) & 0xBF);
         codepoint >>= 6;
     }
     /* encode first byte */
     if (utf8_length > 1) {
-        (*output_pointer)[0] = (unsigned char)((codepoint | first_byte_mark) & 0xFF);
-    } else {
+        (*output_pointer)[0] =
+            (unsigned char)((codepoint | first_byte_mark) & 0xFF);
+    }
+    else {
         (*output_pointer)[0] = (unsigned char)(codepoint & 0x7F);
     }
 
@@ -589,7 +622,7 @@ fail:
 }
 
 /* Parse the input text into an unescaped cinput, and populate item. */
-static Jbool parse_string(J * const item, parse_buffer * const input_buffer)
+static Jbool parse_string(J *const item, parse_buffer *const input_buffer)
 {
     const unsigned char *input_pointer = buffer_at_offset(input_buffer) + 1;
     const unsigned char *input_end = buffer_at_offset(input_buffer) + 1;
@@ -605,11 +638,15 @@ static Jbool parse_string(J * const item, parse_buffer * const input_buffer)
         /* calculate approximate size of the output (overestimate) */
         size_t allocation_length = 0;
         size_t skipped_bytes = 0;
-        while (((size_t)(input_end - input_buffer->content) < input_buffer->length) && (*input_end != '\"')) {
+        while (((size_t)(input_end - input_buffer->content) <
+                input_buffer->length) &&
+               (*input_end != '\"')) {
             /* is escape sequence */
             if (input_end[0] == '\\') {
-                if ((size_t)(input_end + 1 - input_buffer->content) >= input_buffer->length) {
-                    /* prevent buffer overflow when last input character is a backslash */
+                if ((size_t)(input_end + 1 - input_buffer->content) >=
+                    input_buffer->length) {
+                    /* prevent buffer overflow when last input character is a
+                     * backslash */
                     goto fail;
                 }
                 skipped_bytes++;
@@ -617,13 +654,18 @@ static Jbool parse_string(J * const item, parse_buffer * const input_buffer)
             }
             input_end++;
         }
-        if (((size_t)(input_end - input_buffer->content) >= input_buffer->length) || (*input_end != '\"')) {
+        if (((size_t)(input_end - input_buffer->content) >=
+             input_buffer->length) ||
+            (*input_end != '\"')) {
             goto fail; /* string ended unexpectedly */
         }
 
         /* This is at most how much we need for the output */
-        allocation_length = (size_t) (input_end - buffer_at_offset(input_buffer)) - skipped_bytes;
-        output = (unsigned char*)_Malloc(allocation_length + 1);  // trailing '\0'
+        allocation_length =
+            (size_t)(input_end - buffer_at_offset(input_buffer)) -
+            skipped_bytes;
+        output =
+            (unsigned char *)_Malloc(allocation_length + 1);  // trailing '\0'
         if (output == NULL) {
             goto fail; /* allocation failure */
         }
@@ -643,38 +685,39 @@ static Jbool parse_string(J * const item, parse_buffer * const input_buffer)
             }
 
             switch (input_pointer[1]) {
-            case 'b':
-                *output_pointer++ = '\b';
-                break;
-            case 'f':
-                *output_pointer++ = '\f';
-                break;
-            case 'n':
-                *output_pointer++ = '\n';
-                break;
-            case 'r':
-                *output_pointer++ = '\r';
-                break;
-            case 't':
-                *output_pointer++ = '\t';
-                break;
-            case '\"':
-            case '\\':
-            case '/':
-                *output_pointer++ = input_pointer[1];
-                break;
+                case 'b':
+                    *output_pointer++ = '\b';
+                    break;
+                case 'f':
+                    *output_pointer++ = '\f';
+                    break;
+                case 'n':
+                    *output_pointer++ = '\n';
+                    break;
+                case 'r':
+                    *output_pointer++ = '\r';
+                    break;
+                case 't':
+                    *output_pointer++ = '\t';
+                    break;
+                case '\"':
+                case '\\':
+                case '/':
+                    *output_pointer++ = input_pointer[1];
+                    break;
 
-            /* UTF-16 literal */
-            case 'u':
-                sequence_length = utf16_literal_to_utf8(input_pointer, input_end, &output_pointer);
-                if (sequence_length == 0) {
-                    /* failed to convert UTF16-literal to UTF-8 */
+                /* UTF-16 literal */
+                case 'u':
+                    sequence_length = utf16_literal_to_utf8(
+                        input_pointer, input_end, &output_pointer);
+                    if (sequence_length == 0) {
+                        /* failed to convert UTF16-literal to UTF-8 */
+                        goto fail;
+                    }
+                    break;
+
+                default:
                     goto fail;
-                }
-                break;
-
-            default:
-                goto fail;
             }
             input_pointer += sequence_length;
         }
@@ -684,9 +727,9 @@ static Jbool parse_string(J * const item, parse_buffer * const input_buffer)
     *output_pointer = '\0';
 
     item->type = JString;
-    item->valuestring = (char*)output;
+    item->valuestring = (char *)output;
 
-    input_buffer->offset = (size_t) (input_end - input_buffer->content);
+    input_buffer->offset = (size_t)(input_end - input_buffer->content);
     input_buffer->offset++;
 
     return true;
@@ -707,12 +750,13 @@ fail:
 void htoa16(uint16_t n, unsigned char *p)
 {
     int i;
-    for (i=0; i<4; i++) {
+    for (i = 0; i < 4; i++) {
         uint16_t nibble = (n >> 12) & 0xff;
         n = n << 4;
         if (nibble >= 10) {
-            *p++ = 'A' + (nibble-10);
-        } else {
+            *p++ = 'A' + (nibble - 10);
+        }
+        else {
             *p++ = '0' + nibble;
         }
     }
@@ -720,7 +764,8 @@ void htoa16(uint16_t n, unsigned char *p)
 }
 
 /* Render the cstring provided to an escaped version that can be printed. */
-static Jbool print_string_ptr(const unsigned char * const input, printbuffer * const output_buffer)
+static Jbool print_string_ptr(const unsigned char *const input,
+                              printbuffer *const output_buffer)
 {
     const unsigned char *input_pointer = NULL;
     unsigned char *output = NULL;
@@ -749,22 +794,22 @@ static Jbool print_string_ptr(const unsigned char * const input, printbuffer * c
     /* set "flag" to 1 if something needs to be escaped */
     for (input_pointer = input; *input_pointer; input_pointer++) {
         switch (*input_pointer) {
-        case '\"':
-        case '\\':
-        case '\b':
-        case '\f':
-        case '\n':
-        case '\r':
-        case '\t':
-            /* one character escape sequence */
-            escape_characters++;
-            break;
-        default:
-            if (*input_pointer < 32) {
-                /* UTF-16 escape sequence uXXXX */
-                escape_characters += 5;
-            }
-            break;
+            case '\"':
+            case '\\':
+            case '\b':
+            case '\f':
+            case '\n':
+            case '\r':
+            case '\t':
+                /* one character escape sequence */
+                escape_characters++;
+                break;
+            default:
+                if (*input_pointer < 32) {
+                    /* UTF-16 escape sequence uXXXX */
+                    escape_characters += 5;
+                }
+                break;
         }
     }
     output_length = (size_t)(input_pointer - input) + escape_characters;
@@ -787,41 +832,44 @@ static Jbool print_string_ptr(const unsigned char * const input, printbuffer * c
     output[0] = '\"';
     output_pointer = output + 1;
     /* copy the string */
-    for (input_pointer = input; *input_pointer != '\0'; (void)input_pointer++, output_pointer++) {
-        if ((*input_pointer > 31) && (*input_pointer != '\"') && (*input_pointer != '\\')) {
+    for (input_pointer = input; *input_pointer != '\0';
+         (void)input_pointer++, output_pointer++) {
+        if ((*input_pointer > 31) && (*input_pointer != '\"') &&
+            (*input_pointer != '\\')) {
             /* normal character, copy */
             *output_pointer = *input_pointer;
-        } else {
+        }
+        else {
             /* character needs to be escaped */
             *output_pointer++ = '\\';
             switch (*input_pointer) {
-            case '\\':
-                *output_pointer = '\\';
-                break;
-            case '\"':
-                *output_pointer = '\"';
-                break;
-            case '\b':
-                *output_pointer = 'b';
-                break;
-            case '\f':
-                *output_pointer = 'f';
-                break;
-            case '\n':
-                *output_pointer = 'n';
-                break;
-            case '\r':
-                *output_pointer = 'r';
-                break;
-            case '\t':
-                *output_pointer = 't';
-                break;
-            default:
-                /* escape and print as unicode codepoint */
-                *output_pointer++ = 'u';
-                htoa16(*input_pointer, output_pointer);
-                output_pointer += 4;
-                break;
+                case '\\':
+                    *output_pointer = '\\';
+                    break;
+                case '\"':
+                    *output_pointer = '\"';
+                    break;
+                case '\b':
+                    *output_pointer = 'b';
+                    break;
+                case '\f':
+                    *output_pointer = 'f';
+                    break;
+                case '\n':
+                    *output_pointer = 'n';
+                    break;
+                case '\r':
+                    *output_pointer = 'r';
+                    break;
+                case '\t':
+                    *output_pointer = 't';
+                    break;
+                default:
+                    /* escape and print as unicode codepoint */
+                    *output_pointer++ = 'u';
+                    htoa16(*input_pointer, output_pointer);
+                    output_pointer += 4;
+                    break;
             }
         }
     }
@@ -832,27 +880,29 @@ static Jbool print_string_ptr(const unsigned char * const input, printbuffer * c
 }
 
 /* Invoke print_string_ptr (which is useful) on an item. */
-static Jbool print_string(const J * const item, printbuffer * const p)
+static Jbool print_string(const J *const item, printbuffer *const p)
 {
-    return print_string_ptr((unsigned char*)item->valuestring, p);
+    return print_string_ptr((unsigned char *)item->valuestring, p);
 }
 
 /* Predeclare these prototypes. */
-static Jbool parse_value(J * const item, parse_buffer * const input_buffer);
-static Jbool print_value(const J * const item, printbuffer * const output_buffer);
-static Jbool parse_array(J * const item, parse_buffer * const input_buffer);
-static Jbool print_array(const J * const item, printbuffer * const output_buffer);
-static Jbool parse_object(J * const item, parse_buffer * const input_buffer);
-static Jbool print_object(const J * const item, printbuffer * const output_buffer);
+static Jbool parse_value(J *const item, parse_buffer *const input_buffer);
+static Jbool print_value(const J *const item, printbuffer *const output_buffer);
+static Jbool parse_array(J *const item, parse_buffer *const input_buffer);
+static Jbool print_array(const J *const item, printbuffer *const output_buffer);
+static Jbool parse_object(J *const item, parse_buffer *const input_buffer);
+static Jbool print_object(const J *const item,
+                          printbuffer *const output_buffer);
 
 /* Utility to jump whitespace and cr/lf */
-static parse_buffer *buffer_skip_whitespace(parse_buffer * const buffer)
+static parse_buffer *buffer_skip_whitespace(parse_buffer *const buffer)
 {
     if ((buffer == NULL) || (buffer->content == NULL)) {
         return NULL;
     }
 
-    while (can_access_at_index(buffer, 0) && (buffer_at_offset(buffer)[0] <= 32)) {
+    while (can_access_at_index(buffer, 0) &&
+           (buffer_at_offset(buffer)[0] <= 32)) {
         buffer->offset++;
     }
 
@@ -864,13 +914,16 @@ static parse_buffer *buffer_skip_whitespace(parse_buffer * const buffer)
 }
 
 /* skip the UTF-8 BOM (byte order mark) if it is at the beginning of a buffer */
-static parse_buffer *skip_utf8_bom(parse_buffer * const buffer)
+static parse_buffer *skip_utf8_bom(parse_buffer *const buffer)
 {
-    if ((buffer == NULL) || (buffer->content == NULL) || (buffer->offset != 0)) {
+    if ((buffer == NULL) || (buffer->content == NULL) ||
+        (buffer->offset != 0)) {
         return NULL;
     }
 
-    if (can_access_at_index(buffer, 4) && (strncmp((const char*)buffer_at_offset(buffer), "\xEF\xBB\xBF", 3) == 0)) {
+    if (can_access_at_index(buffer, 4) &&
+        (strncmp((const char *)buffer_at_offset(buffer), "\xEF\xBB\xBF", 3) ==
+         0)) {
         buffer->offset += 3;
     }
 
@@ -878,9 +931,11 @@ static parse_buffer *skip_utf8_bom(parse_buffer * const buffer)
 }
 
 /* Parse an object - create a new root, and populate. */
-N_CJSON_PUBLIC(J *) JParseWithOpts(const char *value, const char **return_parse_end, Jbool require_null_terminated)
+N_CJSON_PUBLIC(J *)
+JParseWithOpts(const char *value, const char **return_parse_end,
+               Jbool require_null_terminated)
 {
-    parse_buffer buffer = { 0, 0, 0, 0 };
+    parse_buffer buffer = {0, 0, 0, 0};
     J *item = NULL;
 
     /* reset error position */
@@ -891,8 +946,8 @@ N_CJSON_PUBLIC(J *) JParseWithOpts(const char *value, const char **return_parse_
         goto fail;
     }
 
-    buffer.content = (const unsigned char*)value;
-    buffer.length = strlen((const char*)value) + 1;   // Trailing '\0'
+    buffer.content = (const unsigned char *)value;
+    buffer.length = strlen((const char *)value) + 1;  // Trailing '\0'
     buffer.offset = 0;
 
     item = JNew_Item();
@@ -905,15 +960,17 @@ N_CJSON_PUBLIC(J *) JParseWithOpts(const char *value, const char **return_parse_
         goto fail;
     }
 
-    /* if we require null-terminated JSON without appended garbage, skip and then check for a null terminator */
+    /* if we require null-terminated JSON without appended garbage, skip and
+     * then check for a null terminator */
     if (require_null_terminated) {
         buffer_skip_whitespace(&buffer);
-        if ((buffer.offset >= buffer.length) || buffer_at_offset(&buffer)[0] != '\0') {
+        if ((buffer.offset >= buffer.length) ||
+            buffer_at_offset(&buffer)[0] != '\0') {
             goto fail;
         }
     }
     if (return_parse_end) {
-        *return_parse_end = (const char*)buffer_at_offset(&buffer);
+        *return_parse_end = (const char *)buffer_at_offset(&buffer);
     }
 
     return item;
@@ -925,17 +982,19 @@ fail:
 
     if (value != NULL) {
         error local_error;
-        local_error.json = (const unsigned char*)value;
+        local_error.json = (const unsigned char *)value;
         local_error.position = 0;
 
         if (buffer.offset < buffer.length) {
             local_error.position = buffer.offset;
-        } else if (buffer.length > 0) {
+        }
+        else if (buffer.length > 0) {
             local_error.position = buffer.length - 1;
         }
 
         if (return_parse_end != NULL) {
-            *return_parse_end = (const char*)local_error.json + local_error.position;
+            *return_parse_end =
+                (const char *)local_error.json + local_error.position;
         }
 
         global_error = local_error;
@@ -952,7 +1011,7 @@ N_CJSON_PUBLIC(J *) JParse(const char *value)
 
 #define cjson_min(a, b) ((a < b) ? a : b)
 
-static unsigned char *print(const J * const item, Jbool format)
+static unsigned char *print(const J *const item, Jbool format)
 {
     static const size_t default_buffer_size = 128;
     printbuffer buffer[1];
@@ -961,7 +1020,7 @@ static unsigned char *print(const J * const item, Jbool format)
     memset(buffer, 0, sizeof(buffer));
 
     /* create buffer */
-    buffer->buffer = (unsigned char*) _Malloc(default_buffer_size);
+    buffer->buffer = (unsigned char *)_Malloc(default_buffer_size);
     buffer->length = default_buffer_size;
     buffer->format = format;
     if (buffer->buffer == NULL) {
@@ -975,11 +1034,12 @@ static unsigned char *print(const J * const item, Jbool format)
     update_offset(buffer);
 
     /* copy the JSON over to a new buffer */
-    printed = (unsigned char*) _Malloc(buffer->offset + 1);
+    printed = (unsigned char *)_Malloc(buffer->offset + 1);
     if (printed == NULL) {
         goto fail;
     }
-    memcpy(printed, buffer->buffer, cjson_min(buffer->length, buffer->offset + 1));
+    memcpy(printed, buffer->buffer,
+           cjson_min(buffer->length, buffer->offset + 1));
     printed[buffer->offset] = '\0'; /* just to be sure */
 
     /* free the buffer */
@@ -1005,7 +1065,7 @@ N_CJSON_PUBLIC(char *) JPrint(const J *item)
     if (item == NULL) {
         return (char *)"";
     }
-    return (char*)print(item, true);
+    return (char *)print(item, true);
 }
 
 N_CJSON_PUBLIC(char *) JPrintUnformatted(const J *item)
@@ -1013,12 +1073,12 @@ N_CJSON_PUBLIC(char *) JPrintUnformatted(const J *item)
     if (item == NULL) {
         return (char *)"";
     }
-    return (char*)print(item, false);
+    return (char *)print(item, false);
 }
 
 N_CJSON_PUBLIC(char *) JPrintBuffered(const J *item, int prebuffer, Jbool fmt)
 {
-    printbuffer p = { 0, 0, 0, 0, 0, 0 };
+    printbuffer p = {0, 0, 0, 0, 0, 0};
 
     if (item == NULL) {
         return (char *)"";
@@ -1028,7 +1088,7 @@ N_CJSON_PUBLIC(char *) JPrintBuffered(const J *item, int prebuffer, Jbool fmt)
         return NULL;
     }
 
-    p.buffer = (unsigned char*)_Malloc((size_t)prebuffer);
+    p.buffer = (unsigned char *)_Malloc((size_t)prebuffer);
     if (!p.buffer) {
         return NULL;
     }
@@ -1043,12 +1103,13 @@ N_CJSON_PUBLIC(char *) JPrintBuffered(const J *item, int prebuffer, Jbool fmt)
         return NULL;
     }
 
-    return (char*)p.buffer;
+    return (char *)p.buffer;
 }
 
-N_CJSON_PUBLIC(Jbool) JPrintPreallocated(J *item, char *buf, const int len, const Jbool fmt)
+N_CJSON_PUBLIC(Jbool)
+JPrintPreallocated(J *item, char *buf, const int len, const Jbool fmt)
 {
-    printbuffer p = { 0, 0, 0, 0, 0, 0 };
+    printbuffer p = {0, 0, 0, 0, 0, 0};
 
     if (item == NULL) {
         return false;
@@ -1057,7 +1118,7 @@ N_CJSON_PUBLIC(Jbool) JPrintPreallocated(J *item, char *buf, const int len, cons
         return false;
     }
 
-    p.buffer = (unsigned char*)buf;
+    p.buffer = (unsigned char *)buf;
     p.length = (size_t)len;
     p.offset = 0;
     p.noalloc = true;
@@ -1067,7 +1128,7 @@ N_CJSON_PUBLIC(Jbool) JPrintPreallocated(J *item, char *buf, const int len, cons
 }
 
 /* Parser core - when encountering text, process appropriately. */
-static Jbool parse_value(J * const item, parse_buffer * const input_buffer)
+static Jbool parse_value(J *const item, parse_buffer *const input_buffer)
 {
     if (item == NULL) {
         return false;
@@ -1078,38 +1139,50 @@ static Jbool parse_value(J * const item, parse_buffer * const input_buffer)
 
     /* parse the different types of values */
     /* null */
-    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), c_null, c_null_len) == 0)) {
+    if (can_read(input_buffer, 4) &&
+        (strncmp((const char *)buffer_at_offset(input_buffer), c_null,
+                 c_null_len) == 0)) {
         item->type = JNULL;
         input_buffer->offset += 4;
         return true;
     }
     /* false */
-    if (can_read(input_buffer, 5) && (strncmp((const char*)buffer_at_offset(input_buffer), c_false, c_false_len) == 0)) {
+    if (can_read(input_buffer, 5) &&
+        (strncmp((const char *)buffer_at_offset(input_buffer), c_false,
+                 c_false_len) == 0)) {
         item->type = JFalse;
         input_buffer->offset += 5;
         return true;
     }
     /* true */
-    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), c_true, c_true_len) == 0)) {
+    if (can_read(input_buffer, 4) &&
+        (strncmp((const char *)buffer_at_offset(input_buffer), c_true,
+                 c_true_len) == 0)) {
         item->type = JTrue;
         item->valueint = 1;
         input_buffer->offset += 4;
         return true;
     }
     /* string */
-    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '\"')) {
+    if (can_access_at_index(input_buffer, 0) &&
+        (buffer_at_offset(input_buffer)[0] == '\"')) {
         return parse_string(item, input_buffer);
     }
     /* number */
-    if (can_access_at_index(input_buffer, 0) && ((buffer_at_offset(input_buffer)[0] == '-') || ((buffer_at_offset(input_buffer)[0] >= '0') && (buffer_at_offset(input_buffer)[0] <= '9')))) {
+    if (can_access_at_index(input_buffer, 0) &&
+        ((buffer_at_offset(input_buffer)[0] == '-') ||
+         ((buffer_at_offset(input_buffer)[0] >= '0') &&
+          (buffer_at_offset(input_buffer)[0] <= '9')))) {
         return parse_number(item, input_buffer);
     }
     /* array */
-    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '[')) {
+    if (can_access_at_index(input_buffer, 0) &&
+        (buffer_at_offset(input_buffer)[0] == '[')) {
         return parse_array(item, input_buffer);
     }
     /* object */
-    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '{')) {
+    if (can_access_at_index(input_buffer, 0) &&
+        (buffer_at_offset(input_buffer)[0] == '{')) {
         return parse_object(item, input_buffer);
     }
 
@@ -1117,7 +1190,7 @@ static Jbool parse_value(J * const item, parse_buffer * const input_buffer)
 }
 
 /* Render a value to text. */
-static Jbool print_value(const J * const item, printbuffer * const output_buffer)
+static Jbool print_value(const J *const item, printbuffer *const output_buffer)
 {
     unsigned char *output = NULL;
 
@@ -1126,64 +1199,64 @@ static Jbool print_value(const J * const item, printbuffer * const output_buffer
     }
 
     switch ((item->type) & 0xFF) {
-    case JNULL:
-        output = ensure(output_buffer, c_null_len+1);
-        if (output == NULL) {
-            return false;
+        case JNULL:
+            output = ensure(output_buffer, c_null_len + 1);
+            if (output == NULL) {
+                return false;
+            }
+            strcpy((char *)output, c_null);
+            return true;
+
+        case JFalse:
+            output = ensure(output_buffer, c_false_len + 1);
+            if (output == NULL) {
+                return false;
+            }
+            strcpy((char *)output, c_false);
+            return true;
+
+        case JTrue:
+            output = ensure(output_buffer, c_true_len + 1);
+            if (output == NULL) {
+                return false;
+            }
+            strcpy((char *)output, c_true);
+            return true;
+
+        case JNumber:
+            return print_number(item, output_buffer);
+
+        case JRaw: {
+            size_t raw_length = 0;
+            if (item->valuestring == NULL) {
+                return false;
+            }
+
+            raw_length = strlen(item->valuestring) + 1;  // Trailing '\0';
+            output = ensure(output_buffer, raw_length);
+            if (output == NULL) {
+                return false;
+            }
+            memcpy(output, item->valuestring, raw_length);
+            return true;
         }
-        strcpy((char*)output, c_null);
-        return true;
 
-    case JFalse:
-        output = ensure(output_buffer, c_false_len+1);
-        if (output == NULL) {
+        case JString:
+            return print_string(item, output_buffer);
+
+        case JArray:
+            return print_array(item, output_buffer);
+
+        case JObject:
+            return print_object(item, output_buffer);
+
+        default:
             return false;
-        }
-        strcpy((char*)output, c_false);
-        return true;
-
-    case JTrue:
-        output = ensure(output_buffer, c_true_len+1);
-        if (output == NULL) {
-            return false;
-        }
-        strcpy((char*)output, c_true);
-        return true;
-
-    case JNumber:
-        return print_number(item, output_buffer);
-
-    case JRaw: {
-        size_t raw_length = 0;
-        if (item->valuestring == NULL) {
-            return false;
-        }
-
-        raw_length = strlen(item->valuestring) + 1;   // Trailing '\0';
-        output = ensure(output_buffer, raw_length);
-        if (output == NULL) {
-            return false;
-        }
-        memcpy(output, item->valuestring, raw_length);
-        return true;
-    }
-
-    case JString:
-        return print_string(item, output_buffer);
-
-    case JArray:
-        return print_array(item, output_buffer);
-
-    case JObject:
-        return print_object(item, output_buffer);
-
-    default:
-        return false;
     }
 }
 
 /* Build an array from input text. */
-static Jbool parse_array(J * const item, parse_buffer * const input_buffer)
+static Jbool parse_array(J *const item, parse_buffer *const input_buffer)
 {
     J *head = NULL; /* head of the linked list */
     J *current_item = NULL;
@@ -1200,7 +1273,8 @@ static Jbool parse_array(J * const item, parse_buffer * const input_buffer)
 
     input_buffer->offset++;
     buffer_skip_whitespace(input_buffer);
-    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ']')) {
+    if (can_access_at_index(input_buffer, 0) &&
+        (buffer_at_offset(input_buffer)[0] == ']')) {
         /* empty array */
         goto success;
     }
@@ -1225,7 +1299,8 @@ static Jbool parse_array(J * const item, parse_buffer * const input_buffer)
         if (head == NULL) {
             /* start the linked list */
             current_item = head = new_item;
-        } else {
+        }
+        else {
             /* add to the end and advance */
             current_item->next = new_item;
             new_item->prev = current_item;
@@ -1239,9 +1314,11 @@ static Jbool parse_array(J * const item, parse_buffer * const input_buffer)
             goto fail; /* failed to parse value */
         }
         buffer_skip_whitespace(input_buffer);
-    } while (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ','));
+    } while (can_access_at_index(input_buffer, 0) &&
+             (buffer_at_offset(input_buffer)[0] == ','));
 
-    if (cannot_access_at_index(input_buffer, 0) || buffer_at_offset(input_buffer)[0] != ']') {
+    if (cannot_access_at_index(input_buffer, 0) ||
+        buffer_at_offset(input_buffer)[0] != ']') {
         goto fail; /* expected end of array */
     }
 
@@ -1264,7 +1341,7 @@ fail:
 }
 
 /* Render an array to text */
-static Jbool print_array(const J * const item, printbuffer * const output_buffer)
+static Jbool print_array(const J *const item, printbuffer *const output_buffer)
 {
     unsigned char *output_pointer = NULL;
     size_t length = 0;
@@ -1291,13 +1368,13 @@ static Jbool print_array(const J * const item, printbuffer * const output_buffer
         }
         update_offset(output_buffer);
         if (current_element->next) {
-            length = (size_t) (output_buffer->format ? 2 : 1);
+            length = (size_t)(output_buffer->format ? 2 : 1);
             output_pointer = ensure(output_buffer, length + 1);
             if (output_pointer == NULL) {
                 return false;
             }
             *output_pointer++ = ',';
-            if(output_buffer->format) {
+            if (output_buffer->format) {
                 *output_pointer++ = ' ';
             }
             *output_pointer = '\0';
@@ -1318,7 +1395,7 @@ static Jbool print_array(const J * const item, printbuffer * const output_buffer
 }
 
 /* Build an object from the text. */
-static Jbool parse_object(J * const item, parse_buffer * const input_buffer)
+static Jbool parse_object(J *const item, parse_buffer *const input_buffer)
 {
     J *head = NULL; /* linked list head */
     J *current_item = NULL;
@@ -1328,13 +1405,15 @@ static Jbool parse_object(J * const item, parse_buffer * const input_buffer)
     }
     input_buffer->depth++;
 
-    if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '{')) {
+    if (cannot_access_at_index(input_buffer, 0) ||
+        (buffer_at_offset(input_buffer)[0] != '{')) {
         goto fail; /* not an object */
     }
 
     input_buffer->offset++;
     buffer_skip_whitespace(input_buffer);
-    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '}')) {
+    if (can_access_at_index(input_buffer, 0) &&
+        (buffer_at_offset(input_buffer)[0] == '}')) {
         goto success; /* empty object */
     }
 
@@ -1358,7 +1437,8 @@ static Jbool parse_object(J * const item, parse_buffer * const input_buffer)
         if (head == NULL) {
             /* start the linked list */
             current_item = head = new_item;
-        } else {
+        }
+        else {
             /* add to the end and advance */
             current_item->next = new_item;
             new_item->prev = current_item;
@@ -1377,7 +1457,8 @@ static Jbool parse_object(J * const item, parse_buffer * const input_buffer)
         current_item->string = current_item->valuestring;
         current_item->valuestring = NULL;
 
-        if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != ':')) {
+        if (cannot_access_at_index(input_buffer, 0) ||
+            (buffer_at_offset(input_buffer)[0] != ':')) {
             goto fail; /* invalid object */
         }
 
@@ -1388,9 +1469,11 @@ static Jbool parse_object(J * const item, parse_buffer * const input_buffer)
             goto fail; /* failed to parse value */
         }
         buffer_skip_whitespace(input_buffer);
-    } while (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ','));
+    } while (can_access_at_index(input_buffer, 0) &&
+             (buffer_at_offset(input_buffer)[0] == ','));
 
-    if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '}')) {
+    if (cannot_access_at_index(input_buffer, 0) ||
+        (buffer_at_offset(input_buffer)[0] != '}')) {
         goto fail; /* expected end of object */
     }
 
@@ -1412,7 +1495,7 @@ fail:
 }
 
 /* Render an object to text. */
-static Jbool print_object(const J * const item, printbuffer * const output_buffer)
+static Jbool print_object(const J *const item, printbuffer *const output_buffer)
 {
     unsigned char *output_pointer = NULL;
     size_t length = 0;
@@ -1423,7 +1506,7 @@ static Jbool print_object(const J * const item, printbuffer * const output_buffe
     }
 
     /* Compose the output: */
-    length = (size_t) (output_buffer->format ? 2 : 1); /* fmt: {\n */
+    length = (size_t)(output_buffer->format ? 2 : 1); /* fmt: {\n */
     output_pointer = ensure(output_buffer, length + 1);
     if (output_pointer == NULL) {
         return false;
@@ -1450,12 +1533,13 @@ static Jbool print_object(const J * const item, printbuffer * const output_buffe
         }
 
         /* print key */
-        if (!print_string_ptr((unsigned char*)current_item->string, output_buffer)) {
+        if (!print_string_ptr((unsigned char *)current_item->string,
+                              output_buffer)) {
             return false;
         }
         update_offset(output_buffer);
 
-        length = (size_t) (output_buffer->format ? 2 : 1);
+        length = (size_t)(output_buffer->format ? 2 : 1);
         output_pointer = ensure(output_buffer, length);
         if (output_pointer == NULL) {
             return false;
@@ -1473,7 +1557,8 @@ static Jbool print_object(const J * const item, printbuffer * const output_buffe
         update_offset(output_buffer);
 
         /* print comma if not last */
-        length = (size_t) ((output_buffer->format ? 1 : 0) + (current_item->next ? 1 : 0));
+        length = (size_t)((output_buffer->format ? 1 : 0) +
+                          (current_item->next ? 1 : 0));
         output_pointer = ensure(output_buffer, length + 1);
         if (output_pointer == NULL) {
             return false;
@@ -1491,7 +1576,8 @@ static Jbool print_object(const J * const item, printbuffer * const output_buffe
         current_item = current_item->next;
     }
 
-    output_pointer = ensure(output_buffer, output_buffer->format ? (output_buffer->depth + 1) : 2);
+    output_pointer = ensure(
+        output_buffer, output_buffer->format ? (output_buffer->depth + 1) : 2);
     if (output_pointer == NULL) {
         return false;
     }
@@ -1520,7 +1606,7 @@ N_CJSON_PUBLIC(int) JGetArraySize(const J *array)
 
     child = array->child;
 
-    while(child != NULL) {
+    while (child != NULL) {
         size++;
         child = child->next;
     }
@@ -1530,7 +1616,7 @@ N_CJSON_PUBLIC(int) JGetArraySize(const J *array)
     return (int)size;
 }
 
-static J* get_array_item(const J *array, size_t index)
+static J *get_array_item(const J *array, size_t index)
 {
     J *current_child = NULL;
 
@@ -1559,7 +1645,8 @@ N_CJSON_PUBLIC(J *) JGetArrayItem(const J *array, int index)
     return get_array_item(array, (size_t)index);
 }
 
-static J *get_object_item(const J * const object, const char * const name, const Jbool case_sensitive)
+static J *get_object_item(const J *const object, const char *const name,
+                          const Jbool case_sensitive)
 {
     J *current_element = NULL;
 
@@ -1569,11 +1656,16 @@ static J *get_object_item(const J * const object, const char * const name, const
 
     current_element = object->child;
     if (case_sensitive) {
-        while ((current_element != NULL) && (strcmp(name, current_element->string) != 0)) {
+        while ((current_element != NULL) &&
+               (strcmp(name, current_element->string) != 0)) {
             current_element = current_element->next;
         }
-    } else {
-        while ((current_element != NULL) && (case_insensitive_strcmp((const unsigned char*)name, (const unsigned char*)(current_element->string)) != 0)) {
+    }
+    else {
+        while ((current_element != NULL) &&
+               (case_insensitive_strcmp(
+                    (const unsigned char *)name,
+                    (const unsigned char *)(current_element->string)) != 0)) {
             current_element = current_element->next;
         }
     }
@@ -1581,7 +1673,8 @@ static J *get_object_item(const J * const object, const char * const name, const
     return current_element;
 }
 
-N_CJSON_PUBLIC(J *) JGetObjectItem(const J * const object, const char * const string)
+N_CJSON_PUBLIC(J *)
+JGetObjectItem(const J *const object, const char *const string)
 {
     if (object == NULL) {
         return NULL;
@@ -1589,7 +1682,8 @@ N_CJSON_PUBLIC(J *) JGetObjectItem(const J * const object, const char * const st
     return get_object_item(object, string, false);
 }
 
-N_CJSON_PUBLIC(J *) JGetObjectItemCaseSensitive(const J * const object, const char * const string)
+N_CJSON_PUBLIC(J *)
+JGetObjectItemCaseSensitive(const J *const object, const char *const string)
 {
     if (object == NULL) {
         return NULL;
@@ -1645,7 +1739,8 @@ static Jbool add_item_to_array(J *array, J *item)
     if (child == NULL) {
         /* list is empty, start new one */
         array->child = item;
-    } else {
+    }
+    else {
         /* append to the end */
         while (child->next) {
             child = child->next;
@@ -1665,23 +1760,24 @@ N_CJSON_PUBLIC(void) JAddItemToArray(J *array, J *item)
     add_item_to_array(array, item);
 }
 
-#if defined(__clang__) || (defined(__GNUC__)  && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
+#if defined(__clang__) || \
+    (defined(__GNUC__) && \
+     ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
 #pragma GCC diagnostic push
 #endif
 #ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wcast-qual"
 #endif
 /* helper function to cast away const */
-static void* cast_away_const(const void* string)
-{
-    return (void*)string;
-}
-#if defined(__clang__) || (defined(__GNUC__)  && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
+static void *cast_away_const(const void *string) { return (void *)string; }
+#if defined(__clang__) || \
+    (defined(__GNUC__) && \
+     ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
 #pragma GCC diagnostic pop
 #endif
 
-
-static Jbool add_item_to_object(J * const object, const char * const string, J * const item, const Jbool constant_key)
+static Jbool add_item_to_object(J *const object, const char *const string,
+                                J *const item, const Jbool constant_key)
 {
     char *new_key = NULL;
     int new_type = JInvalid;
@@ -1691,10 +1787,11 @@ static Jbool add_item_to_object(J * const object, const char * const string, J *
     }
 
     if (constant_key) {
-        new_key = (char*)cast_away_const(string);
+        new_key = (char *)cast_away_const(string);
         new_type = item->type | JStringIsConst;
-    } else {
-        new_key = (char*)Jstrdup((const unsigned char*)string);
+    }
+    else {
+        new_key = (char *)Jstrdup((const unsigned char *)string);
         if (new_key == NULL) {
             return false;
         }
@@ -1737,7 +1834,8 @@ N_CJSON_PUBLIC(void) JAddItemReferenceToArray(J *array, J *item)
     add_item_to_array(array, create_reference(item));
 }
 
-N_CJSON_PUBLIC(void) JAddItemReferenceToObject(J *object, const char *string, J *item)
+N_CJSON_PUBLIC(void)
+JAddItemReferenceToObject(J *object, const char *string, J *item)
 {
     if (object == NULL || string == NULL || item == NULL) {
         return;
@@ -1745,7 +1843,7 @@ N_CJSON_PUBLIC(void) JAddItemReferenceToObject(J *object, const char *string, J 
     add_item_to_object(object, string, create_reference(item), false);
 }
 
-N_CJSON_PUBLIC(J*) JAddNullToObject(J * const object, const char * const name)
+N_CJSON_PUBLIC(J *) JAddNullToObject(J *const object, const char *const name)
 {
     if (object == NULL) {
         return NULL;
@@ -1759,7 +1857,7 @@ N_CJSON_PUBLIC(J*) JAddNullToObject(J * const object, const char * const name)
     return NULL;
 }
 
-N_CJSON_PUBLIC(J*) JAddTrueToObject(J * const object, const char * const name)
+N_CJSON_PUBLIC(J *) JAddTrueToObject(J *const object, const char *const name)
 {
     if (object == NULL) {
         return NULL;
@@ -1774,7 +1872,7 @@ N_CJSON_PUBLIC(J*) JAddTrueToObject(J * const object, const char * const name)
     return NULL;
 }
 
-N_CJSON_PUBLIC(J*) JAddFalseToObject(J * const object, const char * const name)
+N_CJSON_PUBLIC(J *) JAddFalseToObject(J *const object, const char *const name)
 {
     if (object == NULL) {
         return NULL;
@@ -1789,7 +1887,8 @@ N_CJSON_PUBLIC(J*) JAddFalseToObject(J * const object, const char * const name)
     return NULL;
 }
 
-N_CJSON_PUBLIC(J*) JAddBoolToObject(J * const object, const char * const name, const Jbool boolean)
+N_CJSON_PUBLIC(J *)
+JAddBoolToObject(J *const object, const char *const name, const Jbool boolean)
 {
     if (object == NULL) {
         return NULL;
@@ -1804,7 +1903,9 @@ N_CJSON_PUBLIC(J*) JAddBoolToObject(J * const object, const char * const name, c
     return NULL;
 }
 
-N_CJSON_PUBLIC(J*) JAddNumberToObject(J * const object, const char * const name, const JNUMBER number)
+N_CJSON_PUBLIC(J *)
+JAddNumberToObject(J *const object, const char *const name,
+                   const JNUMBER number)
 {
     if (object == NULL) {
         return NULL;
@@ -1819,7 +1920,9 @@ N_CJSON_PUBLIC(J*) JAddNumberToObject(J * const object, const char * const name,
     return NULL;
 }
 
-N_CJSON_PUBLIC(J*) JAddStringToObject(J * const object, const char * const name, const char * const string)
+N_CJSON_PUBLIC(J *)
+JAddStringToObject(J *const object, const char *const name,
+                   const char *const string)
 {
     if (object == NULL || string == NULL) {
         return NULL;
@@ -1834,7 +1937,8 @@ N_CJSON_PUBLIC(J*) JAddStringToObject(J * const object, const char * const name,
     return NULL;
 }
 
-N_CJSON_PUBLIC(J*) JAddRawToObject(J * const object, const char * const name, const char * const raw)
+N_CJSON_PUBLIC(J *)
+JAddRawToObject(J *const object, const char *const name, const char *const raw)
 {
     if (object == NULL || raw == NULL) {
         return NULL;
@@ -1849,7 +1953,7 @@ N_CJSON_PUBLIC(J*) JAddRawToObject(J * const object, const char * const name, co
     return NULL;
 }
 
-N_CJSON_PUBLIC(J*) JAddObjectToObject(J * const object, const char * const name)
+N_CJSON_PUBLIC(J *) JAddObjectToObject(J *const object, const char *const name)
 {
     if (object == NULL) {
         return NULL;
@@ -1864,7 +1968,7 @@ N_CJSON_PUBLIC(J*) JAddObjectToObject(J * const object, const char * const name)
     return NULL;
 }
 
-N_CJSON_PUBLIC(J*) JAddArrayToObject(J * const object, const char * const name)
+N_CJSON_PUBLIC(J *) JAddArrayToObject(J *const object, const char *const name)
 {
     if (object == NULL) {
         return NULL;
@@ -1879,7 +1983,7 @@ N_CJSON_PUBLIC(J*) JAddArrayToObject(J * const object, const char * const name)
     return NULL;
 }
 
-N_CJSON_PUBLIC(J *) JDetachItemViaPointer(J *parent, J * const item)
+N_CJSON_PUBLIC(J *) JDetachItemViaPointer(J *parent, J *const item)
 {
     if (parent == NULL || item == NULL) {
         return NULL;
@@ -1936,7 +2040,8 @@ N_CJSON_PUBLIC(J *) JDetachItemFromObject(J *object, const char *string)
     return JDetachItemViaPointer(object, to_detach);
 }
 
-N_CJSON_PUBLIC(J *) JDetachItemFromObjectCaseSensitive(J *object, const char *string)
+N_CJSON_PUBLIC(J *)
+JDetachItemFromObjectCaseSensitive(J *object, const char *string)
 {
     if (object == NULL) {
         return NULL;
@@ -1955,7 +2060,8 @@ N_CJSON_PUBLIC(void) JDeleteItemFromObject(J *object, const char *string)
     JDelete(JDetachItemFromObject(object, string));
 }
 
-N_CJSON_PUBLIC(void) JDeleteItemFromObjectCaseSensitive(J *object, const char *string)
+N_CJSON_PUBLIC(void)
+JDeleteItemFromObjectCaseSensitive(J *object, const char *string)
 {
     if (object == NULL) {
         return;
@@ -1987,12 +2093,14 @@ N_CJSON_PUBLIC(void) JInsertItemInArray(J *array, int which, J *newitem)
     after_inserted->prev = newitem;
     if (after_inserted == array->child) {
         array->child = newitem;
-    } else {
+    }
+    else {
         newitem->prev->next = newitem;
     }
 }
 
-N_CJSON_PUBLIC(Jbool) JReplaceItemViaPointer(J * const parent, J * const item, J * replacement)
+N_CJSON_PUBLIC(Jbool)
+JReplaceItemViaPointer(J *const parent, J *const item, J *replacement)
 {
     if (parent == NULL || replacement == NULL || item == NULL) {
         return false;
@@ -2032,28 +2140,33 @@ N_CJSON_PUBLIC(void) JReplaceItemInArray(J *array, int which, J *newitem)
         return;
     }
 
-    JReplaceItemViaPointer(array, get_array_item(array, (size_t)which), newitem);
+    JReplaceItemViaPointer(array, get_array_item(array, (size_t)which),
+                           newitem);
 }
 
-static Jbool replace_item_in_object(J *object, const char *string, J *replacement, Jbool case_sensitive)
+static Jbool replace_item_in_object(J *object, const char *string,
+                                    J *replacement, Jbool case_sensitive)
 {
     if (object == NULL || replacement == NULL || string == NULL) {
         return false;
     }
 
     /* replace the name in the replacement */
-    if (!(replacement->type & JStringIsConst) && (replacement->string != NULL)) {
+    if (!(replacement->type & JStringIsConst) &&
+        (replacement->string != NULL)) {
         _Free(replacement->string);
     }
-    replacement->string = (char*)Jstrdup((const unsigned char*)string);
+    replacement->string = (char *)Jstrdup((const unsigned char *)string);
     replacement->type &= ~JStringIsConst;
 
-    JReplaceItemViaPointer(object, get_object_item(object, string, case_sensitive), replacement);
+    JReplaceItemViaPointer(
+        object, get_object_item(object, string, case_sensitive), replacement);
 
     return true;
 }
 
-N_CJSON_PUBLIC(void) JReplaceItemInObject(J *object, const char *string, J *newitem)
+N_CJSON_PUBLIC(void)
+JReplaceItemInObject(J *object, const char *string, J *newitem)
 {
     if (object == NULL || newitem == NULL) {
         return;
@@ -2061,7 +2174,8 @@ N_CJSON_PUBLIC(void) JReplaceItemInObject(J *object, const char *string, J *newi
     replace_item_in_object(object, string, newitem, false);
 }
 
-N_CJSON_PUBLIC(void) JReplaceItemInObjectCaseSensitive(J *object, const char *string, J *newitem)
+N_CJSON_PUBLIC(void)
+JReplaceItemInObjectCaseSensitive(J *object, const char *string, J *newitem)
 {
     if (object == NULL || newitem == NULL) {
         return;
@@ -2073,7 +2187,7 @@ N_CJSON_PUBLIC(void) JReplaceItemInObjectCaseSensitive(J *object, const char *st
 N_CJSON_PUBLIC(J *) JCreateNull(void)
 {
     J *item = JNew_Item();
-    if(item) {
+    if (item) {
         item->type = JNULL;
     }
     return item;
@@ -2082,7 +2196,7 @@ N_CJSON_PUBLIC(J *) JCreateNull(void)
 N_CJSON_PUBLIC(J *) JCreateTrue(void)
 {
     J *item = JNew_Item();
-    if(item) {
+    if (item) {
         item->type = JTrue;
     }
     return item;
@@ -2091,7 +2205,7 @@ N_CJSON_PUBLIC(J *) JCreateTrue(void)
 N_CJSON_PUBLIC(J *) JCreateFalse(void)
 {
     J *item = JNew_Item();
-    if(item) {
+    if (item) {
         item->type = JFalse;
     }
     return item;
@@ -2100,7 +2214,7 @@ N_CJSON_PUBLIC(J *) JCreateFalse(void)
 N_CJSON_PUBLIC(J *) JCreateBool(Jbool b)
 {
     J *item = JNew_Item();
-    if(item) {
+    if (item) {
         item->type = b ? JTrue : JFalse;
     }
     return item;
@@ -2109,15 +2223,17 @@ N_CJSON_PUBLIC(J *) JCreateBool(Jbool b)
 N_CJSON_PUBLIC(J *) JCreateNumber(JNUMBER num)
 {
     J *item = JNew_Item();
-    if(item) {
+    if (item) {
         item->type = JNumber;
         item->valuenumber = num;
         /* use saturation in case of overflow */
         if (num >= LONG_MAX) {
             item->valueint = LONG_MAX;
-        } else if (num <= LONG_MIN) {
+        }
+        else if (num <= LONG_MIN) {
             item->valueint = LONG_MIN;
-        } else {
+        }
+        else {
             item->valueint = (long int)num;
         }
     }
@@ -2127,10 +2243,10 @@ N_CJSON_PUBLIC(J *) JCreateNumber(JNUMBER num)
 N_CJSON_PUBLIC(J *) JCreateString(const char *string)
 {
     J *item = JNew_Item();
-    if(item) {
+    if (item) {
         item->type = JString;
-        item->valuestring = (char*)Jstrdup((const unsigned char*)string);
-        if(!item->valuestring) {
+        item->valuestring = (char *)Jstrdup((const unsigned char *)string);
+        if (!item->valuestring) {
             JDelete(item);
             return NULL;
         }
@@ -2143,7 +2259,7 @@ N_CJSON_PUBLIC(J *) JCreateStringValue(const char *string)
     J *item = JNew_Item();
     if (item != NULL) {
         item->type = JString;
-        item->valuestring = (char*)cast_away_const(string);
+        item->valuestring = (char *)cast_away_const(string);
     }
     return item;
 }
@@ -2153,7 +2269,7 @@ N_CJSON_PUBLIC(J *) JCreateStringReference(const char *string)
     J *item = JNew_Item();
     if (item != NULL) {
         item->type = JString | JIsReference;
-        item->valuestring = (char*)cast_away_const(string);
+        item->valuestring = (char *)cast_away_const(string);
     }
     return item;
 }
@@ -2166,7 +2282,7 @@ N_CJSON_PUBLIC(J *) JCreateObjectReference(const J *child)
     J *item = JNew_Item();
     if (item != NULL) {
         item->type = JObject | JIsReference;
-        item->child = (J*)cast_away_const(child);
+        item->child = (J *)cast_away_const(child);
     }
     return item;
 }
@@ -2179,7 +2295,7 @@ N_CJSON_PUBLIC(J *) JCreateArrayReference(const J *child)
     J *item = JNew_Item();
     if (item != NULL) {
         item->type = JArray | JIsReference;
-        item->child = (J*)cast_away_const(child);
+        item->child = (J *)cast_away_const(child);
     }
     return item;
 }
@@ -2187,10 +2303,10 @@ N_CJSON_PUBLIC(J *) JCreateArrayReference(const J *child)
 N_CJSON_PUBLIC(J *) JCreateRaw(const char *raw)
 {
     J *item = JNew_Item();
-    if(item) {
+    if (item) {
         item->type = JRaw;
-        item->valuestring = (char*)Jstrdup((const unsigned char*)raw);
-        if(!item->valuestring) {
+        item->valuestring = (char *)Jstrdup((const unsigned char *)raw);
+        if (!item->valuestring) {
             JDelete(item);
             return NULL;
         }
@@ -2201,8 +2317,8 @@ N_CJSON_PUBLIC(J *) JCreateRaw(const char *raw)
 N_CJSON_PUBLIC(J *) JCreateArray(void)
 {
     J *item = JNew_Item();
-    if(item) {
-        item->type=JArray;
+    if (item) {
+        item->type = JArray;
     }
     return item;
 }
@@ -2229,15 +2345,16 @@ N_CJSON_PUBLIC(J *) JCreateIntArray(const long int *numbers, int count)
     }
 
     a = JCreateArray();
-    for(i = 0; a && (i < (size_t)count); i++) {
+    for (i = 0; a && (i < (size_t)count); i++) {
         n = JCreateNumber(numbers[i]);
         if (!n) {
             JDelete(a);
             return NULL;
         }
-        if(!i) {
+        if (!i) {
             a->child = n;
-        } else {
+        }
+        else {
             suffix_object(p, n);
         }
         p = n;
@@ -2259,15 +2376,16 @@ N_CJSON_PUBLIC(J *) JCreateNumberArray(const JNUMBER *numbers, int count)
 
     a = JCreateArray();
 
-    for(i = 0; a && (i < (size_t)count); i++) {
+    for (i = 0; a && (i < (size_t)count); i++) {
         n = JCreateNumber(numbers[i]);
-        if(!n) {
+        if (!n) {
             JDelete(a);
             return NULL;
         }
-        if(!i) {
+        if (!i) {
             a->child = n;
-        } else {
+        }
+        else {
             suffix_object(p, n);
         }
         p = n;
@@ -2291,14 +2409,15 @@ N_CJSON_PUBLIC(J *) JCreateStringArray(const char **strings, int count)
 
     for (i = 0; a && (i < (size_t)count); i++) {
         n = JCreateString(strings[i]);
-        if(!n) {
+        if (!n) {
             JDelete(a);
             return NULL;
         }
-        if(!i) {
+        if (!i) {
             a->child = n;
-        } else {
-            suffix_object(p,n);
+        }
+        else {
+            suffix_object(p, n);
         }
         p = n;
     }
@@ -2328,13 +2447,16 @@ N_CJSON_PUBLIC(J *) JDuplicate(const J *item, Jbool recurse)
     newitem->valueint = item->valueint;
     newitem->valuenumber = item->valuenumber;
     if (item->valuestring) {
-        newitem->valuestring = (char*)Jstrdup((unsigned char*)item->valuestring);
+        newitem->valuestring =
+            (char *)Jstrdup((unsigned char *)item->valuestring);
         if (!newitem->valuestring) {
             goto fail;
         }
     }
     if (item->string) {
-        newitem->string = (item->type&JStringIsConst) ? item->string : (char*)Jstrdup((unsigned char*)item->string);
+        newitem->string = (item->type & JStringIsConst)
+                              ? item->string
+                              : (char *)Jstrdup((unsigned char *)item->string);
         if (!newitem->string) {
             goto fail;
         }
@@ -2346,16 +2468,20 @@ N_CJSON_PUBLIC(J *) JDuplicate(const J *item, Jbool recurse)
     /* Walk the ->next chain for the child. */
     child = item->child;
     while (child != NULL) {
-        newchild = JDuplicate(child, true); /* Duplicate (with recurse) each item in the ->next chain */
+        newchild = JDuplicate(
+            child,
+            true); /* Duplicate (with recurse) each item in the ->next chain */
         if (!newchild) {
             goto fail;
         }
         if (next != NULL) {
-            /* If newitem->child already set, then crosswire ->prev and ->next and move on */
+            /* If newitem->child already set, then crosswire ->prev and ->next
+             * and move on */
             next->next = newchild;
             newchild->prev = next;
             next = newchild;
-        } else {
+        }
+        else {
             /* Set newitem->child and move to it */
             newitem->child = newchild;
             next = newchild;
@@ -2375,7 +2501,7 @@ fail:
 
 N_CJSON_PUBLIC(void) JMinify(char *json)
 {
-    unsigned char *into = (unsigned char*)json;
+    unsigned char *into = (unsigned char *)json;
 
     if (json == NULL) {
         return;
@@ -2384,25 +2510,31 @@ N_CJSON_PUBLIC(void) JMinify(char *json)
     while (*json) {
         if (*json == ' ') {
             json++;
-        } else if (*json == '\t') {
+        }
+        else if (*json == '\t') {
             /* Whitespace characters. */
             json++;
-        } else if (*json == '\r') {
+        }
+        else if (*json == '\r') {
             json++;
-        } else if (*json=='\n') {
+        }
+        else if (*json == '\n') {
             json++;
-        } else if ((*json == '/') && (json[1] == '/')) {
+        }
+        else if ((*json == '/') && (json[1] == '/')) {
             /* double-slash comments, to end of line. */
             while (*json && (*json != '\n')) {
                 json++;
             }
-        } else if ((*json == '/') && (json[1] == '*')) {
+        }
+        else if ((*json == '/') && (json[1] == '*')) {
             /* multiline comments. */
             while (*json && !((*json == '*') && (json[1] == '/'))) {
                 json++;
             }
             json += 2;
-        } else if (*json == '\"') {
+        }
+        else if (*json == '\"') {
             /* string literals, which are \" sensitive. */
             *into++ = (unsigned char)*json++;
             while (*json && (*json != '\"')) {
@@ -2412,7 +2544,8 @@ N_CJSON_PUBLIC(void) JMinify(char *json)
                 *into++ = (unsigned char)*json++;
             }
             *into++ = (unsigned char)*json++;
-        } else {
+        }
+        else {
             /* All other characters. */
             *into++ = (unsigned char)*json++;
         }
@@ -2422,7 +2555,7 @@ N_CJSON_PUBLIC(void) JMinify(char *json)
     *into = '\0';
 }
 
-N_CJSON_PUBLIC(Jbool) JIsInvalid(const J * const item)
+N_CJSON_PUBLIC(Jbool) JIsInvalid(const J *const item)
 {
     if (item == NULL) {
         return false;
@@ -2430,7 +2563,7 @@ N_CJSON_PUBLIC(Jbool) JIsInvalid(const J * const item)
     return (item->type & 0xFF) == JInvalid;
 }
 
-N_CJSON_PUBLIC(Jbool) JIsFalse(const J * const item)
+N_CJSON_PUBLIC(Jbool) JIsFalse(const J *const item)
 {
     if (item == NULL) {
         return false;
@@ -2438,7 +2571,7 @@ N_CJSON_PUBLIC(Jbool) JIsFalse(const J * const item)
     return (item->type & 0xFF) == JFalse;
 }
 
-N_CJSON_PUBLIC(Jbool) JIsTrue(const J * const item)
+N_CJSON_PUBLIC(Jbool) JIsTrue(const J *const item)
 {
     if (item == NULL) {
         return false;
@@ -2446,15 +2579,14 @@ N_CJSON_PUBLIC(Jbool) JIsTrue(const J * const item)
     return (item->type & 0xff) == JTrue;
 }
 
-
-N_CJSON_PUBLIC(Jbool) JIsBool(const J * const item)
+N_CJSON_PUBLIC(Jbool) JIsBool(const J *const item)
 {
     if (item == NULL) {
         return false;
     }
     return (item->type & (JTrue | JFalse)) != 0;
 }
-N_CJSON_PUBLIC(Jbool) JIsNull(const J * const item)
+N_CJSON_PUBLIC(Jbool) JIsNull(const J *const item)
 {
     if (item == NULL) {
         return false;
@@ -2462,7 +2594,7 @@ N_CJSON_PUBLIC(Jbool) JIsNull(const J * const item)
     return (item->type & 0xFF) == JNULL;
 }
 
-N_CJSON_PUBLIC(Jbool) JIsNumber(const J * const item)
+N_CJSON_PUBLIC(Jbool) JIsNumber(const J *const item)
 {
     if (item == NULL) {
         return false;
@@ -2470,7 +2602,7 @@ N_CJSON_PUBLIC(Jbool) JIsNumber(const J * const item)
     return (item->type & 0xFF) == JNumber;
 }
 
-N_CJSON_PUBLIC(Jbool) JIsString(const J * const item)
+N_CJSON_PUBLIC(Jbool) JIsString(const J *const item)
 {
     if (item == NULL) {
         return false;
@@ -2478,7 +2610,7 @@ N_CJSON_PUBLIC(Jbool) JIsString(const J * const item)
     return (item->type & 0xFF) == JString;
 }
 
-N_CJSON_PUBLIC(Jbool) JIsArray(const J * const item)
+N_CJSON_PUBLIC(Jbool) JIsArray(const J *const item)
 {
     if (item == NULL) {
         return false;
@@ -2486,7 +2618,7 @@ N_CJSON_PUBLIC(Jbool) JIsArray(const J * const item)
     return (item->type & 0xFF) == JArray;
 }
 
-N_CJSON_PUBLIC(Jbool) JIsObject(const J * const item)
+N_CJSON_PUBLIC(Jbool) JIsObject(const J *const item)
 {
     if (item == NULL) {
         return false;
@@ -2494,7 +2626,7 @@ N_CJSON_PUBLIC(Jbool) JIsObject(const J * const item)
     return (item->type & 0xFF) == JObject;
 }
 
-N_CJSON_PUBLIC(Jbool) JIsRaw(const J * const item)
+N_CJSON_PUBLIC(Jbool) JIsRaw(const J *const item)
 {
     if (item == NULL) {
         return false;
@@ -2502,26 +2634,28 @@ N_CJSON_PUBLIC(Jbool) JIsRaw(const J * const item)
     return (item->type & 0xFF) == JRaw;
 }
 
-N_CJSON_PUBLIC(Jbool) JCompare(const J * const a, const J * const b, const Jbool case_sensitive)
+N_CJSON_PUBLIC(Jbool)
+JCompare(const J *const a, const J *const b, const Jbool case_sensitive)
 {
-    if ((a == NULL) || (b == NULL) || ((a->type & 0xFF) != (b->type & 0xFF)) || JIsInvalid(a)) {
+    if ((a == NULL) || (b == NULL) || ((a->type & 0xFF) != (b->type & 0xFF)) ||
+        JIsInvalid(a)) {
         return false;
     }
 
     /* check if type is valid */
     switch (a->type & 0xFF) {
-    case JFalse:
-    case JTrue:
-    case JNULL:
-    case JNumber:
-    case JString:
-    case JRaw:
-    case JArray:
-    case JObject:
-        break;
+        case JFalse:
+        case JTrue:
+        case JNULL:
+        case JNumber:
+        case JString:
+        case JRaw:
+        case JArray:
+        case JObject:
+            break;
 
-    default:
-        return false;
+        default:
+            return false;
     }
 
     /* identical objects are equal */
@@ -2530,82 +2664,87 @@ N_CJSON_PUBLIC(Jbool) JCompare(const J * const a, const J * const b, const Jbool
     }
 
     switch (a->type & 0xFF) {
-    /* in these cases and equal type is enough */
-    case JFalse:
-    case JTrue:
-    case JNULL:
-        return true;
+        /* in these cases and equal type is enough */
+        case JFalse:
+        case JTrue:
+        case JNULL:
+            return true;
 
-    case JNumber:
-        if (a->valuenumber == b->valuenumber) {
+        case JNumber:
+            if (a->valuenumber == b->valuenumber) {
+                return true;
+            }
+            return false;
+
+        case JString:
+        case JRaw:
+            if ((a->valuestring == NULL) || (b->valuestring == NULL)) {
+                return false;
+            }
+            if (strcmp(a->valuestring, b->valuestring) == 0) {
+                return true;
+            }
+
+            return false;
+
+        case JArray: {
+            J *a_element = a->child;
+            J *b_element = b->child;
+
+            for (; (a_element != NULL) && (b_element != NULL);) {
+                if (!JCompare(a_element, b_element, case_sensitive)) {
+                    return false;
+                }
+
+                a_element = a_element->next;
+                b_element = b_element->next;
+            }
+
+            /* one of the arrays is longer than the other */
+            if (a_element != b_element) {
+                return false;
+            }
+
             return true;
         }
-        return false;
 
-    case JString:
-    case JRaw:
-        if ((a->valuestring == NULL) || (b->valuestring == NULL)) {
-            return false;
-        }
-        if (strcmp(a->valuestring, b->valuestring) == 0) {
+        case JObject: {
+            J *a_element = NULL;
+            J *b_element = NULL;
+            JArrayForEach(a_element, a)
+            {
+                /* TODO This has O(n^2) runtime, which is horrible! */
+                b_element =
+                    get_object_item(b, a_element->string, case_sensitive);
+                if (b_element == NULL) {
+                    return false;
+                }
+
+                if (!JCompare(a_element, b_element, case_sensitive)) {
+                    return false;
+                }
+            }
+
+            /* doing this twice, once on a and b to prevent true comparison if a
+             * subset of b
+             * TODO: Do this the proper way, this is just a fix for now */
+            JArrayForEach(b_element, b)
+            {
+                a_element =
+                    get_object_item(a, b_element->string, case_sensitive);
+                if (a_element == NULL) {
+                    return false;
+                }
+
+                if (!JCompare(b_element, a_element, case_sensitive)) {
+                    return false;
+                }
+            }
+
             return true;
         }
 
-        return false;
-
-    case JArray: {
-        J *a_element = a->child;
-        J *b_element = b->child;
-
-        for (; (a_element != NULL) && (b_element != NULL);) {
-            if (!JCompare(a_element, b_element, case_sensitive)) {
-                return false;
-            }
-
-            a_element = a_element->next;
-            b_element = b_element->next;
-        }
-
-        /* one of the arrays is longer than the other */
-        if (a_element != b_element) {
+        default:
             return false;
-        }
-
-        return true;
-    }
-
-    case JObject: {
-        J *a_element = NULL;
-        J *b_element = NULL;
-        JArrayForEach(a_element, a) {
-            /* TODO This has O(n^2) runtime, which is horrible! */
-            b_element = get_object_item(b, a_element->string, case_sensitive);
-            if (b_element == NULL) {
-                return false;
-            }
-
-            if (!JCompare(a_element, b_element, case_sensitive)) {
-                return false;
-            }
-        }
-
-        /* doing this twice, once on a and b to prevent true comparison if a subset of b
-         * TODO: Do this the proper way, this is just a fix for now */
-        JArrayForEach(b_element, b) {
-            a_element = get_object_item(a, b_element->string, case_sensitive);
-            if (a_element == NULL) {
-                return false;
-            }
-
-            if (!JCompare(b_element, a_element, case_sensitive)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    default:
-        return false;
     }
 }

--- a/n_cjson.h
+++ b/n_cjson.h
@@ -3,11 +3,10 @@
  *
  * Written by Ray Ozzie and Blues Inc. team.
  *
- * Portions Copyright (c) 2019 Blues Inc. MIT License. Use of this source code is
- * governed by licenses granted by the copyright holder including that found in
- * the
- * <a href="https://github.com/blues/note-c/blob/master/LICENSE">LICENSE</a>
- * file.
+ * Portions Copyright (c) 2019 Blues Inc. MIT License. Use of this source code
+ * is governed by licenses granted by the copyright holder including that found
+ * in the <a
+ * href="https://github.com/blues/note-c/blob/master/LICENSE">LICENSE</a> file.
  *
  * MODIFIED for use in notecard primarily by altering default memory allocator
  * and by renaming the functions so that they won't conflict with a developer's
@@ -44,8 +43,7 @@
 #define J_h
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
 /* project version */
@@ -57,24 +55,26 @@ extern "C"
 
 /* J Types: */
 #define JInvalid (0)
-#define JFalse  (1 << 0)
-#define JTrue   (1 << 1)
-#define JNULL   (1 << 2)
+#define JFalse (1 << 0)
+#define JTrue (1 << 1)
+#define JNULL (1 << 2)
 #define JNumber (1 << 3)
 #define JString (1 << 4)
-#define JArray  (1 << 5)
+#define JArray (1 << 5)
 #define JObject (1 << 6)
-#define JRaw    (1 << 7) /* raw json */
+#define JRaw (1 << 7) /* raw json */
 
 #define JIsReference 256
 #define JStringIsConst 512
 
 /* The J structure: */
 typedef struct J {
-    /* next/prev allow you to walk array/object chains. Alternatively, use GetArraySize/GetArrayItem/GetObjectItem */
+    /* next/prev allow you to walk array/object chains. Alternatively, use
+     * GetArraySize/GetArrayItem/GetObjectItem */
     struct J *next;
     struct J *prev;
-    /* An array or object item will have a child pointer pointing to a chain of the items in the array/object. */
+    /* An array or object item will have a child pointer pointing to a chain of
+     * the items in the array/object. */
     struct J *child;
 
     /* The type of the item, as above. */
@@ -86,7 +86,8 @@ typedef struct J {
     long int valueint;
     /* The item's number, if type==JNumber */
     JNUMBER valuenumber;
-    /* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
+    /* The item's name string, if this item is the child of, or is in the list
+     * of subitems of an object. */
     char *string;
 } J;
 
@@ -97,18 +98,23 @@ typedef struct JHooks {
 
 typedef int Jbool;
 
-#if !defined(__WINDOWS__) && (defined(WIN32) || defined(WIN64) || defined(_MSC_VER) || defined(_WIN32))
+#if !defined(__WINDOWS__) && \
+    (defined(WIN32) || defined(WIN64) || defined(_MSC_VER) || defined(_WIN32))
 #define __WINDOWS__
 #endif
 #ifdef __WINDOWS__
 
-/* When compiling for windows, we specify a specific calling convention to avoid issues where we are being called from a project with a different default calling convention.  For windows you have 2 define options:
+/* When compiling for windows, we specify a specific calling convention to avoid
+issues where we are being called from a project with a different default calling
+convention.  For windows you have 2 define options:
 
-N_CJSON_HIDE_SYMBOLS - Define this in the case where you don't want to ever dllexport symbols
-N_CJSON_EXPORT_SYMBOLS - Define this on library build when you want to dllexport symbols (default)
-N_CJSON_IMPORT_SYMBOLS - Define this if you want to dllimport symbol
+N_CJSON_HIDE_SYMBOLS - Define this in the case where you don't want to ever
+dllexport symbols N_CJSON_EXPORT_SYMBOLS - Define this on library build when you
+want to dllexport symbols (default) N_CJSON_IMPORT_SYMBOLS - Define this if you
+want to dllimport symbol
 
-For *nix builds that support visibility attribute, you can define similar behavior by
+For *nix builds that support visibility attribute, you can define similar
+behavior by
 
 setting default visibility to hidden by adding
 -fvisibility=hidden (for gcc)
@@ -116,86 +122,109 @@ or
 -xldscope=hidden (for sun cc)
 to CFLAGS
 
-then using the N_CJSON_API_VISIBILITY flag to "export" the same symbols the way N_CJSON_EXPORT_SYMBOLS does
+then using the N_CJSON_API_VISIBILITY flag to "export" the same symbols the way
+N_CJSON_EXPORT_SYMBOLS does
 
 */
 
-/* export symbols by default, this is necessary for copy pasting the C and header file */
-#if !defined(N_CJSON_HIDE_SYMBOLS) && !defined(N_CJSON_IMPORT_SYMBOLS) && !defined(N_CJSON_EXPORT_SYMBOLS)
+/* export symbols by default, this is necessary for copy pasting the C and
+ * header file */
+#if !defined(N_CJSON_HIDE_SYMBOLS) && !defined(N_CJSON_IMPORT_SYMBOLS) && \
+    !defined(N_CJSON_EXPORT_SYMBOLS)
 #define N_CJSON_EXPORT_SYMBOLS
 #endif
 
 #if defined(N_CJSON_HIDE_SYMBOLS)
-#define N_CJSON_PUBLIC(type)   type __stdcall
+#define N_CJSON_PUBLIC(type) type __stdcall
 #elif defined(N_CJSON_EXPORT_SYMBOLS)
-#define N_CJSON_PUBLIC(type)   __declspec(dllexport) type __stdcall
+#define N_CJSON_PUBLIC(type) __declspec(dllexport) type __stdcall
 #elif defined(N_CJSON_IMPORT_SYMBOLS)
-#define N_CJSON_PUBLIC(type)   __declspec(dllimport) type __stdcall
+#define N_CJSON_PUBLIC(type) __declspec(dllimport) type __stdcall
 #endif
 #else /* !WIN32 */
-#if (defined(__GNUC__) || defined(__SUNPRO_CC) || defined (__SUNPRO_C)) && defined(N_CJSON_API_VISIBILITY)
-#define N_CJSON_PUBLIC(type)   __attribute__((visibility("default"))) type
+#if (defined(__GNUC__) || defined(__SUNPRO_CC) || defined(__SUNPRO_C)) && \
+    defined(N_CJSON_API_VISIBILITY)
+#define N_CJSON_PUBLIC(type) __attribute__((visibility("default"))) type
 #else
 #define N_CJSON_PUBLIC(type) type
 #endif
 #endif
 
-/* Limits how deeply nested arrays/objects can be before J rejects to parse them.
- * This is to prevent stack overflows. */
+/* Limits how deeply nested arrays/objects can be before J rejects to parse
+ * them. This is to prevent stack overflows. */
 #ifndef N_CJSON_NESTING_LIMIT
 #define N_CJSON_NESTING_LIMIT 1000
 #endif
 
 /* returns the version of J as a string */
-N_CJSON_PUBLIC(const char*) JVersion(void);
+N_CJSON_PUBLIC(const char *) JVersion(void);
 
 /* Supply malloc, realloc and free functions to J */
-N_CJSON_PUBLIC(void) JInitHooks(JHooks* hooks);
+N_CJSON_PUBLIC(void) JInitHooks(JHooks *hooks);
 
-/* Memory Management: the caller is always responsible to free the results from all variants of JParse (with JDelete) and JPrint (with stdlib free, JHooks.free_fn, or JFree as appropriate). The exception is JPrintPreallocated, where the caller has full responsibility of the buffer. */
+/* Memory Management: the caller is always responsible to free the results from
+ * all variants of JParse (with JDelete) and JPrint (with stdlib free,
+ * JHooks.free_fn, or JFree as appropriate). The exception is
+ * JPrintPreallocated, where the caller has full responsibility of the buffer.
+ */
 /* Supply a block of JSON, and this returns a J object you can interrogate. */
 N_CJSON_PUBLIC(J *) JParse(const char *value);
-/* ParseWithOpts allows you to require (and check) that the JSON is null terminated, and to retrieve the pointer to the final byte parsed. */
-/* If you supply a ptr in return_parse_end and parsing fails, then return_parse_end will contain a pointer to the error so will match JGetErrorPtr(). */
-N_CJSON_PUBLIC(J *) JParseWithOpts(const char *value, const char **return_parse_end, Jbool require_null_terminated);
+/* ParseWithOpts allows you to require (and check) that the JSON is null
+ * terminated, and to retrieve the pointer to the final byte parsed. */
+/* If you supply a ptr in return_parse_end and parsing fails, then
+ * return_parse_end will contain a pointer to the error so will match
+ * JGetErrorPtr(). */
+N_CJSON_PUBLIC(J *)
+JParseWithOpts(const char *value, const char **return_parse_end,
+               Jbool require_null_terminated);
 
 /* Render a J entity to text for transfer/storage. */
 N_CJSON_PUBLIC(char *) JPrint(const J *item);
 /* Render a J entity to text for transfer/storage without any formatting. */
 N_CJSON_PUBLIC(char *) JPrintUnformatted(const J *item);
-/* Render a J entity to text using a buffered strategy. prebuffer is a guess at the final size. guessing well reduces reallocation. fmt=0 gives unformatted, =1 gives formatted */
+/* Render a J entity to text using a buffered strategy. prebuffer is a guess at
+ * the final size. guessing well reduces reallocation. fmt=0 gives unformatted,
+ * =1 gives formatted */
 N_CJSON_PUBLIC(char *) JPrintBuffered(const J *item, int prebuffer, Jbool fmt);
-/* Render a J entity to text using a buffer already allocated in memory with given length. Returns 1 on success and 0 on failure. */
-/* NOTE: J is not always 100% accurate in estimating how much memory it will use, so to be safe allocate 5 bytes more than you actually need */
-N_CJSON_PUBLIC(Jbool) JPrintPreallocated(J *item, char *buffer, const int length, const Jbool format);
+/* Render a J entity to text using a buffer already allocated in memory with
+ * given length. Returns 1 on success and 0 on failure. */
+/* NOTE: J is not always 100% accurate in estimating how much memory it will
+ * use, so to be safe allocate 5 bytes more than you actually need */
+N_CJSON_PUBLIC(Jbool)
+JPrintPreallocated(J *item, char *buffer, const int length, const Jbool format);
 /* Delete a J entity and all subentities. */
 N_CJSON_PUBLIC(void) JDelete(J *c);
 
 /* Returns the number of items in an array (or object). */
 N_CJSON_PUBLIC(int) JGetArraySize(const J *array);
-/* Retrieve item number "index" from array "array". Returns NULL if unsuccessful. */
+/* Retrieve item number "index" from array "array". Returns NULL if
+ * unsuccessful. */
 N_CJSON_PUBLIC(J *) JGetArrayItem(const J *array, int index);
 /* Get item "string" from object. Case insensitive. */
-N_CJSON_PUBLIC(J *) JGetObjectItem(const J * const object, const char * const string);
-N_CJSON_PUBLIC(J *) JGetObjectItemCaseSensitive(const J * const object, const char * const string);
+N_CJSON_PUBLIC(J *)
+JGetObjectItem(const J *const object, const char *const string);
+N_CJSON_PUBLIC(J *)
+JGetObjectItemCaseSensitive(const J *const object, const char *const string);
 N_CJSON_PUBLIC(Jbool) JHasObjectItem(const J *object, const char *string);
-/* For analysing failed parses. This returns a pointer to the parse error. You'll probably need to look a few chars back to make sense of it. Defined when JParse() returns 0. 0 when JParse() succeeds. */
+/* For analysing failed parses. This returns a pointer to the parse error.
+ * You'll probably need to look a few chars back to make sense of it. Defined
+ * when JParse() returns 0. 0 when JParse() succeeds. */
 N_CJSON_PUBLIC(const char *) JGetErrorPtr(void);
 
 /* Check if the item is a string and return its valuestring */
 N_CJSON_PUBLIC(char *) JGetStringValue(J *item);
 
 /* These functions check the type of an item */
-N_CJSON_PUBLIC(Jbool) JIsInvalid(const J * const item);
-N_CJSON_PUBLIC(Jbool) JIsFalse(const J * const item);
-N_CJSON_PUBLIC(Jbool) JIsTrue(const J * const item);
-N_CJSON_PUBLIC(Jbool) JIsBool(const J * const item);
-N_CJSON_PUBLIC(Jbool) JIsNull(const J * const item);
-N_CJSON_PUBLIC(Jbool) JIsNumber(const J * const item);
-N_CJSON_PUBLIC(Jbool) JIsString(const J * const item);
-N_CJSON_PUBLIC(Jbool) JIsArray(const J * const item);
-N_CJSON_PUBLIC(Jbool) JIsObject(const J * const item);
-N_CJSON_PUBLIC(Jbool) JIsRaw(const J * const item);
+N_CJSON_PUBLIC(Jbool) JIsInvalid(const J *const item);
+N_CJSON_PUBLIC(Jbool) JIsFalse(const J *const item);
+N_CJSON_PUBLIC(Jbool) JIsTrue(const J *const item);
+N_CJSON_PUBLIC(Jbool) JIsBool(const J *const item);
+N_CJSON_PUBLIC(Jbool) JIsNull(const J *const item);
+N_CJSON_PUBLIC(Jbool) JIsNumber(const J *const item);
+N_CJSON_PUBLIC(Jbool) JIsString(const J *const item);
+N_CJSON_PUBLIC(Jbool) JIsArray(const J *const item);
+N_CJSON_PUBLIC(Jbool) JIsObject(const J *const item);
+N_CJSON_PUBLIC(Jbool) JIsRaw(const J *const item);
 
 /* These calls create a J item of the appropriate type. */
 N_CJSON_PUBLIC(J *) JCreateNull(void);
@@ -226,68 +255,94 @@ N_CJSON_PUBLIC(J *) JCreateStringArray(const char **strings, int count);
 /* Append item to the specified array/object. */
 N_CJSON_PUBLIC(void) JAddItemToArray(J *array, J *item);
 N_CJSON_PUBLIC(void) JAddItemToObject(J *object, const char *string, J *item);
-/* Use this when string is definitely const (i.e. a literal, or as good as), and will definitely survive the J object.
- * WARNING: When this function was used, make sure to always check that (item->type & JStringIsConst) is zero before
+/* Use this when string is definitely const (i.e. a literal, or as good as), and
+ * will definitely survive the J object. WARNING: When this function was used,
+ * make sure to always check that (item->type & JStringIsConst) is zero before
  * writing to `item->string` */
 N_CJSON_PUBLIC(void) JAddItemToObjectCS(J *object, const char *string, J *item);
-/* Append reference to item to the specified array/object. Use this when you want to add an existing J to a new J, but don't want to corrupt your existing J. */
+/* Append reference to item to the specified array/object. Use this when you
+ * want to add an existing J to a new J, but don't want to corrupt your existing
+ * J. */
 N_CJSON_PUBLIC(void) JAddItemReferenceToArray(J *array, J *item);
-N_CJSON_PUBLIC(void) JAddItemReferenceToObject(J *object, const char *string, J *item);
+N_CJSON_PUBLIC(void)
+JAddItemReferenceToObject(J *object, const char *string, J *item);
 
 /* Remove/Detatch items from Arrays/Objects. */
-N_CJSON_PUBLIC(J *) JDetachItemViaPointer(J *parent, J * const item);
+N_CJSON_PUBLIC(J *) JDetachItemViaPointer(J *parent, J *const item);
 N_CJSON_PUBLIC(J *) JDetachItemFromArray(J *array, int which);
 N_CJSON_PUBLIC(void) JDeleteItemFromArray(J *array, int which);
 N_CJSON_PUBLIC(J *) JDetachItemFromObject(J *object, const char *string);
-N_CJSON_PUBLIC(J *) JDetachItemFromObjectCaseSensitive(J *object, const char *string);
+N_CJSON_PUBLIC(J *)
+JDetachItemFromObjectCaseSensitive(J *object, const char *string);
 N_CJSON_PUBLIC(void) JDeleteItemFromObject(J *object, const char *string);
-N_CJSON_PUBLIC(void) JDeleteItemFromObjectCaseSensitive(J *object, const char *string);
+N_CJSON_PUBLIC(void)
+JDeleteItemFromObjectCaseSensitive(J *object, const char *string);
 
 /* Update array items. */
-N_CJSON_PUBLIC(void) JInsertItemInArray(J *array, int which, J *newitem); /* Shifts pre-existing items to the right. */
-N_CJSON_PUBLIC(Jbool) JReplaceItemViaPointer(J * const parent, J * const item, J * replacement);
+N_CJSON_PUBLIC(void)
+JInsertItemInArray(J *array, int which,
+                   J *newitem); /* Shifts pre-existing items to the right. */
+N_CJSON_PUBLIC(Jbool)
+JReplaceItemViaPointer(J *const parent, J *const item, J *replacement);
 N_CJSON_PUBLIC(void) JReplaceItemInArray(J *array, int which, J *newitem);
-N_CJSON_PUBLIC(void) JReplaceItemInObject(J *object,const char *string,J *newitem);
-N_CJSON_PUBLIC(void) JReplaceItemInObjectCaseSensitive(J *object,const char *string,J *newitem);
+N_CJSON_PUBLIC(void)
+JReplaceItemInObject(J *object, const char *string, J *newitem);
+N_CJSON_PUBLIC(void)
+JReplaceItemInObjectCaseSensitive(J *object, const char *string, J *newitem);
 
 /* Duplicate a J item */
 N_CJSON_PUBLIC(J *) JDuplicate(const J *item, Jbool recurse);
-/* Duplicate will create a new, identical J item to the one you pass, in new memory that will
-need to be released. With recurse!=0, it will duplicate any children connected to the item.
-The item->next and ->prev pointers are always zero on return from Duplicate. */
-/* Recursively compare two J items for equality. If either a or b is NULL or invalid, they will be considered unequal.
- * case_sensitive determines if object keys are treated case sensitive (1) or case insensitive (0) */
-N_CJSON_PUBLIC(Jbool) JCompare(const J * const a, const J * const b, const Jbool case_sensitive);
-
+/* Duplicate will create a new, identical J item to the one you pass, in new
+memory that will need to be released. With recurse!=0, it will duplicate any
+children connected to the item. The item->next and ->prev pointers are always
+zero on return from Duplicate. */
+/* Recursively compare two J items for equality. If either a or b is NULL or
+ * invalid, they will be considered unequal. case_sensitive determines if object
+ * keys are treated case sensitive (1) or case insensitive (0) */
+N_CJSON_PUBLIC(Jbool)
+JCompare(const J *const a, const J *const b, const Jbool case_sensitive);
 
 N_CJSON_PUBLIC(void) JMinify(char *json);
 
 /* Helper functions for creating and adding items to an object at the same time.
  * They return the added item or NULL on failure. */
-N_CJSON_PUBLIC(J*) JAddNullToObject(J * const object, const char * const name);
-N_CJSON_PUBLIC(J*) JAddTrueToObject(J * const object, const char * const name);
-N_CJSON_PUBLIC(J*) JAddFalseToObject(J * const object, const char * const name);
-N_CJSON_PUBLIC(J*) JAddBoolToObject(J * const object, const char * const name, const Jbool boolean);
-N_CJSON_PUBLIC(J*) JAddNumberToObject(J * const object, const char * const name, const JNUMBER number);
-N_CJSON_PUBLIC(J*) JAddStringToObject(J * const object, const char * const name, const char * const string);
-N_CJSON_PUBLIC(J*) JAddRawToObject(J * const object, const char * const name, const char * const raw);
-N_CJSON_PUBLIC(J*) JAddObjectToObject(J * const object, const char * const name);
-N_CJSON_PUBLIC(J*) JAddArrayToObject(J * const object, const char * const name);
+N_CJSON_PUBLIC(J *) JAddNullToObject(J *const object, const char *const name);
+N_CJSON_PUBLIC(J *) JAddTrueToObject(J *const object, const char *const name);
+N_CJSON_PUBLIC(J *) JAddFalseToObject(J *const object, const char *const name);
+N_CJSON_PUBLIC(J *)
+JAddBoolToObject(J *const object, const char *const name, const Jbool boolean);
+N_CJSON_PUBLIC(J *)
+JAddNumberToObject(J *const object, const char *const name,
+                   const JNUMBER number);
+N_CJSON_PUBLIC(J *)
+JAddStringToObject(J *const object, const char *const name,
+                   const char *const string);
+N_CJSON_PUBLIC(J *)
+JAddRawToObject(J *const object, const char *const name, const char *const raw);
+N_CJSON_PUBLIC(J *) JAddObjectToObject(J *const object, const char *const name);
+N_CJSON_PUBLIC(J *) JAddArrayToObject(J *const object, const char *const name);
 #define JConvertToJSONString JPrintUnformatted
 #define JConvertFromJSONString JParse
 
-/* When assigning an integer value, it needs to be propagated to valuenumber too. */
-#define JSetIntValue(object, number) ((object) ? (object)->valueint = (object)->valuenumber = (number) : (number))
+/* When assigning an integer value, it needs to be propagated to valuenumber
+ * too. */
+#define JSetIntValue(object, number)                                  \
+    ((object) ? (object)->valueint = (object)->valuenumber = (number) \
+              : (number))
 /* helper for the JSetNumberValue macro */
 N_CJSON_PUBLIC(JNUMBER) JSetNumberHelper(J *object, JNUMBER number);
-#define JSetNumberValue(object, number) ((object != NULL) ? JSetNumberHelper(object, (JNUMBER)number) : (number))
+#define JSetNumberValue(object, number) \
+    ((object != NULL) ? JSetNumberHelper(object, (JNUMBER)number) : (number))
 
 /* Macro for iterating over an array or object */
-#define JArrayForEach(element, array) for(element = (array != NULL) ? (array)->child : NULL; element != NULL; element = element->next)
+#define JArrayForEach(element, array)                                        \
+    for (element = (array != NULL) ? (array)->child : NULL; element != NULL; \
+         element = element->next)
 // Iterate over the fields of an object
 #define JObjectForEach(element, array) JArrayForEach(element, array)
 
-/* malloc/free objects using the malloc/free functions that have been set with JInitHooks */
+/* malloc/free objects using the malloc/free functions that have been set with
+ * JInitHooks */
 N_CJSON_PUBLIC(void *) JMalloc(size_t size);
 N_CJSON_PUBLIC(void) JFree(void *object);
 

--- a/n_cjson_helpers.c
+++ b/n_cjson_helpers.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+
 #include "n_lib.h"
 
 //**************************************************************************/
@@ -43,17 +44,17 @@ bool JIsPresent(J *rsp, const char *field)
 char *JGetString(J *rsp, const char *field)
 {
     if (rsp == NULL) {
-        return (char *) c_nullstring;
+        return (char *)c_nullstring;
     }
     J *item = JGetObjectItem(rsp, field);
     if (item == NULL) {
-        return (char *) c_nullstring;
+        return (char *)c_nullstring;
     }
     if (!JIsString(item)) {
-        return (char *) c_nullstring;
+        return (char *)c_nullstring;
     }
     if (item->valuestring == NULL) {
-        return (char *) c_nullstring;
+        return (char *)c_nullstring;
     }
     return item->valuestring;
 }
@@ -312,13 +313,14 @@ bool JContainsString(J *rsp, const char *field, const char *substr)
     @returns bool. Whether the binary field was set.
 */
 /**************************************************************************/
-bool JAddBinaryToObject(J *req, const char *fieldName, const void *binaryData, uint32_t binaryDataLen)
+bool JAddBinaryToObject(J *req, const char *fieldName, const void *binaryData,
+                        uint32_t binaryDataLen)
 {
     if (req == NULL) {
         return false;
     }
     unsigned stringDataLen = JB64EncodeLen(binaryDataLen);
-    char *stringData = (char *) _Malloc(stringDataLen);
+    char *stringData = (char *)_Malloc(stringDataLen);
     if (stringData == NULL) {
         return false;
     }
@@ -334,52 +336,57 @@ bool JAddBinaryToObject(J *req, const char *fieldName, const void *binaryData, u
 
 //**************************************************************************/
 /*!
-    @brief  Get binary from an object that is expected to be a Base64-encoded string.
+    @brief  Get binary from an object that is expected to be a Base64-encoded
+   string.
     @param   rsp The JSON object containing the  field.
     @param   fieldName The field to get data from.
-    @param   retBinaryData The binary data object allocated.  (Use standard "free" method to free it.)
-			 Note that, as a convenience to the caller in case the "binary data" is actually a string,
-			 one byte extra is allocated in the return buffer which is filled with '\0'.  This byte
-			 is not included in the retBinaryDataLen length.
+    @param   retBinaryData The binary data object allocated.  (Use standard
+   "free" method to free it.) Note that, as a convenience to the caller in case
+   the "binary data" is actually a string, one byte extra is allocated in the
+   return buffer which is filled with '\0'.  This byte is not included in the
+   retBinaryDataLen length.
     @param   retBinaryDataLen The length of the binary data.
     @returns bool. Whether the binary data was allocated and returned.
 */
 /**************************************************************************/
-bool JGetBinaryFromObject(J *rsp, const char *fieldName, uint8_t **retBinaryData, uint32_t *retBinaryDataLen)
+bool JGetBinaryFromObject(J *rsp, const char *fieldName,
+                          uint8_t **retBinaryData, uint32_t *retBinaryDataLen)
 {
     if (rsp == NULL) {
         return false;
     }
 
-    // In some cases, the caller may already have extracted the string from a different field, in which
-    // case "rsp" will be set to the payload pointer.
+    // In some cases, the caller may already have extracted the string from a
+    // different field, in which case "rsp" will be set to the payload pointer.
     char *payload;
     if (fieldName == NULL) {
-        payload = (char *) rsp;
-    } else {
+        payload = (char *)rsp;
+    }
+    else {
         payload = JGetString(rsp, fieldName);
     }
     if (payload[0] == '\0') {
         return false;
     }
 
-    // Allocate a buffer for the payload, with an extra 'convenience byte' for null termination.  (see below)
-    char *p = (char *) _Malloc(JB64DecodeLen(payload)+1);
+    // Allocate a buffer for the payload, with an extra 'convenience byte' for
+    // null termination.  (see below)
+    char *p = (char *)_Malloc(JB64DecodeLen(payload) + 1);
     if (p == NULL) {
         return false;
     }
     uint32_t actualLen = JB64Decode(p, payload);
 
-    // As a convenience to the caller, null-terminate the returned buffer in case it's a string.
-    // (If we didn't do this, the caller would be forced to alloc another buffer of length+1 and
-    // copy it to add the null terminator, while it's easy for us to do it here.)
+    // As a convenience to the caller, null-terminate the returned buffer in
+    // case it's a string. (If we didn't do this, the caller would be forced to
+    // alloc another buffer of length+1 and copy it to add the null terminator,
+    // while it's easy for us to do it here.)
     p[actualLen] = '\0';
 
     // Return the binary to the caller
     *retBinaryData = (uint8_t *)p;
     *retBinaryDataLen = actualLen;
     return true;
-
 }
 
 //**************************************************************************/
@@ -389,7 +396,7 @@ bool JGetBinaryFromObject(J *rsp, const char *fieldName, uint8_t **retBinaryData
     @returns The number, or and empty string, if NULL.
 */
 /**************************************************************************/
-const char *JGetItemName(const J * item)
+const char *JGetItemName(const J *item)
 {
     if (item == NULL || item->string == NULL) {
         return "";
@@ -420,7 +427,7 @@ void JItoA(long int n, char *s)
         s[i++] = '-';
     }
     s[i] = '\0';
-    for (i = 0, j = strlen(s)-1; i<j; i++, j--) {
+    for (i = 0, j = strlen(s) - 1; i < j; i++, j--) {
         c = s[i];
         s[i] = s[j];
         s[j] = c;
@@ -445,18 +452,19 @@ long int JAtoI(const char *string)
     if (*string == '-') {
         sign = 1;
         string += 1;
-    } else {
+    }
+    else {
         sign = 0;
         if (*string == '+') {
             string += 1;
         }
     }
-    for ( ; ; string += 1) {
+    for (;; string += 1) {
         digit = *string - '0';
         if (digit > 9) {
             break;
         }
-        result = (10*result) + digit;
+        result = (10 * result) + digit;
     }
     if (sign) {
         result = -result;
@@ -473,7 +481,7 @@ long int JAtoI(const char *string)
 /**************************************************************************/
 char *JAllocString(uint8_t *buffer, uint32_t len)
 {
-    char *buf = _Malloc(len+1);
+    char *buf = _Malloc(len + 1);
     if (buf == NULL) {
         return false;
     }
@@ -497,20 +505,20 @@ const char *JType(J *item)
         return "";
     }
     switch (item->type & 0xff) {
-    case JTrue:
-    case JFalse:
-        return "bool";
-    case JNULL:
-        return "null";
-    case JNumber:
-        return "number";
-    case JRaw:
-    case JString:
-        return "string";
-    case JObject:
-        return "object";
-    case JArray:
-        return "array";
+        case JTrue:
+        case JFalse:
+            return "bool";
+        case JNULL:
+            return "null";
+        case JNumber:
+            return "number";
+        case JRaw:
+        case JString:
+            return "string";
+        case JObject:
+            return "object";
+        case JArray:
+            return "array";
     }
     return "invalid";
 }
@@ -534,52 +542,49 @@ int JGetType(J *rsp, const char *field)
         return JTYPE_NOT_PRESENT;
     }
     switch (item->type & 0xff) {
-    case JTrue:
-        return JTYPE_BOOL_TRUE;
-    case JFalse:
-        return JTYPE_BOOL_FALSE;
-    case JNULL:
-        return JTYPE_NULL;
-    case JNumber:
-        if (item->valueint == 0 && item->valuenumber == 0) {
-            return JTYPE_NUMBER_ZERO;
-        }
-        return JTYPE_NUMBER;
-    case JRaw:
-    case JString:
-        v = item->valuestring;
-        if (v == NULL || v[0] == 0) {
-            return JTYPE_STRING_BLANK;
-        }
-        int vlen = strlen(v);
-        char *endstr;
-        JNUMBER value = JAtoN(v, &endstr);
-        if (endstr[0] == 0) {
-            if (value == 0) {
-                return JTYPE_STRING_ZERO;
+        case JTrue:
+            return JTYPE_BOOL_TRUE;
+        case JFalse:
+            return JTYPE_BOOL_FALSE;
+        case JNULL:
+            return JTYPE_NULL;
+        case JNumber:
+            if (item->valueint == 0 && item->valuenumber == 0) {
+                return JTYPE_NUMBER_ZERO;
             }
-            return JTYPE_STRING_NUMBER;
-        }
-        if (vlen == 4 && (
-                    (v[0] == 't' || v[0] == 'T')
-                    && (v[1] == 'r' || v[1] == 'R')
-                    && (v[2] == 'u' || v[2] == 'U')
-                    && (v[3] == 'e' || v[3] == 'E'))) {
-            return JTYPE_STRING_BOOL_TRUE;
-        }
-        if (vlen == 5 && (
-                    (v[0] == 'f' || v[0] == 'F')
-                    && (v[1] == 'a' || v[1] == 'A')
-                    && (v[2] == 'l' || v[2] == 'L')
-                    && (v[3] == 's' || v[3] == 'S')
-                    && (v[4] == 'e' || v[4] == 'E'))) {
-            return JTYPE_STRING_BOOL_FALSE;
-        }
-        return JTYPE_STRING;
-    case JObject:
-        return JTYPE_OBJECT;
-    case JArray:
-        return JTYPE_ARRAY;
+            return JTYPE_NUMBER;
+        case JRaw:
+        case JString:
+            v = item->valuestring;
+            if (v == NULL || v[0] == 0) {
+                return JTYPE_STRING_BLANK;
+            }
+            int vlen = strlen(v);
+            char *endstr;
+            JNUMBER value = JAtoN(v, &endstr);
+            if (endstr[0] == 0) {
+                if (value == 0) {
+                    return JTYPE_STRING_ZERO;
+                }
+                return JTYPE_STRING_NUMBER;
+            }
+            if (vlen == 4 &&
+                ((v[0] == 't' || v[0] == 'T') && (v[1] == 'r' || v[1] == 'R') &&
+                 (v[2] == 'u' || v[2] == 'U') &&
+                 (v[3] == 'e' || v[3] == 'E'))) {
+                return JTYPE_STRING_BOOL_TRUE;
+            }
+            if (vlen == 5 &&
+                ((v[0] == 'f' || v[0] == 'F') && (v[1] == 'a' || v[1] == 'A') &&
+                 (v[2] == 'l' || v[2] == 'L') && (v[3] == 's' || v[3] == 'S') &&
+                 (v[4] == 'e' || v[4] == 'E'))) {
+                return JTYPE_STRING_BOOL_FALSE;
+            }
+            return JTYPE_STRING;
+        case JObject:
+            return JTYPE_OBJECT;
+        case JArray:
+            return JTYPE_ARRAY;
     }
     return JTYPE_NOT_PRESENT;
 }

--- a/n_edge.h
+++ b/n_edge.h
@@ -78,11 +78,11 @@ typedef struct {
 } LogData;
 
 // Format of the edge entry which is the dequeued note body
-#define	EDGE_NOTEFILE				"_edge.qi"
-#define EDGETYPE_SCAN				"scan"
-#define EDGETYPE_TRACKPOINT			"track"
-#define EDGETYPE_MOTIONPOINT		"motion"
-#define EDGETYPE_LOG				"log"
+#define EDGE_NOTEFILE "_edge.qi"
+#define EDGETYPE_SCAN "scan"
+#define EDGETYPE_TRACKPOINT "track"
+#define EDGETYPE_MOTIONPOINT "motion"
+#define EDGETYPE_LOG "log"
 typedef struct {
 #define EDGE_TYPE "type"
     char edgeType[32];
@@ -127,23 +127,23 @@ typedef struct {
 } EdgeData;
 
 // Scan formats
-#define SCAN_SEP            '\n'			// inter-reading separator
-#define SCAN_TYPE_GSM       'g'             // FORMAT_2G
-#define SCAN_TYPE_CDMA      'c'             // FORMAT_2G
-#define SCAN_TYPE_UMTS      'u'             // FORMAT_3G
-#define SCAN_TYPE_WCDMA     'w'             // FORMAT_3G
-#define SCAN_TYPE_LTE       'l'             // FORMAT_4G
-#define SCAN_TYPE_EMTC      'e'             // FORMAT_4G
-#define SCAN_TYPE_NBIOT     'i'             // FORMAT_4G
-#define SCAN_TYPE_NR        'n'             // FORMAT_5G
-#define SCAN_TYPE_WIFI      'x'             // FORMAT_WIFI
-#define SCAN_TYPE_CELLTIME  't'             // FORMAT_TIME
-#define SCAN_TYPE_WIFITIME  's'             // FORMAT_TIME
-#define SCAN_TYPE_GPS       'd'             // FORMAT_GPS
-#define SCAN_FORMAT_2G      "xmcc,xmnc,xlac,xcid,xrssi"
-#define SCAN_FORMAT_3G      "xmcc,xmnc,xlac,xcid,xpsc,xrscp"
-#define SCAN_FORMAT_4G      "xmcc,xmnc,xtac,xcid,xpci,rssi,rsrp,rsrq,xband,xchan"
-#define SCAN_FORMAT_5G      "xmcc,xmnc,xtac,xcid,xpci,rssi,rsrp,rsrq,xband,xchan"
-#define SCAN_FORMAT_WIFI    "xbssid,xchannel,xfreq,rssi,snr,\"ssid\""
-#define SCAN_FORMAT_TIME    "epochsecs"
-#define SCAN_FORMAT_GPS     "epochsecs,olc,hdop"
+#define SCAN_SEP '\n'           // inter-reading separator
+#define SCAN_TYPE_GSM 'g'       // FORMAT_2G
+#define SCAN_TYPE_CDMA 'c'      // FORMAT_2G
+#define SCAN_TYPE_UMTS 'u'      // FORMAT_3G
+#define SCAN_TYPE_WCDMA 'w'     // FORMAT_3G
+#define SCAN_TYPE_LTE 'l'       // FORMAT_4G
+#define SCAN_TYPE_EMTC 'e'      // FORMAT_4G
+#define SCAN_TYPE_NBIOT 'i'     // FORMAT_4G
+#define SCAN_TYPE_NR 'n'        // FORMAT_5G
+#define SCAN_TYPE_WIFI 'x'      // FORMAT_WIFI
+#define SCAN_TYPE_CELLTIME 't'  // FORMAT_TIME
+#define SCAN_TYPE_WIFITIME 's'  // FORMAT_TIME
+#define SCAN_TYPE_GPS 'd'       // FORMAT_GPS
+#define SCAN_FORMAT_2G "xmcc,xmnc,xlac,xcid,xrssi"
+#define SCAN_FORMAT_3G "xmcc,xmnc,xlac,xcid,xpsc,xrscp"
+#define SCAN_FORMAT_4G "xmcc,xmnc,xtac,xcid,xpci,rssi,rsrp,rsrq,xband,xchan"
+#define SCAN_FORMAT_5G "xmcc,xmnc,xtac,xcid,xpci,rssi,rsrp,rsrq,xband,xchan"
+#define SCAN_FORMAT_WIFI "xbssid,xchannel,xfreq,rssi,snr,\"ssid\""
+#define SCAN_FORMAT_TIME "epochsecs"
+#define SCAN_FORMAT_GPS "epochsecs,olc,hdop"

--- a/n_ftoa.c
+++ b/n_ftoa.c
@@ -18,20 +18,20 @@
  * modified) versions of this file, nor is leaving this notice intact mandatory.
  */
 
+#include <math.h>
+#include <stdint.h>
 
 #include "n_lib.h"
-#include <stdint.h>
-#include <math.h>
 
-#define	PRINT_F_QUOTE		0x0001
-#define	PRINT_F_TYPE_E		0x0002
-#define	PRINT_F_TYPE_G		0x0004
-#define	PRINT_F_NUM			0x0008
-#define	PRINT_F_PLUS		0x0010
-#define	PRINT_F_MINUS		0x0020
-#define	PRINT_F_ZERO		0x0040
-#define	PRINT_F_SPACE		0x0080
-#define	PRINT_F_UP			0x0100
+#define PRINT_F_QUOTE 0x0001
+#define PRINT_F_TYPE_E 0x0002
+#define PRINT_F_TYPE_G 0x0004
+#define PRINT_F_NUM 0x0008
+#define PRINT_F_PLUS 0x0010
+#define PRINT_F_MINUS 0x0020
+#define PRINT_F_ZERO 0x0040
+#define PRINT_F_SPACE 0x0080
+#define PRINT_F_UP 0x0100
 
 static void fmtstr(char *, size_t *, size_t, const char *, int, int, int);
 static void fmtflt(char *, size_t *, size_t, JNUMBER, int, int, int, int *);
@@ -42,18 +42,17 @@ static int convert(uintmax_t, char *, size_t, int, int);
 static uintmax_t cast(JNUMBER);
 static uintmax_t myround(JNUMBER);
 static JNUMBER mypow10(int);
-#define OUTCHAR(str, len, size, ch) \
-do { \
-	if (len + 1 < size) \
-		str[len] = ch; \
-	(len)++; \
-} while (0)
+#define OUTCHAR(str, len, size, ch)        \
+    do {                                   \
+        if (len + 1 < size) str[len] = ch; \
+        (len)++;                           \
+    } while (0)
 
 // Convert a JNUMBER into a null-terminated text string.  Note that buf must
 // be pointing at a buffer of JNTOA_MAX length, which is defined so that it
 // includes enough space for the null terminator, so there's no need to
 // have a buffer of JNTOA_MAX+1.
-char * JNtoA(JNUMBER f, char * buf, int precision)
+char *JNtoA(JNUMBER f, char *buf, int precision)
 {
     int overflow = 0;
     size_t len = 0;
@@ -69,9 +68,8 @@ char * JNtoA(JNUMBER f, char * buf, int precision)
     return buf;
 }
 
-static void
-fmtflt(char *str, size_t *len, size_t size, JNUMBER fvalue, int width,
-       int precision, int flags, int *overflow)
+static void fmtflt(char *str, size_t *len, size_t size, JNUMBER fvalue,
+                   int width, int precision, int flags, int *overflow)
 {
     JNUMBER ufvalue;
     uintmax_t intpart;
@@ -80,7 +78,7 @@ fmtflt(char *str, size_t *len, size_t size, JNUMBER fvalue, int width,
     const char *infnan = NULL;
     char iconvert[JNTOA_MAX];
     char fconvert[JNTOA_MAX];
-    char econvert[4];	/* "e-12" (without nul-termination). */
+    char econvert[4]; /* "e-12" (without nul-termination). */
     char esign = 0;
     char sign = 0;
     int leadfraczeros = 0;
@@ -106,15 +104,18 @@ fmtflt(char *str, size_t *len, size_t size, JNUMBER fvalue, int width,
 
     if (fvalue < 0.0) {
         sign = '-';
-    } else if (flags & PRINT_F_PLUS) {	/* Do a sign. */
+    }
+    else if (flags & PRINT_F_PLUS) { /* Do a sign. */
         sign = '+';
-    } else if (flags & PRINT_F_SPACE) {
+    }
+    else if (flags & PRINT_F_SPACE) {
         sign = ' ';
     }
 
     if (isnan(fvalue)) {
         infnan = (flags & PRINT_F_UP) ? "NAN" : "nan";
-    } else if (isinf(fvalue)) {
+    }
+    else if (isinf(fvalue)) {
         infnan = (flags & PRINT_F_UP) ? "INF" : "inf";
     }
 
@@ -166,25 +167,25 @@ again:
      * minus one) past the decimal point due to our conversion method.
      */
     switch (sizeof(uintmax_t)) {
-    case 16:
-        if (precision > 38) {
-            precision = 38;
-        }
-        break;
-    case 8:
-        if (precision > 19) {
-            precision = 19;
-        }
-        break;
-    default:
-        if (precision > 9) {
-            precision = 9;
-        }
-        break;
+        case 16:
+            if (precision > 38) {
+                precision = 38;
+            }
+            break;
+        case 8:
+            if (precision > 19) {
+                precision = 19;
+            }
+            break;
+        default:
+            if (precision > 9) {
+                precision = 9;
+            }
+            break;
     }
 
     ufvalue = (fvalue >= 0.0) ? fvalue : -fvalue;
-    if (estyle) {	/* We want exactly one integer digit. */
+    if (estyle) { /* We want exactly one integer digit. */
         ufvalue /= mypow10(exponent);
     }
 
@@ -241,8 +242,8 @@ again:
      *
      * Note that we had decremented the precision by one.
      */
-    if (flags & PRINT_F_TYPE_G && estyle &&
-            precision + 1 > exponent && exponent >= -4) {
+    if (flags & PRINT_F_TYPE_G && estyle && precision + 1 > exponent &&
+        exponent >= -4) {
         precision -= exponent;
         estyle = 0;
         goto again;
@@ -252,7 +253,8 @@ again:
         if (exponent < 0) {
             exponent = -exponent;
             esign = '-';
-        } else {
+        }
+        else {
             esign = '+';
         }
 
@@ -277,18 +279,18 @@ again:
 
     /* Convert the integer part and the fractional part. */
     ipos = convert(intpart, iconvert, sizeof(iconvert), 10, 0);
-    if (fracpart != 0) {	/* convert() would return 1 if fracpart == 0. */
+    if (fracpart != 0) { /* convert() would return 1 if fracpart == 0. */
         fpos = convert(fracpart, fconvert, sizeof(fconvert), 10, 0);
     }
 
     leadfraczeros = precision - fpos;
 
     if (omitzeros) {
-        if (fpos > 0)	/* Omit trailing fractional part zeros. */
+        if (fpos > 0) /* Omit trailing fractional part zeros. */
             while (omitcount < fpos && fconvert[omitcount] == '0') {
                 omitcount++;
             }
-        else {	/* The fractional part is zero, omit it completely. */
+        else { /* The fractional part is zero, omit it completely. */
             omitcount = precision;
             leadfraczeros = 0;
         }
@@ -302,17 +304,17 @@ again:
     if (precision > 0 || flags & PRINT_F_NUM) {
         emitpoint = 1;
     }
-    if (separators) {	/* Get the number of group separators we'll print. */
+    if (separators) { /* Get the number of group separators we'll print. */
         separators = getnumsep(ipos);
     }
 
-    padlen = width                  /* Minimum field width. */
-             - ipos                      /* Number of integer digits. */
-             - epos                      /* Number of exponent characters. */
-             - precision                 /* Number of fractional digits. */
-             - separators                /* Number of group separators. */
-             - (emitpoint ? 1 : 0)       /* Will we print a decimal point? */
-             - ((sign != 0) ? 1 : 0);    /* Will we print a sign character? */
+    padlen = width                    /* Minimum field width. */
+             - ipos                   /* Number of integer digits. */
+             - epos                   /* Number of exponent characters. */
+             - precision              /* Number of fractional digits. */
+             - separators             /* Number of group separators. */
+             - (emitpoint ? 1 : 0)    /* Will we print a decimal point? */
+             - ((sign != 0) ? 1 : 0); /* Will we print a sign character? */
 
     if (padlen < 0) {
         padlen = 0;
@@ -322,77 +324,78 @@ again:
      * C99 says: "If the `0' and `-' flags both appear, the `0' flag is
      * ignored." (7.19.6.1, 6)
      */
-    if (flags & PRINT_F_MINUS) {	/* Left justifty. */
+    if (flags & PRINT_F_MINUS) { /* Left justifty. */
         padlen = -padlen;
-    } else if (flags & PRINT_F_ZERO && padlen > 0) {
-        if (sign != 0) {	/* Sign. */
+    }
+    else if (flags & PRINT_F_ZERO && padlen > 0) {
+        if (sign != 0) { /* Sign. */
             OUTCHAR(str, *len, size, sign);
             sign = 0;
         }
-        while (padlen > 0) {	/* Leading zeros. */
+        while (padlen > 0) { /* Leading zeros. */
             OUTCHAR(str, *len, size, '0');
             padlen--;
         }
     }
-    while (padlen > 0) {	/* Leading spaces. */
+    while (padlen > 0) { /* Leading spaces. */
         OUTCHAR(str, *len, size, ' ');
         padlen--;
     }
-    if (sign != 0) {	/* Sign. */
+    if (sign != 0) { /* Sign. */
         OUTCHAR(str, *len, size, sign);
     }
-    while (ipos > 0) {	/* Integer part. */
+    while (ipos > 0) { /* Integer part. */
         ipos--;
         OUTCHAR(str, *len, size, iconvert[ipos]);
         if (separators > 0 && ipos > 0 && ipos % 3 == 0) {
             printsep(str, len, size);
         }
     }
-    if (emitpoint) {	/* Decimal point. */
+    if (emitpoint) { /* Decimal point. */
         OUTCHAR(str, *len, size, '.');
     }
-    while (leadfraczeros > 0) {	/* Leading fractional part zeros. */
+    while (leadfraczeros > 0) { /* Leading fractional part zeros. */
         OUTCHAR(str, *len, size, '0');
         leadfraczeros--;
     }
-    while (fpos > omitcount) {	/* The remaining fractional part. */
+    while (fpos > omitcount) { /* The remaining fractional part. */
         fpos--;
         OUTCHAR(str, *len, size, fconvert[fpos]);
     }
-    while (epos > 0) {	/* Exponent. */
+    while (epos > 0) { /* Exponent. */
         epos--;
         OUTCHAR(str, *len, size, econvert[epos]);
     }
-    while (padlen < 0) {	/* Trailing spaces. */
+    while (padlen < 0) { /* Trailing spaces. */
         OUTCHAR(str, *len, size, ' ');
         padlen++;
     }
 }
 
-static void fmtstr(char *str, size_t *len, size_t size, const char *value, int width,
-                   int precision, int flags)
+static void fmtstr(char *str, size_t *len, size_t size, const char *value,
+                   int width, int precision, int flags)
 {
-    int padlen, strln;	/* Amount to pad. */
+    int padlen, strln; /* Amount to pad. */
     int noprecision = (precision == -1);
 
-    if (value == NULL) {	/* We're forgiving. */
+    if (value == NULL) { /* We're forgiving. */
         value = "(null)";
     }
 
     /* If a precision was specified, don't read the string past it. */
-    for (strln = 0; value[strln] != '\0' &&
-            (noprecision || strln < precision); strln++) {
+    for (strln = 0; value[strln] != '\0' && (noprecision || strln < precision);
+         strln++) {
         continue;
     }
 
     if ((padlen = width - strln) < 0) {
         padlen = 0;
     }
-    if (flags & PRINT_F_MINUS) {	/* Left justify. */
+    if (flags & PRINT_F_MINUS) { /* Left justify. */
         padlen = -padlen;
     }
 
-    while (padlen > 0) {	/* Leading spaces. */
+    while (padlen > 0) { /* Leading spaces. */
         OUTCHAR(str, *len, size, ' ');
         padlen--;
     }
@@ -400,7 +403,7 @@ static void fmtstr(char *str, size_t *len, size_t size, const char *value, int w
         OUTCHAR(str, *len, size, *value);
         value++;
     }
-    while (padlen < 0) {	/* Trailing spaces. */
+    while (padlen < 0) { /* Trailing spaces. */
         OUTCHAR(str, *len, size, ' ');
         padlen++;
     }

--- a/n_hooks.c
+++ b/n_hooks.c
@@ -17,9 +17,10 @@
  *
  */
 
-#include <stdio.h>
 #include <stdarg.h>
+#include <stdio.h>
 #include <stdlib.h>
+
 #include "n_lib.h"
 
 //**************************************************************************/
@@ -27,16 +28,16 @@
   @brief  Show malloc operations for debugging in very low mem environments.
 */
 /**************************************************************************/
-#define NOTE_SHOW_MALLOC  false
+#define NOTE_SHOW_MALLOC false
 #if NOTE_SHOW_MALLOC
 #include <string.h>
 void *malloc_show(size_t len);
 #endif
 
 // Which I/O port to use
-#define interfaceNone       0
-#define interfaceSerial     1
-#define interfaceI2C        2
+#define interfaceNone 0
+#define interfaceSerial 1
+#define interfaceI2C 2
 
 // Externalized Hooks
 //**************************************************************************/
@@ -161,8 +162,8 @@ i2cTransmitFn hookI2CTransmit = NULL;
 i2cReceiveFn hookI2CReceive = NULL;
 
 // Internal hooks
-typedef bool (*nNoteResetFn) (void);
-typedef const char * (*nTransactionFn) (char *, char **);
+typedef bool (*nNoteResetFn)(void);
+typedef const char *(*nTransactionFn)(char *, char **);
 static nNoteResetFn notecardReset = NULL;
 static nTransactionFn notecardTransaction = NULL;
 
@@ -177,7 +178,8 @@ static nTransactionFn notecardTransaction = NULL;
   @param   millisfn  The default 'millis' function to use.
 */
 /**************************************************************************/
-void NoteSetFnDefault(mallocFn mallocfn, freeFn freefn, delayMsFn delayfn, getMsFn millisfn)
+void NoteSetFnDefault(mallocFn mallocfn, freeFn freefn, delayMsFn delayfn,
+                      getMsFn millisfn)
 {
     if (hookMalloc == NULL) {
         hookMalloc = mallocfn;
@@ -204,7 +206,8 @@ void NoteSetFnDefault(mallocFn mallocfn, freeFn freefn, delayMsFn delayfn, getMs
   @param   millisfn  The platform-specific 'millis' function to use.
 */
 /**************************************************************************/
-void NoteSetFn(mallocFn mallocfn, freeFn freefn, delayMsFn delayfn, getMsFn millisfn)
+void NoteSetFn(mallocFn mallocfn, freeFn freefn, delayMsFn delayfn,
+               getMsFn millisfn)
 {
     hookMalloc = mallocfn;
     hookFree = freefn;
@@ -218,10 +221,7 @@ void NoteSetFn(mallocFn mallocfn, freeFn freefn, delayMsFn delayfn, getMsFn mill
   @param   fn  A function pointer to call for debug output.
 */
 /**************************************************************************/
-void NoteSetFnDebugOutput(debugOutputFn fn)
-{
-    hookDebugOutput = fn;
-}
+void NoteSetFnDebugOutput(debugOutputFn fn) { hookDebugOutput = fn; }
 
 //**************************************************************************/
 /*!
@@ -230,10 +230,7 @@ void NoteSetFnDebugOutput(debugOutputFn fn)
   provided.
 */
 /**************************************************************************/
-bool NoteIsDebugOutputActive()
-{
-    return hookDebugOutput != NULL;
-}
+bool NoteIsDebugOutputActive() { return hookDebugOutput != NULL; }
 
 //**************************************************************************/
 /*!
@@ -246,7 +243,8 @@ bool NoteIsDebugOutputActive()
   to use.
 */
 /**************************************************************************/
-void NoteSetFnMutex(mutexFn lockI2Cfn, mutexFn unlockI2Cfn, mutexFn lockNotefn, mutexFn unlockNotefn)
+void NoteSetFnMutex(mutexFn lockI2Cfn, mutexFn unlockI2Cfn, mutexFn lockNotefn,
+                    mutexFn unlockNotefn)
 {
     hookLockI2C = lockI2Cfn;
     hookUnlockI2C = unlockI2Cfn;
@@ -264,7 +262,8 @@ void NoteSetFnMutex(mutexFn lockI2Cfn, mutexFn unlockI2Cfn, mutexFn lockNotefn, 
   @param   receivefn  The platform-specific Serial receive function to use.
 */
 /**************************************************************************/
-void NoteSetFnSerial(serialResetFn resetfn, serialTransmitFn transmitfn, serialAvailableFn availfn, serialReceiveFn receivefn)
+void NoteSetFnSerial(serialResetFn resetfn, serialTransmitFn transmitfn,
+                     serialAvailableFn availfn, serialReceiveFn receivefn)
 {
     hookActiveInterface = interfaceSerial;
 
@@ -289,7 +288,8 @@ void NoteSetFnSerial(serialResetFn resetfn, serialTransmitFn transmitfn, serialA
   @param   receivefn  The platform-specific I2C receive function to use.
 */
 /**************************************************************************/
-void NoteSetFnI2C(uint32_t i2caddress, uint32_t i2cmax, i2cResetFn resetfn, i2cTransmitFn transmitfn, i2cReceiveFn receivefn)
+void NoteSetFnI2C(uint32_t i2caddress, uint32_t i2cmax, i2cResetFn resetfn,
+                  i2cTransmitFn transmitfn, i2cReceiveFn receivefn)
 {
     i2cAddress = i2caddress;
     i2cMax = i2cmax;
@@ -311,12 +311,10 @@ void NoteSetFnI2C(uint32_t i2caddress, uint32_t i2cmax, i2cResetFn resetfn, i2cT
 /**************************************************************************/
 void NoteSetFnDisabled()
 {
-
     hookActiveInterface = interfaceNone;
 
     notecardReset = NULL;
     notecardTransaction = NULL;
-
 }
 
 // Runtime hook wrappers
@@ -404,12 +402,13 @@ void htoa32(uint32_t n, char *p);
 void htoa32(uint32_t n, char *p)
 {
     int i;
-    for (i=0; i<8; i++) {
+    for (i = 0; i < 8; i++) {
         uint32_t nibble = (n >> 28) & 0xff;
         n = n << 4;
         if (nibble >= 10) {
-            *p++ = 'A' + (nibble-10);
-        } else {
+            *p++ = 'A' + (nibble - 10);
+        }
+        else {
             *p++ = '0' + nibble;
         }
     }
@@ -424,7 +423,8 @@ void *malloc_show(size_t len)
     void *p = hookMalloc(len);
     if (p == NULL) {
         hookDebugOutput("FAIL");
-    } else {
+    }
+    else {
         htoa32((uint32_t)p, str);
         hookDebugOutput(str);
     }
@@ -526,10 +526,10 @@ void NoteUnlockNote()
 const char *NoteActiveInterface()
 {
     switch (hookActiveInterface) {
-    case interfaceSerial:
-        return "serial";
-    case interfaceI2C:
-        return "i2c";
+        case interfaceSerial:
+            return "serial";
+        case interfaceI2C:
+            return "i2c";
     }
     return "unknown";
 }
@@ -617,7 +617,8 @@ bool NoteI2CReset(uint16_t DevAddress)
   if the bus is not active.
 */
 /**************************************************************************/
-const char *NoteI2CTransmit(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size)
+const char *NoteI2CTransmit(uint16_t DevAddress, uint8_t *pBuffer,
+                            uint16_t Size)
 {
     if (hookActiveInterface == interfaceI2C && hookI2CTransmit != NULL) {
         return hookI2CTransmit(DevAddress, pBuffer, Size);
@@ -636,7 +637,8 @@ const char *NoteI2CTransmit(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size
   if the bus is not active.
 */
 /**************************************************************************/
-const char *NoteI2CReceive(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size, uint32_t *available)
+const char *NoteI2CReceive(uint16_t DevAddress, uint8_t *pBuffer, uint16_t Size,
+                           uint32_t *available)
 {
     if (hookActiveInterface == interfaceI2C && hookI2CReceive != NULL) {
         return hookI2CReceive(DevAddress, pBuffer, Size, available);
@@ -664,10 +666,7 @@ uint32_t NoteI2CAddress()
   @param   i2caddress the I2C address to use for the Notecard.
 */
 /**************************************************************************/
-void NoteSetI2CAddress(uint32_t i2caddress)
-{
-    i2cAddress = i2caddress;
-}
+void NoteSetI2CAddress(uint32_t i2caddress) { i2cAddress = i2caddress; }
 
 //**************************************************************************/
 /*!
@@ -678,8 +677,9 @@ void NoteSetI2CAddress(uint32_t i2caddress)
 /**************************************************************************/
 uint32_t NoteI2CMax()
 {
-    // Many Arduino libraries (such as ESP32) have a limit less than 32, so if the max isn't specified
-    // we must assume the worst and segment the I2C messages into very tiny chunks.
+    // Many Arduino libraries (such as ESP32) have a limit less than 32, so if
+    // the max isn't specified we must assume the worst and segment the I2C
+    // messages into very tiny chunks.
     if (i2cMax == 0) {
         return NOTE_I2C_MAX_DEFAULT;
     }
@@ -690,12 +690,12 @@ uint32_t NoteI2CMax()
     return i2cMax;
 }
 
-
 //**************************************************************************/
 /*!
   @brief  Perform a hard reset on the Notecard using the platform-specific
   hook.
-  @returns A boolean indicating whether the Notecard has been reset successfully.
+  @returns A boolean indicating whether the Notecard has been reset
+  successfully.
 */
 /**************************************************************************/
 bool NoteHardReset()
@@ -705,7 +705,6 @@ bool NoteHardReset()
     }
     return notecardReset();
 }
-
 
 //**************************************************************************/
 /*!

--- a/n_lib.h
+++ b/n_lib.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <string.h>
+
 #include "note.h"
 
 // C-callable functions
@@ -26,7 +27,7 @@ extern "C" {
     @brief  How long to wait for the card for any given transaction.
 */
 /**************************************************************************/
-#define NOTECARD_TRANSACTION_TIMEOUT_SEC     10
+#define NOTECARD_TRANSACTION_TIMEOUT_SEC 10
 
 // The notecard is a real-time device that has a fixed size interrupt buffer.
 // We can push data at it far, far faster than it can process it, therefore we
@@ -46,7 +47,8 @@ extern "C" {
 #define CARD_REQUEST_I2C_SEGMENT_DELAY_MS 250
 /**************************************************************************/
 /*!
-    @brief  The delay, in miliseconds, between each request chunk when using I2C.
+    @brief  The delay, in miliseconds, between each request chunk when using
+   I2C.
 */
 /**************************************************************************/
 #define CARD_REQUEST_I2C_CHUNK_DELAY_MS 20
@@ -89,8 +91,10 @@ void NoteSerialTransmit(uint8_t *, size_t, bool);
 bool NoteSerialAvailable(void);
 char NoteSerialReceive(void);
 bool NoteI2CReset(uint16_t DevAddress);
-const char *NoteI2CTransmit(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size);
-const char *NoteI2CReceive(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size, uint32_t *avail);
+const char *NoteI2CTransmit(uint16_t DevAddress, uint8_t *pBuffer,
+                            uint16_t Size);
+const char *NoteI2CReceive(uint16_t DevAddress, uint8_t *pBuffer, uint16_t Size,
+                           uint32_t *avail);
 bool NoteHardReset(void);
 const char *NoteJSONTransaction(char *json, char **jsonResponse);
 bool NoteIsDebugOutputActive(void);
@@ -134,7 +138,6 @@ extern const char *c_iobad;
 
 extern const char *c_ioerr;
 #define c_ioerr_len 4
-
 
 // Readability wrappers.  Anything starting with _ is simply calling the wrapper
 // function.

--- a/n_md5.c
+++ b/n_md5.c
@@ -26,12 +26,13 @@
    public domain.  */
 
 #include <string.h>
+
 #include "n_lib.h"
 
 // Forwards
 void htoa8(unsigned char n, unsigned char *p);
-static void putu32 (unsigned long data, unsigned char *addr);
-static unsigned long getu32 (const unsigned char *addr);
+static void putu32(unsigned long data, unsigned char *addr);
+static unsigned long getu32(const unsigned char *addr);
 
 /* Little-endian byte-swapping routines.  Note that these do not
    depend on the size of datatypes such as unsigned long, nor do they require
@@ -39,13 +40,13 @@ static unsigned long getu32 (const unsigned char *addr);
    is possible they should be macros for speed, but I would be
    surprised if they were a performance bottleneck for MD5.  */
 
-static unsigned long getu32 (const unsigned char *addr)
+static unsigned long getu32(const unsigned char *addr)
 {
-    return (((((unsigned long)addr[3] << 8) | addr[2]) << 8)
-            | addr[1]) << 8 | addr[0];
+    return (((((unsigned long)addr[3] << 8) | addr[2]) << 8) | addr[1]) << 8 |
+           addr[0];
 }
 
-static void putu32 (unsigned long data, unsigned char *addr)
+static void putu32(unsigned long data, unsigned char *addr)
 {
     addr[0] = (unsigned char)data;
     addr[1] = (unsigned char)(data >> 8);
@@ -58,14 +59,16 @@ void htoa8(unsigned char n, unsigned char *p)
 {
     unsigned char nibble = (n >> 4) & 0xf;
     if (nibble >= 10) {
-        *p++ = 'a' + (nibble-10);
-    } else {
+        *p++ = 'a' + (nibble - 10);
+    }
+    else {
         *p++ = '0' + nibble;
     }
     nibble = n & 0xf;
     if (nibble >= 10) {
-        *p++ = 'a' + (nibble-10);
-    } else {
+        *p++ = 'a' + (nibble - 10);
+    }
+    else {
         *p++ = '0' + nibble;
     }
     *p = '\0';
@@ -92,7 +95,8 @@ void NoteMD5Init(NoteMD5Context *ctx)
  * Update context to reflect the concatenation of another buffer full
  * of bytes.
  */
-void NoteMD5Update(NoteMD5Context *ctx, unsigned char const *buf, unsigned long len)
+void NoteMD5Update(NoteMD5Context *ctx, unsigned char const *buf,
+                   unsigned long len)
 {
     unsigned long t;
 
@@ -100,18 +104,18 @@ void NoteMD5Update(NoteMD5Context *ctx, unsigned char const *buf, unsigned long 
 
     t = ctx->bits[0];
     if ((ctx->bits[0] = (t + ((unsigned long)len << 3)) & 0xffffffff) < t) {
-        ctx->bits[1]++;    /* Carry from low to high */
+        ctx->bits[1]++; /* Carry from low to high */
     }
     ctx->bits[1] += len >> 29;
 
-    t = (t >> 3) & 0x3f;  /* Bytes already in shsInfo->data */
+    t = (t >> 3) & 0x3f; /* Bytes already in shsInfo->data */
 
     /* Handle any leading odd-sized chunks */
 
-    if ( t ) {
+    if (t) {
         unsigned char *p = ctx->in + t;
 
-        t = 64-t;
+        t = 64 - t;
         if (len < t) {
             memcpy(p, buf, len);
             return;
@@ -164,9 +168,10 @@ void NoteMD5Final(unsigned char *digest, NoteMD5Context *ctx)
 
         /* Now fill the next block with 56 bytes */
         memset(ctx->in, 0, 56);
-    } else {
+    }
+    else {
         /* Pad block to 56 bytes */
-        memset(p, 0, count-8);
+        memset(p, 0, count - 8);
     }
 
     /* Append length in bits and transform */
@@ -190,8 +195,9 @@ void NoteMD5Final(unsigned char *digest, NoteMD5Context *ctx)
 #define F4(x, y, z) (y ^ (x | ~z))
 
 /* This is the central step in the MD5 algorithm. */
-#define MD5STEP(f, w, x, y, z, data, s) \
-  ( w += f(x, y, z) + data, w &= 0xffffffff, w = w<<s | w>>(32-s), w += x )
+#define MD5STEP(f, w, x, y, z, data, s)                                   \
+    (w += f(x, y, z) + data, w &= 0xffffffff, w = w << s | w >> (32 - s), \
+     w += x)
 
 /*
  * The core of the MD5 algorithm, this alters an existing MD5 hash to
@@ -205,7 +211,7 @@ void NoteMD5Transform(unsigned long buf[4], const unsigned char inraw[64])
     int i;
 
     for (i = 0; i < 16; ++i) {
-        in[i] = getu32 (inraw + 4 * i);
+        in[i] = getu32(inraw + 4 * i);
     }
 
     a = buf[0];
@@ -213,83 +219,82 @@ void NoteMD5Transform(unsigned long buf[4], const unsigned char inraw[64])
     c = buf[2];
     d = buf[3];
 
-    MD5STEP(F1, a, b, c, d, in[ 0]+0xd76aa478,  7);
-    MD5STEP(F1, d, a, b, c, in[ 1]+0xe8c7b756, 12);
-    MD5STEP(F1, c, d, a, b, in[ 2]+0x242070db, 17);
-    MD5STEP(F1, b, c, d, a, in[ 3]+0xc1bdceee, 22);
-    MD5STEP(F1, a, b, c, d, in[ 4]+0xf57c0faf,  7);
-    MD5STEP(F1, d, a, b, c, in[ 5]+0x4787c62a, 12);
-    MD5STEP(F1, c, d, a, b, in[ 6]+0xa8304613, 17);
-    MD5STEP(F1, b, c, d, a, in[ 7]+0xfd469501, 22);
-    MD5STEP(F1, a, b, c, d, in[ 8]+0x698098d8,  7);
-    MD5STEP(F1, d, a, b, c, in[ 9]+0x8b44f7af, 12);
-    MD5STEP(F1, c, d, a, b, in[10]+0xffff5bb1, 17);
-    MD5STEP(F1, b, c, d, a, in[11]+0x895cd7be, 22);
-    MD5STEP(F1, a, b, c, d, in[12]+0x6b901122,  7);
-    MD5STEP(F1, d, a, b, c, in[13]+0xfd987193, 12);
-    MD5STEP(F1, c, d, a, b, in[14]+0xa679438e, 17);
-    MD5STEP(F1, b, c, d, a, in[15]+0x49b40821, 22);
+    MD5STEP(F1, a, b, c, d, in[0] + 0xd76aa478, 7);
+    MD5STEP(F1, d, a, b, c, in[1] + 0xe8c7b756, 12);
+    MD5STEP(F1, c, d, a, b, in[2] + 0x242070db, 17);
+    MD5STEP(F1, b, c, d, a, in[3] + 0xc1bdceee, 22);
+    MD5STEP(F1, a, b, c, d, in[4] + 0xf57c0faf, 7);
+    MD5STEP(F1, d, a, b, c, in[5] + 0x4787c62a, 12);
+    MD5STEP(F1, c, d, a, b, in[6] + 0xa8304613, 17);
+    MD5STEP(F1, b, c, d, a, in[7] + 0xfd469501, 22);
+    MD5STEP(F1, a, b, c, d, in[8] + 0x698098d8, 7);
+    MD5STEP(F1, d, a, b, c, in[9] + 0x8b44f7af, 12);
+    MD5STEP(F1, c, d, a, b, in[10] + 0xffff5bb1, 17);
+    MD5STEP(F1, b, c, d, a, in[11] + 0x895cd7be, 22);
+    MD5STEP(F1, a, b, c, d, in[12] + 0x6b901122, 7);
+    MD5STEP(F1, d, a, b, c, in[13] + 0xfd987193, 12);
+    MD5STEP(F1, c, d, a, b, in[14] + 0xa679438e, 17);
+    MD5STEP(F1, b, c, d, a, in[15] + 0x49b40821, 22);
 
-    MD5STEP(F2, a, b, c, d, in[ 1]+0xf61e2562,  5);
-    MD5STEP(F2, d, a, b, c, in[ 6]+0xc040b340,  9);
-    MD5STEP(F2, c, d, a, b, in[11]+0x265e5a51, 14);
-    MD5STEP(F2, b, c, d, a, in[ 0]+0xe9b6c7aa, 20);
-    MD5STEP(F2, a, b, c, d, in[ 5]+0xd62f105d,  5);
-    MD5STEP(F2, d, a, b, c, in[10]+0x02441453,  9);
-    MD5STEP(F2, c, d, a, b, in[15]+0xd8a1e681, 14);
-    MD5STEP(F2, b, c, d, a, in[ 4]+0xe7d3fbc8, 20);
-    MD5STEP(F2, a, b, c, d, in[ 9]+0x21e1cde6,  5);
-    MD5STEP(F2, d, a, b, c, in[14]+0xc33707d6,  9);
-    MD5STEP(F2, c, d, a, b, in[ 3]+0xf4d50d87, 14);
-    MD5STEP(F2, b, c, d, a, in[ 8]+0x455a14ed, 20);
-    MD5STEP(F2, a, b, c, d, in[13]+0xa9e3e905,  5);
-    MD5STEP(F2, d, a, b, c, in[ 2]+0xfcefa3f8,  9);
-    MD5STEP(F2, c, d, a, b, in[ 7]+0x676f02d9, 14);
-    MD5STEP(F2, b, c, d, a, in[12]+0x8d2a4c8a, 20);
+    MD5STEP(F2, a, b, c, d, in[1] + 0xf61e2562, 5);
+    MD5STEP(F2, d, a, b, c, in[6] + 0xc040b340, 9);
+    MD5STEP(F2, c, d, a, b, in[11] + 0x265e5a51, 14);
+    MD5STEP(F2, b, c, d, a, in[0] + 0xe9b6c7aa, 20);
+    MD5STEP(F2, a, b, c, d, in[5] + 0xd62f105d, 5);
+    MD5STEP(F2, d, a, b, c, in[10] + 0x02441453, 9);
+    MD5STEP(F2, c, d, a, b, in[15] + 0xd8a1e681, 14);
+    MD5STEP(F2, b, c, d, a, in[4] + 0xe7d3fbc8, 20);
+    MD5STEP(F2, a, b, c, d, in[9] + 0x21e1cde6, 5);
+    MD5STEP(F2, d, a, b, c, in[14] + 0xc33707d6, 9);
+    MD5STEP(F2, c, d, a, b, in[3] + 0xf4d50d87, 14);
+    MD5STEP(F2, b, c, d, a, in[8] + 0x455a14ed, 20);
+    MD5STEP(F2, a, b, c, d, in[13] + 0xa9e3e905, 5);
+    MD5STEP(F2, d, a, b, c, in[2] + 0xfcefa3f8, 9);
+    MD5STEP(F2, c, d, a, b, in[7] + 0x676f02d9, 14);
+    MD5STEP(F2, b, c, d, a, in[12] + 0x8d2a4c8a, 20);
 
-    MD5STEP(F3, a, b, c, d, in[ 5]+0xfffa3942,  4);
-    MD5STEP(F3, d, a, b, c, in[ 8]+0x8771f681, 11);
-    MD5STEP(F3, c, d, a, b, in[11]+0x6d9d6122, 16);
-    MD5STEP(F3, b, c, d, a, in[14]+0xfde5380c, 23);
-    MD5STEP(F3, a, b, c, d, in[ 1]+0xa4beea44,  4);
-    MD5STEP(F3, d, a, b, c, in[ 4]+0x4bdecfa9, 11);
-    MD5STEP(F3, c, d, a, b, in[ 7]+0xf6bb4b60, 16);
-    MD5STEP(F3, b, c, d, a, in[10]+0xbebfbc70, 23);
-    MD5STEP(F3, a, b, c, d, in[13]+0x289b7ec6,  4);
-    MD5STEP(F3, d, a, b, c, in[ 0]+0xeaa127fa, 11);
-    MD5STEP(F3, c, d, a, b, in[ 3]+0xd4ef3085, 16);
-    MD5STEP(F3, b, c, d, a, in[ 6]+0x04881d05, 23);
-    MD5STEP(F3, a, b, c, d, in[ 9]+0xd9d4d039,  4);
-    MD5STEP(F3, d, a, b, c, in[12]+0xe6db99e5, 11);
-    MD5STEP(F3, c, d, a, b, in[15]+0x1fa27cf8, 16);
-    MD5STEP(F3, b, c, d, a, in[ 2]+0xc4ac5665, 23);
+    MD5STEP(F3, a, b, c, d, in[5] + 0xfffa3942, 4);
+    MD5STEP(F3, d, a, b, c, in[8] + 0x8771f681, 11);
+    MD5STEP(F3, c, d, a, b, in[11] + 0x6d9d6122, 16);
+    MD5STEP(F3, b, c, d, a, in[14] + 0xfde5380c, 23);
+    MD5STEP(F3, a, b, c, d, in[1] + 0xa4beea44, 4);
+    MD5STEP(F3, d, a, b, c, in[4] + 0x4bdecfa9, 11);
+    MD5STEP(F3, c, d, a, b, in[7] + 0xf6bb4b60, 16);
+    MD5STEP(F3, b, c, d, a, in[10] + 0xbebfbc70, 23);
+    MD5STEP(F3, a, b, c, d, in[13] + 0x289b7ec6, 4);
+    MD5STEP(F3, d, a, b, c, in[0] + 0xeaa127fa, 11);
+    MD5STEP(F3, c, d, a, b, in[3] + 0xd4ef3085, 16);
+    MD5STEP(F3, b, c, d, a, in[6] + 0x04881d05, 23);
+    MD5STEP(F3, a, b, c, d, in[9] + 0xd9d4d039, 4);
+    MD5STEP(F3, d, a, b, c, in[12] + 0xe6db99e5, 11);
+    MD5STEP(F3, c, d, a, b, in[15] + 0x1fa27cf8, 16);
+    MD5STEP(F3, b, c, d, a, in[2] + 0xc4ac5665, 23);
 
-    MD5STEP(F4, a, b, c, d, in[ 0]+0xf4292244,  6);
-    MD5STEP(F4, d, a, b, c, in[ 7]+0x432aff97, 10);
-    MD5STEP(F4, c, d, a, b, in[14]+0xab9423a7, 15);
-    MD5STEP(F4, b, c, d, a, in[ 5]+0xfc93a039, 21);
-    MD5STEP(F4, a, b, c, d, in[12]+0x655b59c3,  6);
-    MD5STEP(F4, d, a, b, c, in[ 3]+0x8f0ccc92, 10);
-    MD5STEP(F4, c, d, a, b, in[10]+0xffeff47d, 15);
-    MD5STEP(F4, b, c, d, a, in[ 1]+0x85845dd1, 21);
-    MD5STEP(F4, a, b, c, d, in[ 8]+0x6fa87e4f,  6);
-    MD5STEP(F4, d, a, b, c, in[15]+0xfe2ce6e0, 10);
-    MD5STEP(F4, c, d, a, b, in[ 6]+0xa3014314, 15);
-    MD5STEP(F4, b, c, d, a, in[13]+0x4e0811a1, 21);
-    MD5STEP(F4, a, b, c, d, in[ 4]+0xf7537e82,  6);
-    MD5STEP(F4, d, a, b, c, in[11]+0xbd3af235, 10);
-    MD5STEP(F4, c, d, a, b, in[ 2]+0x2ad7d2bb, 15);
-    MD5STEP(F4, b, c, d, a, in[ 9]+0xeb86d391, 21);
+    MD5STEP(F4, a, b, c, d, in[0] + 0xf4292244, 6);
+    MD5STEP(F4, d, a, b, c, in[7] + 0x432aff97, 10);
+    MD5STEP(F4, c, d, a, b, in[14] + 0xab9423a7, 15);
+    MD5STEP(F4, b, c, d, a, in[5] + 0xfc93a039, 21);
+    MD5STEP(F4, a, b, c, d, in[12] + 0x655b59c3, 6);
+    MD5STEP(F4, d, a, b, c, in[3] + 0x8f0ccc92, 10);
+    MD5STEP(F4, c, d, a, b, in[10] + 0xffeff47d, 15);
+    MD5STEP(F4, b, c, d, a, in[1] + 0x85845dd1, 21);
+    MD5STEP(F4, a, b, c, d, in[8] + 0x6fa87e4f, 6);
+    MD5STEP(F4, d, a, b, c, in[15] + 0xfe2ce6e0, 10);
+    MD5STEP(F4, c, d, a, b, in[6] + 0xa3014314, 15);
+    MD5STEP(F4, b, c, d, a, in[13] + 0x4e0811a1, 21);
+    MD5STEP(F4, a, b, c, d, in[4] + 0xf7537e82, 6);
+    MD5STEP(F4, d, a, b, c, in[11] + 0xbd3af235, 10);
+    MD5STEP(F4, c, d, a, b, in[2] + 0x2ad7d2bb, 15);
+    MD5STEP(F4, b, c, d, a, in[9] + 0xeb86d391, 21);
 
     buf[0] += a;
     buf[1] += b;
     buf[2] += c;
     buf[3] += d;
-
 }
 
 // Hash data and return its binary hash into an NOTE_MD5_HASH_SIZE buffer
-void NoteMD5Hash(unsigned char* data, unsigned long len, unsigned char *retHash)
+void NoteMD5Hash(unsigned char *data, unsigned long len, unsigned char *retHash)
 {
     NoteMD5Context context;
     NoteMD5Init(&context);
@@ -297,25 +302,28 @@ void NoteMD5Hash(unsigned char* data, unsigned long len, unsigned char *retHash)
     NoteMD5Final(retHash, &context);
 }
 
-// Hash data and return it as a string into a buffer that is at least (16*2)+1 in length
-void NoteMD5HashString(unsigned char *data, unsigned long len, char *strbuf, unsigned long buflen)
+// Hash data and return it as a string into a buffer that is at least (16*2)+1
+// in length
+void NoteMD5HashString(unsigned char *data, unsigned long len, char *strbuf,
+                       unsigned long buflen)
 {
     unsigned char hash[NOTE_MD5_HASH_SIZE];
     NoteMD5Hash(data, len, hash);
-    char hashstr[NOTE_MD5_HASH_SIZE*3] = {0};
-    for (int i=0; i<NOTE_MD5_HASH_SIZE; i++) {
-        htoa8(hash[i], (unsigned char *)&hashstr[i*2]);
+    char hashstr[NOTE_MD5_HASH_SIZE * 3] = {0};
+    for (int i = 0; i < NOTE_MD5_HASH_SIZE; i++) {
+        htoa8(hash[i], (unsigned char *)&hashstr[i * 2]);
     }
-    hashstr[NOTE_MD5_HASH_SIZE*2+1] = 0;
+    hashstr[NOTE_MD5_HASH_SIZE * 2 + 1] = 0;
     strlcpy(strbuf, hashstr, buflen);
 }
 
 // Convert a hash to string
-void NoteMD5HashToString(unsigned char *hash, char *strbuf, unsigned long buflen)
+void NoteMD5HashToString(unsigned char *hash, char *strbuf,
+                         unsigned long buflen)
 {
-    char hashstr[NOTE_MD5_HASH_SIZE*3] = {0};
-    for (int i=0; i<NOTE_MD5_HASH_SIZE; i++) {
-        htoa8(hash[i], (unsigned char *)&hashstr[i*2]);
+    char hashstr[NOTE_MD5_HASH_SIZE * 3] = {0};
+    for (int i = 0; i < NOTE_MD5_HASH_SIZE; i++) {
+        htoa8(hash[i], (unsigned char *)&hashstr[i * 2]);
     }
     strlcpy(strbuf, hashstr, buflen);
 }

--- a/n_printf.c
+++ b/n_printf.c
@@ -11,9 +11,10 @@
  *
  */
 
-#include <stdlib.h>
-#include <stdio.h>
 #include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "n_lib.h"
 
 // Externalized Hooks
@@ -50,7 +51,8 @@ void NoteDebugf(const char *format, ...)
   @brief  Write a formatted string to the debug output.
   @param   format  A format string for output.
   @param   ...  One or more values to interpolate into the format string.
-  @note.  Do NOT use this in a memory-constrained environment (vsnprintf is large)
+  @note.  Do NOT use this in a memory-constrained environment (vsnprintf is
+  large)
 */
 /**************************************************************************/
 #ifndef NOTE_LOMEM

--- a/n_request.c
+++ b/n_request.c
@@ -46,24 +46,19 @@ static J *errDoc(const char *errmsg)
     @brief  Suppress showing transaction details.
 */
 /**************************************************************************/
-void NoteSuspendTransactionDebug()
-{
-    suppressShowTransactions++;
-}
+void NoteSuspendTransactionDebug() { suppressShowTransactions++; }
 
 /**************************************************************************/
 /*!
     @brief  Resume showing transaction details.
 */
 /**************************************************************************/
-void NoteResumeTransactionDebug()
-{
-    suppressShowTransactions--;
-}
+void NoteResumeTransactionDebug() { suppressShowTransactions--; }
 
 /**************************************************************************/
 /*!
-    @brief  Create a new request object to populate before sending to the Notecard.
+    @brief  Create a new request object to populate before sending to the
+  Notecard.
     @param   request is The name of the request, for example `hub.set`.
   @returns a `J` cJSON object with the request name pre-populated.
 */
@@ -79,7 +74,8 @@ J *NoteNewRequest(const char *request)
 
 /**************************************************************************/
 /*!
-    @brief  Create a new command object to populate before sending to the Notecard.
+    @brief  Create a new command object to populate before sending to the
+  Notecard.
     @param   request is the name of the command, for example `hub.set`.
   @returns a `J` cJSON object with the request name pre-populated.
 */
@@ -106,7 +102,8 @@ J *NoteNewCommand(const char *request)
 /**************************************************************************/
 bool NoteRequest(J *req)
 {
-    // Exit if null request.  This allows safe execution of the form NoteRequest(NoteNewRequest("xxx"))
+    // Exit if null request.  This allows safe execution of the form
+    // NoteRequest(NoteNewRequest("xxx"))
     if (req == NULL) {
         return false;
     }
@@ -127,8 +124,8 @@ bool NoteRequest(J *req)
 /*!
     @brief  Send a request to the Notecard.
             Frees the request structure from memory after sending the request.
-            Retries the request for up to the specified timeoutSeconds if there is
-            no response, or if the response indicates an io error.
+            Retries the request for up to the specified timeoutSeconds if there
+  is no response, or if the response indicates an io error.
     @param   req
                The `J` cJSON request object.
              timeoutSeconds
@@ -141,7 +138,8 @@ bool NoteRequest(J *req)
 /**************************************************************************/
 bool NoteRequestWithRetry(J *req, uint32_t timeoutSeconds)
 {
-    // Exit if null request.  This allows safe execution of the form NoteRequest(NoteNewRequest("xxx"))
+    // Exit if null request.  This allows safe execution of the form
+    // NoteRequest(NoteNewRequest("xxx"))
     if (req == NULL) {
         return false;
     }
@@ -151,20 +149,19 @@ bool NoteRequestWithRetry(J *req, uint32_t timeoutSeconds)
     // Calculate expiry time in milliseconds
     uint32_t expiresMs = _GetMs() + (timeoutSeconds * 1000);
 
-    while(true) {
+    while (true) {
         // Execute the transaction
         rsp = NoteTransaction(req);
 
         // Loop if there is no response, or if there is an io error
-        if ( (rsp == NULL) || JContainsString(rsp, c_err, c_ioerr)) {
-
+        if ((rsp == NULL) || JContainsString(rsp, c_err, c_ioerr)) {
             // Free error response
             if (rsp != NULL) {
                 JDelete(rsp);
                 rsp = NULL;
             }
-        } else {
-
+        }
+        else {
             // Exit loop on non-null response without io error
             break;
         }
@@ -200,7 +197,8 @@ bool NoteRequestWithRetry(J *req, uint32_t timeoutSeconds)
 /**************************************************************************/
 J *NoteRequestResponse(J *req)
 {
-    // Exit if null request.  This allows safe execution of the form NoteRequestResponse(NoteNewRequest("xxx"))
+    // Exit if null request.  This allows safe execution of the form
+    // NoteRequestResponse(NoteNewRequest("xxx"))
     if (req == NULL) {
         return NULL;
     }
@@ -219,8 +217,8 @@ J *NoteRequestResponse(J *req)
 /*!
     @brief  Send a request to the Notecard and return the response.
             Frees the request structure from memory after sending the request.
-            Retries the request for up to the specified timeoutSeconds if there is
-            no response, or if the response indicates an io error.
+            Retries the request for up to the specified timeoutSeconds if there
+  is no response, or if the response indicates an io error.
     @param   req
                The `J` cJSON request object.
              timeoutSeconds
@@ -232,7 +230,8 @@ J *NoteRequestResponse(J *req)
 /**************************************************************************/
 J *NoteRequestResponseWithRetry(J *req, uint32_t timeoutSeconds)
 {
-    // Exit if null request.  This allows safe execution of the form NoteRequestResponse(NoteNewRequest("xxx"))
+    // Exit if null request.  This allows safe execution of the form
+    // NoteRequestResponse(NoteNewRequest("xxx"))
     if (req == NULL) {
         return NULL;
     }
@@ -242,20 +241,19 @@ J *NoteRequestResponseWithRetry(J *req, uint32_t timeoutSeconds)
     // Calculate expiry time in milliseconds
     uint32_t expiresMs = _GetMs() + (timeoutSeconds * 1000);
 
-    while(true) {
+    while (true) {
         // Execute the transaction
         rsp = NoteTransaction(req);
 
         // Loop if there is no response, or if there is an io error
-        if ( (rsp == NULL) || JContainsString(rsp, c_err, c_ioerr)) {
-
+        if ((rsp == NULL) || JContainsString(rsp, c_err, c_ioerr)) {
             // Free error response
             if (rsp != NULL) {
                 JDelete(rsp);
                 rsp = NULL;
             }
-        } else {
-
+        }
+        else {
             // Exit loop on non-null response without io error
             break;
         }
@@ -289,7 +287,6 @@ J *NoteRequestResponseWithRetry(J *req, uint32_t timeoutSeconds)
 /**************************************************************************/
 char *NoteRequestResponseJSON(char *reqJSON)
 {
-
     // Parse the incoming JSON string
     J *req = JParse(reqJSON);
     if (req == NULL) {
@@ -311,7 +308,6 @@ char *NoteRequestResponseJSON(char *reqJSON)
 
     // Done
     return json;
-
 }
 
 /**************************************************************************/
@@ -327,7 +323,6 @@ char *NoteRequestResponseJSON(char *reqJSON)
 /**************************************************************************/
 J *NoteTransaction(J *req)
 {
-
     // Validate in case of memory failure of the requestor
     if (req == NULL) {
         return NULL;
@@ -337,12 +332,13 @@ J *NoteTransaction(J *req)
     const char *reqType = JGetString(req, "req");
     const char *cmdType = JGetString(req, "cmd");
 
-    // Add the user agent object only when we're doing a hub.set and only when we're
-    // specifying the product UID.  The intent is that we only piggyback user agent
-    // data when the host is initializing the Notecard, as opposed to every time
-    // the host does a hub.set to change mode.
+    // Add the user agent object only when we're doing a hub.set and only when
+    // we're specifying the product UID.  The intent is that we only piggyback
+    // user agent data when the host is initializing the Notecard, as opposed to
+    // every time the host does a hub.set to change mode.
 #ifndef NOTE_DISABLE_USER_AGENT
-    if (!JIsPresent(req, "body") && (strcmp(reqType, "hub.set") == 0) && JIsPresent(req, "product")) {
+    if (!JIsPresent(req, "body") && (strcmp(reqType, "hub.set") == 0) &&
+        JIsPresent(req, "product")) {
         J *body = NoteUserAgent();
         if (body != NULL) {
             JAddItemToObject(req, "body", body);
@@ -350,7 +346,8 @@ J *NoteTransaction(J *req)
     }
 #endif
 
-    // Determine whether or not a response will be expected, by virtue of "cmd" being present
+    // Determine whether or not a response will be expected, by virtue of "cmd"
+    // being present
     bool noResponseExpected = (reqType[0] == '\0' && cmdType[0] != '\0');
 
     // If a reset of the module is required for any reason, do it now.
@@ -367,7 +364,7 @@ J *NoteTransaction(J *req)
     // Serialize the JSON request
     char *json = JPrintUnformatted(req);
     if (json == NULL) {
-        J *rsp = errDoc(ERRSTR("can't convert to JSON",c_bad));
+        J *rsp = errDoc(ERRSTR("can't convert to JSON", c_bad));
         _UnlockNote();
         return rsp;
     }
@@ -381,7 +378,8 @@ J *NoteTransaction(J *req)
     const char *errStr;
     if (noResponseExpected) {
         errStr = _Transaction(json, NULL);
-    } else {
+    }
+    else {
         errStr = _Transaction(json, &responseJSON);
     }
 
@@ -410,16 +408,18 @@ J *NoteTransaction(J *req)
             _Debug(responseJSON);
             _Free(responseJSON);
         }
-        J *rsp = errDoc(ERRSTR("unrecognized response from card {io}",c_iobad));
+        J *rsp =
+            errDoc(ERRSTR("unrecognized response from card {io}", c_iobad));
         _UnlockNote();
         return rsp;
     }
 
     // Debug
     if (suppressShowTransactions == 0) {
-        if (responseJSON[strlen(responseJSON)-1] == '\n') {
+        if (responseJSON[strlen(responseJSON) - 1] == '\n') {
             _Debug(responseJSON);
-        } else {
+        }
+        else {
             _Debugln(responseJSON);
         }
     }
@@ -432,7 +432,6 @@ J *NoteTransaction(J *req)
 
     // Done
     return rspdoc;
-
 }
 
 /**************************************************************************/
@@ -441,10 +440,7 @@ J *NoteTransaction(J *req)
             a given port.
 */
 /**************************************************************************/
-void NoteResetRequired()
-{
-    resetRequired = true;
-}
+void NoteResetRequired() { resetRequired = true; }
 
 /**************************************************************************/
 /*!
@@ -487,12 +483,12 @@ bool NoteErrorContains(const char *errstr, const char *errtype)
 void NoteErrorClean(char *begin)
 {
     while (true) {
-        char *end = &begin[strlen(begin)+1];
+        char *end = &begin[strlen(begin) + 1];
         char *beginBrace = strchr(begin, '{');
         if (beginBrace == NULL) {
             break;
         }
-        if (beginBrace>begin && *(beginBrace-1) == ' ') {
+        if (beginBrace > begin && *(beginBrace - 1) == ' ') {
             beginBrace--;
         }
         char *endBrace = strchr(beginBrace, '}');
@@ -500,6 +496,6 @@ void NoteErrorClean(char *begin)
             break;
         }
         char *afterBrace = endBrace + 1;
-        memmove(beginBrace, afterBrace, end-afterBrace);
+        memmove(beginBrace, afterBrace, end - afterBrace);
     }
 }

--- a/n_str.c
+++ b/n_str.c
@@ -20,6 +20,7 @@
  */
 
 #include <string.h>
+
 #include "note.h"
 
 /*
@@ -49,13 +50,13 @@ __attribute__((weak)) size_t strlcpy(char *dst, const char *src, size_t siz)
     /* Not enough room in dst, add NUL and traverse rest of src */
     if (n == 0) {
         if (siz != 0) {
-            *d = '\0';    /* NUL-terminate dst */
+            *d = '\0'; /* NUL-terminate dst */
         }
         while (*s++)
             ;
     }
 
-    return(s - src - 1);    /* count does not include NUL */
+    return (s - src - 1); /* count does not include NUL */
 }
 
 /*
@@ -84,7 +85,7 @@ __attribute__((weak)) size_t strlcat(char *dst, const char *src, size_t siz)
     n = siz - dlen;
 
     if (n == 0) {
-        return(dlen + strlen(s));
+        return (dlen + strlen(s));
     }
     while (*s != '\0') {
         if (n != 1) {
@@ -95,5 +96,5 @@ __attribute__((weak)) size_t strlcat(char *dst, const char *src, size_t siz)
     }
     *d = '\0';
 
-    return(dlen + (s - src));    /* count does not include NUL */
+    return (dlen + (s - src)); /* count does not include NUL */
 }

--- a/n_ua.c
+++ b/n_ua.c
@@ -16,7 +16,7 @@
 #include "n_lib.h"
 
 // Override-able statics
-static char *n_agent = (char *) "note-c";
+static char *n_agent = (char *)"note-c";
 static char *n_os_name = NULL;
 static char *n_os_platform = NULL;
 static char *n_os_family = NULL;
@@ -39,7 +39,7 @@ void NoteUserAgentUpdate(J *ua)
 __attribute__((weak)) void NoteUserAgentUpdate(J *ua)
 #endif
 {
-    ((void)ua);	// avoid compiler warning
+    ((void)ua);  // avoid compiler warning
 }
 
 /**************************************************************************/
@@ -54,7 +54,6 @@ J *NoteUserAgent()
 __attribute__((weak)) J *NoteUserAgent()
 #endif
 {
-
     J *ua = JCreateObject();
     if (ua == NULL) {
         return ua;
@@ -70,65 +69,65 @@ __attribute__((weak)) J *NoteUserAgent()
 #define STRINGIFY_(x) #x
 
 #if defined(__ICCARM__)
-    char *compiler = (char *) ("iar arm" PLUS " " STRINGIFY(__VER__));
+    char *compiler = (char *)("iar arm" PLUS " " STRINGIFY(__VER__));
 #elif defined(__IAR_SYSTEMS_ICC__)
-    char *compiler = (char *) ("iar" PLUS " " STRINGIFY(__VER__));
+    char *compiler = (char *)("iar" PLUS " " STRINGIFY(__VER__));
 #elif defined(__clang__)
-    char *compiler = (char *) ("clang" PLUS " " __VERSION__);
+    char *compiler = (char *)("clang" PLUS " " __VERSION__);
 #elif defined(__GNUC__)
-    char *compiler = (char *) ("gcc" PLUS " " __VERSION__);
+    char *compiler = (char *)("gcc" PLUS " " __VERSION__);
 #elif defined(__ATOLLIC__) && defined(__GNUC__)
-    char *compiler = (char *) ("atollic gcc" PLUS " " __VERSION__);
+    char *compiler = (char *)("atollic gcc" PLUS " " __VERSION__);
 #elif defined(_MSC_FULL_VER)
-    char *compiler = (char *) ("msc" PLUS " " _MSC_FULL_VER);
+    char *compiler = (char *)("msc" PLUS " " _MSC_FULL_VER);
 #elif defined(__STDC_VERSION___)
-    char *compiler = (char *) ("STDC" PLUS " " __STDC_VERSION__);
+    char *compiler = (char *)("STDC" PLUS " " __STDC_VERSION__);
 #else
-    char *compiler = (char *) ("unknown" PLUS " " __VERSION__)
+    char *compiler = (char *)("unknown" PLUS " " __VERSION__)
 #endif
 
 #if defined(ARDUINO_ARCH_ARC32)
-    n_cpu_name = (char *) "arc32";
+    n_cpu_name = (char *)"arc32";
 #elif defined(ARDUINO_ARCH_AVR)
-    n_cpu_name = (char *) "avr";
+    n_cpu_name = (char *)"avr";
 #elif defined(ARDUINO_ARCH_ESP32)
-    n_cpu_name = (char *) "esp32";
+    n_cpu_name = (char *)"esp32";
 #elif defined(ARDUINO_ARCH_ESP8266)
-    n_cpu_name = (char *) "esp8266";
+    n_cpu_name = (char *)"esp8266";
 #elif defined(ARDUINO_ARCH_MEGAAVR)
-    n_cpu_name = (char *) "megaavr";
+    n_cpu_name = (char *)"megaavr";
 #elif defined(ARDUINO_ARCH_NRF52840)
-    n_cpu_name = (char *) "nrf52840";
+    n_cpu_name = (char *)"nrf52840";
 #elif defined(ARDUINO_ARCH_NRF52)
-    n_cpu_name = (char *) "nrf52";
+    n_cpu_name = (char *)"nrf52";
 #elif defined(ARDUINO_ARCH_NRF51)
-    n_cpu_name = (char *) "nrf51";
+        n_cpu_name = (char *)"nrf51";
 #elif defined(ARDUINO_ARCH_PIC32)
-    n_cpu_name = (char *) "pic32";
+    n_cpu_name = (char *)"pic32";
 #elif defined(ARDUINO_ARCH_SAMD)
-    n_cpu_name = (char *) "samd";
+    n_cpu_name = (char *)"samd";
 #elif defined(ARDUINO_ARCH_SAM)
-    n_cpu_name = (char *) "sam";
+    n_cpu_name = (char *)"sam";
 #elif defined(ARDUINO_ARCH_SPRESENSE)
-    n_cpu_name = (char *) "spresence";
+    n_cpu_name = (char *)"spresence";
 #elif defined(ARDUINO_ARCH_STM32F0)
-    n_cpu_name = (char *) "stm32f0";
+    n_cpu_name = (char *)"stm32f0";
 #elif defined(ARDUINO_ARCH_STM32F1)
-    n_cpu_name = (char *) "stm32f1";
+    n_cpu_name = (char *)"stm32f1";
 #elif defined(ARDUINO_ARCH_STM32F4)
-    n_cpu_name = (char *) "stm32f4";
+    n_cpu_name = (char *)"stm32f4";
 #elif defined(ARDUINO_ARCH_STM32G0)
-    n_cpu_name = (char *) "stm32g0";
+    n_cpu_name = (char *)"stm32g0";
 #elif defined(ARDUINO_SWAN_R5)
-    n_cpu_name = (char *) "swan_r5";
+    n_cpu_name = (char *)"swan_r5";
 #elif defined(ARDUINO_ARCH_STM32L4)
-    n_cpu_name = (char *) "stm32l4";
+    n_cpu_name = (char *)"stm32l4";
 #elif defined(ARDUINO_ARCH_STM32U5)
-    n_cpu_name = (char *) "stm32u5";
+    n_cpu_name = (char *)"stm32u5";
 #elif defined(ARDUINO_ARCH_STM32)
-    n_cpu_name = (char *) "stm32";
+    n_cpu_name = (char *)"stm32";
 #else
-    n_cpu_name = (char *) "";
+    n_cpu_name = (char *)"";
 #endif
 
     JAddStringToObject(ua, "agent", n_agent);
@@ -168,7 +167,6 @@ __attribute__((weak)) J *NoteUserAgent()
     NoteUserAgentUpdate(ua);
 
     return ua;
-
 }
 
 /**************************************************************************/
@@ -176,17 +174,15 @@ __attribute__((weak)) J *NoteUserAgent()
     @brief  Set key UA fields from a higher level library context
 */
 /**************************************************************************/
-void NoteSetUserAgent(char *agent)
-{
-    n_agent = agent;
-}
+void NoteSetUserAgent(char *agent) { n_agent = agent; }
 
 /**************************************************************************/
 /*!
     @brief  Set key UA fields from a higher level library context
 */
 /**************************************************************************/
-void NoteSetUserAgentOS(char *os_name, char *os_platform, char *os_family, char *os_version)
+void NoteSetUserAgentOS(char *os_name, char *os_platform, char *os_family,
+                        char *os_version)
 {
     n_os_name = os_name;
     n_os_platform = os_platform;
@@ -199,7 +195,8 @@ void NoteSetUserAgentOS(char *os_name, char *os_platform, char *os_family, char 
     @brief  Set key UA fields from a higher level library context
 */
 /**************************************************************************/
-void NoteSetUserAgentCPU(int cpu_mem, int cpu_mhz, int cpu_cores, char *cpu_vendor, char *cpu_name)
+void NoteSetUserAgentCPU(int cpu_mem, int cpu_mhz, int cpu_cores,
+                         char *cpu_vendor, char *cpu_name)
 {
     n_cpu_mem = cpu_mem;
     n_cpu_mhz = cpu_mhz;

--- a/note.h
+++ b/note.h
@@ -42,8 +42,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-// Determine our basic floating data type.  In most cases "double" is the right answer, however for
-// very small microcontrollers we must use single-precision.
+// Determine our basic floating data type.  In most cases "double" is the right
+// answer, however for very small microcontrollers we must use single-precision.
 #if defined(FLT_MAX_EXP) && defined(DBL_MAX_EXP)
 #if (FLT_MAX_EXP == DBL_MAX_EXP)
 #define NOTE_FLOAT
@@ -56,21 +56,22 @@
 #error What are floating point exponent length symbols for this compiler?
 #endif
 
-// If using a short float, we must be on a VERY small MCU.  In this case, define additional
-// symbols that will save quite a bit of memory in the runtime image.
+// If using a short float, we must be on a VERY small MCU.  In this case, define
+// additional symbols that will save quite a bit of memory in the runtime image.
 #ifdef NOTE_FLOAT
 #define JNUMBER float
-#define ERRSTR(x,y) (y)
+#define ERRSTR(x, y) (y)
 #define NOTE_LOWMEM
 #else
 #define JNUMBER double
-#define ERRSTR(x,y) (x)
+#define ERRSTR(x, y) (x)
 #define ERRDBG
 #endif
 
-// UNIX Epoch time (also known as POSIX time) is the  number of seconds that have elapsed since
-// 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC).  In this project, it always
-// originates from the Notecard, which synchronizes the time from both the cell network and GPS.
+// UNIX Epoch time (also known as POSIX time) is the  number of seconds that
+// have elapsed since 00:00:00 Thursday, 1 January 1970, Coordinated Universal
+// Time (UTC).  In this project, it always originates from the Notecard, which
+// synchronizes the time from both the cell network and GPS.
 typedef unsigned long int JTIME;
 
 // C-callable functions
@@ -85,19 +86,21 @@ extern "C" {
 #include "n_cjson.h"
 
 // Card callback functions
-typedef void (*mutexFn) (void);
-typedef void * (*mallocFn) (size_t size);
-typedef void (*freeFn) (void *);
-typedef void (*delayMsFn) (uint32_t ms);
-typedef uint32_t (*getMsFn) (void);
-typedef size_t (*debugOutputFn) (const char *text);
-typedef bool (*serialResetFn) (void);
-typedef void (*serialTransmitFn) (uint8_t *data, size_t len, bool flush);
-typedef bool (*serialAvailableFn) (void);
-typedef char (*serialReceiveFn) (void);
-typedef bool (*i2cResetFn) (uint16_t DevAddress);
-typedef const char * (*i2cTransmitFn) (uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size);
-typedef const char * (*i2cReceiveFn) (uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size, uint32_t *avail);
+typedef void (*mutexFn)(void);
+typedef void *(*mallocFn)(size_t size);
+typedef void (*freeFn)(void *);
+typedef void (*delayMsFn)(uint32_t ms);
+typedef uint32_t (*getMsFn)(void);
+typedef size_t (*debugOutputFn)(const char *text);
+typedef bool (*serialResetFn)(void);
+typedef void (*serialTransmitFn)(uint8_t *data, size_t len, bool flush);
+typedef bool (*serialAvailableFn)(void);
+typedef char (*serialReceiveFn)(void);
+typedef bool (*i2cResetFn)(uint16_t DevAddress);
+typedef const char *(*i2cTransmitFn)(uint16_t DevAddress, uint8_t *pBuffer,
+                                     uint16_t Size);
+typedef const char *(*i2cReceiveFn)(uint16_t DevAddress, uint8_t *pBuffer,
+                                    uint16_t Size, uint32_t *avail);
 
 // External API
 bool NoteReset(void);
@@ -112,33 +115,39 @@ J *NoteRequestResponseWithRetry(J *req, uint32_t timeoutSeconds);
 char *NoteRequestResponseJSON(char *reqJSON);
 void NoteSuspendTransactionDebug(void);
 void NoteResumeTransactionDebug(void);
-#define SYNCSTATUS_LEVEL_MAJOR         0
-#define SYNCSTATUS_LEVEL_MINOR         1
-#define SYNCSTATUS_LEVEL_DETAILED      2
-#define SYNCSTATUS_LEVEL_ALGORITHMIC   3
-#define SYNCSTATUS_LEVEL_ALL          -1
+#define SYNCSTATUS_LEVEL_MAJOR 0
+#define SYNCSTATUS_LEVEL_MINOR 1
+#define SYNCSTATUS_LEVEL_DETAILED 2
+#define SYNCSTATUS_LEVEL_ALGORITHMIC 3
+#define SYNCSTATUS_LEVEL_ALL -1
 bool NoteDebugSyncStatus(int pollFrequencyMs, int maxLevel);
 bool NoteRequest(J *req);
 bool NoteRequestWithRetry(J *req, uint32_t timeoutms);
 #define NoteResponseError(rsp) (!JIsNullString(rsp, "err"))
-#define NoteResponseErrorContains(rsp, errstr) (JContainsString(rsp, "err", errstr))
+#define NoteResponseErrorContains(rsp, errstr) \
+    (JContainsString(rsp, "err", errstr))
 #define NoteDeleteResponse(rsp) JDelete(rsp)
 J *NoteTransaction(J *req);
 bool NoteErrorContains(const char *errstr, const char *errtype);
 void NoteErrorClean(char *errbuf);
 void NoteSetFnDebugOutput(debugOutputFn fn);
-void NoteSetFnMutex(mutexFn lockI2Cfn, mutexFn unlockI2Cfn, mutexFn lockNotefn, mutexFn unlockNotefn);
-void NoteSetFnDefault(mallocFn mallocfn, freeFn freefn, delayMsFn delayfn, getMsFn millisfn);
-void NoteSetFn(mallocFn mallocfn, freeFn freefn, delayMsFn delayfn, getMsFn millisfn);
-void NoteSetFnSerial(serialResetFn resetfn, serialTransmitFn writefn, serialAvailableFn availfn, serialReceiveFn readfn);
-#define NOTE_I2C_ADDR_DEFAULT	0x17
+void NoteSetFnMutex(mutexFn lockI2Cfn, mutexFn unlockI2Cfn, mutexFn lockNotefn,
+                    mutexFn unlockNotefn);
+void NoteSetFnDefault(mallocFn mallocfn, freeFn freefn, delayMsFn delayfn,
+                      getMsFn millisfn);
+void NoteSetFn(mallocFn mallocfn, freeFn freefn, delayMsFn delayfn,
+               getMsFn millisfn);
+void NoteSetFnSerial(serialResetFn resetfn, serialTransmitFn writefn,
+                     serialAvailableFn availfn, serialReceiveFn readfn);
+#define NOTE_I2C_ADDR_DEFAULT 0x17
 #ifndef NOTE_I2C_MAX_DEFAULT
-#define NOTE_I2C_MAX_DEFAULT	30
+#define NOTE_I2C_MAX_DEFAULT 30
 #endif
 #ifndef NOTE_I2C_MAX_MAX
-#define NOTE_I2C_MAX_MAX		127
+#define NOTE_I2C_MAX_MAX 127
 #endif
-void NoteSetFnI2C(uint32_t i2caddr, uint32_t i2cmax, i2cResetFn resetfn, i2cTransmitFn transmitfn, i2cReceiveFn receivefn);
+void NoteSetFnI2C(uint32_t i2caddr, uint32_t i2cmax, i2cResetFn resetfn,
+                  i2cTransmitFn transmitfn, i2cReceiveFn receivefn);
 void NoteSetFnDisabled(void);
 void NoteSetI2CAddress(uint32_t i2caddress);
 
@@ -146,8 +155,10 @@ void NoteSetI2CAddress(uint32_t i2caddress);
 J *NoteUserAgent(void);
 void NoteUserAgentUpdate(J *ua);
 void NoteSetUserAgent(char *agent);
-void NoteSetUserAgentOS(char *os_name, char *os_platform, char *os_family, char *os_version);
-void NoteSetUserAgentCPU(int cpu_mem, int cpu_mhz, int cpu_cores, char *cpu_vendor, char *cpu_name);
+void NoteSetUserAgentOS(char *os_name, char *os_platform, char *os_family,
+                        char *os_version);
+void NoteSetUserAgentCPU(int cpu_mem, int cpu_mhz, int cpu_cores,
+                         char *cpu_vendor, char *cpu_name);
 
 // Calls to the functions set above
 void NoteDebug(const char *message);
@@ -167,7 +178,8 @@ bool NotePrint(const char *text);
 void NotePrintln(const char *line);
 bool NotePrintf(const char *format, ...);
 
-// String helpers to help encourage the world to abandon the horribly-error-prone strn*
+// String helpers to help encourage the world to abandon the
+// horribly-error-prone strn*
 size_t strlcpy(char *dst, const char *src, size_t siz);
 size_t strlcat(char *dst, const char *src, size_t siz);
 
@@ -187,39 +199,41 @@ long int JIntValue(J *item);
 bool JIsNullString(J *rsp, const char *field);
 bool JIsExactString(J *rsp, const char *field, const char *teststr);
 bool JContainsString(J *rsp, const char *field, const char *substr);
-bool JAddBinaryToObject(J *req, const char *fieldName, const void *binaryData, uint32_t binaryDataLen);
-bool JGetBinaryFromObject(J *rsp, const char *fieldName, uint8_t **retBinaryData, uint32_t *retBinaryDataLen);
-const char *JGetItemName(const J * item);
+bool JAddBinaryToObject(J *req, const char *fieldName, const void *binaryData,
+                        uint32_t binaryDataLen);
+bool JGetBinaryFromObject(J *rsp, const char *fieldName,
+                          uint8_t **retBinaryData, uint32_t *retBinaryDataLen);
+const char *JGetItemName(const J *item);
 char *JAllocString(uint8_t *buffer, uint32_t len);
 const char *JType(J *item);
 
-#define JTYPE_NOT_PRESENT		0
-#define JTYPE_BOOL_TRUE			1
-#define JTYPE_BOOL_FALSE		2
-#define JTYPE_NULL				3
-#define JTYPE_NUMBER_ZERO		4
-#define JTYPE_NUMBER			5
-#define JTYPE_STRING_BLANK		6
-#define JTYPE_STRING_ZERO		7
-#define JTYPE_STRING_NUMBER		8
-#define JTYPE_STRING_BOOL_TRUE 	9
-#define JTYPE_STRING_BOOL_FALSE	10
-#define JTYPE_STRING			11
-#define JTYPE_OBJECT			12
-#define JTYPE_ARRAY				13
+#define JTYPE_NOT_PRESENT 0
+#define JTYPE_BOOL_TRUE 1
+#define JTYPE_BOOL_FALSE 2
+#define JTYPE_NULL 3
+#define JTYPE_NUMBER_ZERO 4
+#define JTYPE_NUMBER 5
+#define JTYPE_STRING_BLANK 6
+#define JTYPE_STRING_ZERO 7
+#define JTYPE_STRING_NUMBER 8
+#define JTYPE_STRING_BOOL_TRUE 9
+#define JTYPE_STRING_BOOL_FALSE 10
+#define JTYPE_STRING 11
+#define JTYPE_OBJECT 12
+#define JTYPE_ARRAY 13
 int JGetType(J *rsp, const char *field);
 
 // Helper functions for apps that wish to limit their C library dependencies
 #define JNTOA_PRECISION (16)
-#define JNTOA_MAX       (44)
-char * JNtoA(JNUMBER f, char * buf, int precision);
+#define JNTOA_MAX (44)
+char *JNtoA(JNUMBER f, char *buf, int precision);
 JNUMBER JAtoN(const char *string, char **endPtr);
 void JItoA(long int n, char *s);
 long int JAtoI(const char *s);
 int JB64EncodeLen(int len);
-int JB64Encode(char * coded_dst, const char *plain_src,int len_plain_src);
-int JB64DecodeLen(const char * coded_src);
-int JB64Decode(char * plain_dst, const char *coded_src);
+int JB64Encode(char *coded_dst, const char *plain_src, int len_plain_src);
+int JB64DecodeLen(const char *coded_src);
+int JB64Decode(char *plain_dst, const char *coded_src);
 
 // MD5 Helper functions
 typedef struct {
@@ -228,31 +242,41 @@ typedef struct {
     unsigned char in[64];
 } NoteMD5Context;
 #define NOTE_MD5_HASH_SIZE 16
-#define NOTE_MD5_HASH_STRING_SIZE (((NOTE_MD5_HASH_SIZE)*2)+1)
+#define NOTE_MD5_HASH_STRING_SIZE (((NOTE_MD5_HASH_SIZE)*2) + 1)
 void NoteMD5Init(NoteMD5Context *ctx);
-void NoteMD5Update(NoteMD5Context *ctx, unsigned char const *buf, unsigned long len);
+void NoteMD5Update(NoteMD5Context *ctx, unsigned char const *buf,
+                   unsigned long len);
 void NoteMD5Final(unsigned char *digest, NoteMD5Context *ctx);
 void NoteMD5Transform(unsigned long buf[4], const unsigned char inraw[64]);
-void NoteMD5Hash(unsigned char* data, unsigned long len, unsigned char *retHash);
-void NoteMD5HashString(unsigned char *data, unsigned long len, char *strbuf, unsigned long buflen);
-void NoteMD5HashToString(unsigned char *hash, char *strbuf, unsigned long buflen);
+void NoteMD5Hash(unsigned char *data, unsigned long len,
+                 unsigned char *retHash);
+void NoteMD5HashString(unsigned char *data, unsigned long len, char *strbuf,
+                       unsigned long buflen);
+void NoteMD5HashToString(unsigned char *hash, char *strbuf,
+                         unsigned long buflen);
 
-// High-level helper functions that are both useful and serve to show developers how to call the API
+// High-level helper functions that are both useful and serve to show developers
+// how to call the API
 uint32_t NoteSetSTSecs(uint32_t secs);
 bool NoteTimeValid(void);
 bool NoteTimeValidST(void);
 JTIME NoteTime(void);
 JTIME NoteTimeST(void);
 void NoteTimeRefreshMins(uint32_t mins);
-void NoteTimeSet(JTIME secondsUTC, int offset, char *zone, char *country, char *area);
-bool NoteLocalTimeST(uint16_t *retYear, uint8_t *retMonth, uint8_t *retDay, uint8_t *retHour, uint8_t *retMinute, uint8_t *retSecond, char **retWeekday, char **retZone);
-bool NoteRegion(char **retCountry, char **retArea, char **retZone, int *retZoneOffset);
+void NoteTimeSet(JTIME secondsUTC, int offset, char *zone, char *country,
+                 char *area);
+bool NoteLocalTimeST(uint16_t *retYear, uint8_t *retMonth, uint8_t *retDay,
+                     uint8_t *retHour, uint8_t *retMinute, uint8_t *retSecond,
+                     char **retWeekday, char **retZone);
+bool NoteRegion(char **retCountry, char **retArea, char **retZone,
+                int *retZoneOffset);
 bool NoteLocationValid(char *errbuf, uint32_t errbuflen);
 bool NoteLocationValidST(char *errbuf, uint32_t errbuflen);
 void NoteTurboIO(bool enable);
 long int NoteGetEnvInt(const char *variable, long int defaultVal);
 JNUMBER NoteGetEnvNumber(const char *variable, JNUMBER defaultVal);
-bool NoteGetEnv(const char *variable, const char *defaultVal, char *buf, uint32_t buflen);
+bool NoteGetEnv(const char *variable, const char *defaultVal, char *buf,
+                uint32_t buflen);
 bool NoteSetEnvDefault(const char *variable, char *buf);
 bool NoteSetEnvDefaultNumber(const char *variable, JNUMBER defaultVal);
 bool NoteSetEnvDefaultInt(const char *variable, long int defaultVal);
@@ -260,28 +284,40 @@ bool NoteIsConnected(void);
 bool NoteIsConnectedST(void);
 bool NoteGetNetStatus(char *statusBuf, int statusBufLen);
 bool NoteGetVersion(char *versionBuf, int versionBufLen);
-bool NoteGetLocation(JNUMBER *retLat, JNUMBER *retLon, JTIME *time, char *statusBuf, int statusBufLen);
+bool NoteGetLocation(JNUMBER *retLat, JNUMBER *retLon, JTIME *time,
+                     char *statusBuf, int statusBufLen);
 bool NoteSetLocation(JNUMBER lat, JNUMBER lon);
 bool NoteClearLocation(void);
 bool NoteGetLocationMode(char *modeBuf, int modeBufLen);
 bool NoteSetLocationMode(const char *mode, uint32_t seconds);
-bool NoteGetServiceConfig(char *productBuf, int productBufLen, char *serviceBuf, int serviceBufLen, char *deviceBuf, int deviceBufLen, char *snBuf, int snBufLen);
-bool NoteGetServiceConfigST(char *productBuf, int productBufLen, char *serviceBuf, int serviceBufLen, char *deviceBuf, int deviceBufLen, char *snBuf, int snBufLen);
-bool NoteGetStatus(char *statusBuf, int statusBufLen, JTIME *bootTime, bool *retUSB, bool *retSignals);
-bool NoteGetStatusST(char *statusBuf, int statusBufLen, JTIME *bootTime, bool *retUSB, bool *retSignals);
+bool NoteGetServiceConfig(char *productBuf, int productBufLen, char *serviceBuf,
+                          int serviceBufLen, char *deviceBuf, int deviceBufLen,
+                          char *snBuf, int snBufLen);
+bool NoteGetServiceConfigST(char *productBuf, int productBufLen,
+                            char *serviceBuf, int serviceBufLen,
+                            char *deviceBuf, int deviceBufLen, char *snBuf,
+                            int snBufLen);
+bool NoteGetStatus(char *statusBuf, int statusBufLen, JTIME *bootTime,
+                   bool *retUSB, bool *retSignals);
+bool NoteGetStatusST(char *statusBuf, int statusBufLen, JTIME *bootTime,
+                     bool *retUSB, bool *retSignals);
 bool NoteSleep(char *stateb64, uint32_t seconds, const char *modes);
 bool NoteWake(int stateLen, void *state);
 bool NoteFactoryReset(bool deleteConfigSettings);
 bool NoteSetSerialNumber(const char *sn);
 bool NoteSetProductID(const char *productID);
 bool NoteSetUploadMode(const char *uploadMode, int uploadMinutes, bool align);
-bool NoteSetSyncMode(const char *uploadMode, int uploadMinutes, int downloadMinutes, bool align, bool sync);
+bool NoteSetSyncMode(const char *uploadMode, int uploadMinutes,
+                     int downloadMinutes, bool align, bool sync);
 #define NoteSend NoteAdd
 bool NoteAdd(const char *target, J *body, bool urgent);
-bool NoteSendToRoute(const char *method, const char *routeAlias, char *notefile, J *body);
+bool NoteSendToRoute(const char *method, const char *routeAlias, char *notefile,
+                     J *body);
 bool NoteGetVoltage(JNUMBER *voltage);
 bool NoteGetTemperature(JNUMBER *temp);
-bool NoteGetContact(char *nameBuf, int nameBufLen, char *orgBuf, int orgBufLen, char *roleBuf, int roleBufLen, char *emailBuf, int emailBufLen);
+bool NoteGetContact(char *nameBuf, int nameBufLen, char *orgBuf, int orgBufLen,
+                    char *roleBuf, int roleBufLen, char *emailBuf,
+                    int emailBufLen);
 bool NoteSetContact(char *nameBuf, char *orgBuf, char *roleBuf, char *emailBuf);
 
 // Definitions necessary for payload descriptor
@@ -293,33 +329,46 @@ typedef struct {
     uint32_t alloc;
     uint32_t length;
 } NotePayloadDesc;
-bool NotePayloadSaveAndSleep(NotePayloadDesc *desc, uint32_t seconds, const char *modes);
+bool NotePayloadSaveAndSleep(NotePayloadDesc *desc, uint32_t seconds,
+                             const char *modes);
 bool NotePayloadRetrieveAfterSleep(NotePayloadDesc *desc);
 void NotePayloadSet(NotePayloadDesc *desc, uint8_t *buf, uint32_t buflen);
 void NotePayloadFree(NotePayloadDesc *desc);
-bool NotePayloadAddSegment(NotePayloadDesc *desc, const char segtype[NP_SEGTYPE_LEN], void *pdata, uint32_t plen);
-bool NotePayloadFindSegment(NotePayloadDesc *desc, const char segtype[NP_SEGTYPE_LEN], void *pdata, uint32_t *plen);
-bool NotePayloadGetSegment(NotePayloadDesc *desc, const char segtype[NP_SEGTYPE_LEN], void *pdata, uint32_t len);
+bool NotePayloadAddSegment(NotePayloadDesc *desc,
+                           const char segtype[NP_SEGTYPE_LEN], void *pdata,
+                           uint32_t plen);
+bool NotePayloadFindSegment(NotePayloadDesc *desc,
+                            const char segtype[NP_SEGTYPE_LEN], void *pdata,
+                            uint32_t *plen);
+bool NotePayloadGetSegment(NotePayloadDesc *desc,
+                           const char segtype[NP_SEGTYPE_LEN], void *pdata,
+                           uint32_t len);
 
 // C macro to convert a number to a string for use below
-#define _tstring(x)     #x
+#define _tstring(x) #x
 
 // Hard-wired constants used to specify field types when creating note templates
-#define TBOOL           true                // bool
-#define TINT8           11                  // 1-byte signed integer
-#define TINT16          12                  // 2-byte signed integer
-#define TINT24          13                  // 3-byte signed integer
-#define TINT32          14                  // 4-byte signed integer
-#define TINT64          18                  // 8-byte signed integer (note-c support depends upon platform)
-#define TUINT8          21                  // 1-byte unsigned integer (requires notecard firmware >= build 14444)
-#define TUINT16         22                  // 2-byte unsigned integer (requires notecard firmware >= build 14444)
-#define TUINT24         23                  // 3-byte unsigned integer (requires notecard firmware >= build 14444)
-#define TUINT32         24                  // 4-byte unsigned integer (requires notecard firmware >= build 14444)
-#define TFLOAT16        12.1                // 2-byte IEEE 754 floating point
-#define TFLOAT32        14.1                // 4-byte IEEE 754 floating point (a.k.a. "float")
-#define TFLOAT64        18.1                // 8-byte IEEE 754 floating point (a.k.a. "double")
-#define TSTRING(N)      _tstring(N)         // UTF-8 text of N bytes maximum (fixed-length reserved buffer)
-#define TSTRINGV        _tstring(0)         // variable-length string
+#define TBOOL true  // bool
+#define TINT8 11    // 1-byte signed integer
+#define TINT16 12   // 2-byte signed integer
+#define TINT24 13   // 3-byte signed integer
+#define TINT32 14   // 4-byte signed integer
+#define TINT64 \
+    18  // 8-byte signed integer (note-c support depends upon platform)
+#define TUINT8 \
+    21  // 1-byte unsigned integer (requires notecard firmware >= build 14444)
+#define TUINT16 \
+    22  // 2-byte unsigned integer (requires notecard firmware >= build 14444)
+#define TUINT24 \
+    23  // 3-byte unsigned integer (requires notecard firmware >= build 14444)
+#define TUINT32 \
+    24  // 4-byte unsigned integer (requires notecard firmware >= build 14444)
+#define TFLOAT16 12.1  // 2-byte IEEE 754 floating point
+#define TFLOAT32 14.1  // 4-byte IEEE 754 floating point (a.k.a. "float")
+#define TFLOAT64 18.1  // 8-byte IEEE 754 floating point (a.k.a. "double")
+#define TSTRING(N) \
+    _tstring(N)  // UTF-8 text of N bytes maximum (fixed-length reserved buffer)
+#define TSTRINGV _tstring(0)  // variable-length string
 bool NoteTemplate(const char *notefileID, J *templateBody);
 
 // End of C-callable functions

--- a/tests/NoteRequest_test.cpp
+++ b/tests/NoteRequest_test.cpp
@@ -12,23 +12,19 @@
  */
 
 #include <catch2/catch_test_macros.hpp>
-#include "fff.h"
 
-#include "note.h"
+#include "fff.h"
 #include "n_lib.h"
+#include "note.h"
 
 DEFINE_FFF_GLOBALS;
 // These note-c functions are mocked for the purposes of testing
 // NoteRequest.
 FAKE_VALUE_FUNC(J *, NoteTransaction, J *)
 
-namespace
-{
+namespace {
 
-J *NoteTransactionValid(J *req)
-{
-    return JCreateObject();
-}
+J *NoteTransactionValid(J *req) { return JCreateObject(); }
 
 J *NoteTransactionError(J *req)
 {
@@ -49,7 +45,6 @@ TEST_CASE("NoteRequest")
     {
         REQUIRE(!NoteRequest(NULL));
     }
-
 
     SECTION("NoteTransaction returns NULL")
     {
@@ -82,4 +77,4 @@ TEST_CASE("NoteRequest")
     }
 }
 
-}
+}  // namespace

--- a/tests/NoteTransaction_test.cpp
+++ b/tests/NoteTransaction_test.cpp
@@ -12,8 +12,8 @@
  */
 
 #include <catch2/catch_test_macros.hpp>
-#include "fff.h"
 
+#include "fff.h"
 #include "n_lib.h"
 
 DEFINE_FFF_GLOBALS;
@@ -22,15 +22,14 @@ DEFINE_FFF_GLOBALS;
 FAKE_VALUE_FUNC(bool, NoteReset)
 FAKE_VALUE_FUNC(const char *, NoteJSONTransaction, char *, char **)
 
-namespace
-{
+namespace {
 
 const char *NoteJSONTransactionValid(char *req, char **resp)
 {
     static char respString[] = "{ \"total\": 1 }";
 
     if (resp) {
-        char* respBuf = reinterpret_cast<char *>(malloc(sizeof(respString)));
+        char *respBuf = reinterpret_cast<char *>(malloc(sizeof(respString)));
         memcpy(respBuf, respString, sizeof(respString));
         *resp = respBuf;
     }
@@ -48,7 +47,7 @@ const char *NoteJSONTransactionBadJSON(char *req, char **resp)
     static char respString[] = "Bad JSON";
 
     if (resp) {
-        char* respBuf = reinterpret_cast<char *>(malloc(sizeof(respString)));
+        char *respBuf = reinterpret_cast<char *>(malloc(sizeof(respString)));
         memcpy(respBuf, respString, sizeof(respString));
         *resp = respBuf;
     }
@@ -184,4 +183,4 @@ TEST_CASE("NoteTransaction")
     }
 }
 
-}
+}  // namespace


### PR DESCRIPTION
The enforced style is based on Google's, which is one of the preset styles support by clang-format. There are some customizations:

- 4 spaces for indent.
- Brace after function definition on newline.
- Else on newline after closing brace of the corresponding if.

Here's the script I used to format the code:

```
#!/bin/bash

# These files won't be clang-formatted.
EXCLUDE_FILES=(
    tests/fff.h
)

for FILE in $(git ls-files '*.c' '*.h' '*.cpp' '*.hpp')
do
    if [[ ! " ${EXCLUDE_FILES[*]} " =~ " ${FILE} " ]]; then
        clang-format -style=file -i $FILE
    fi
done
```

Most IDEs/editors have the ability to run scripts when a file is saved, which is another way to have code formatted as you're working on it.

I'm opening this as a draft PR, since it touches every file in note-c, and I want to solicit any opinions on style before we move forward.