### PR TITLE
Print a coverage summary after running make coverage.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,6 +79,7 @@ if(COVERAGE)
     add_custom_command(
         TARGET coverage POST_BUILD
         COMMAND lcov --capture --no-external --directory ${NOTE_C_SRC_DIR} --output-file lcov.info --rc lcov_branch_coverage=1
+        COMMAND lcov --summary lcov.info
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/coverage
     )
     # The tests have to be built before we can generate the coverage report.


### PR DESCRIPTION
Example output at the end of running `make coverage`:

```
Reading tracefile lcov.info
Summary coverage rate:
  lines......: 22.5% (846 of 3755 lines)
  functions..: 28.1% (84 of 299 functions)
  branches...: no data found
[100%] Built target coverage
```