### PR TITLE
Add more unit tests and other cleanups.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,14 @@ if(BUILD_TESTS)
          NoteI2CReceive;
          NoteLockI2C;
          NoteUnlockI2C;
-         NoteI2CReset"
+         NoteI2CReset;
+         NoteSerialAvailable;
+         NoteSerialTransmit;
+         NoteSerialReceive;
+         NoteSerialReset;
+         NoteIsDebugOutputActive;
+         NoteDebug;
+         NotePrint"
     )
     foreach(MOCKED_FN ${MOCKED_FNS})
         string(APPEND OBJCOPY_WEAKEN "-W ${MOCKED_FN} ")

--- a/n_cjson_helpers.c
+++ b/n_cjson_helpers.c
@@ -83,7 +83,7 @@ J *JGetObject(J *rsp, const char *field)
 
 //**************************************************************************/
 /*!
-    @brief  Return the boolean repsentation of an item.
+    @brief  Return the boolean representation of an item.
     @param   item The JSON item.
     @returns The boolean value.
 */
@@ -98,7 +98,7 @@ bool JBoolValue(J *item)
 
 //**************************************************************************/
 /*!
-    @brief  Return the string repsentation of an item.
+    @brief  Return the string representation of an item.
     @param   item The JSON item.
     @returns The string value, or empty string, if NULL.
 */
@@ -113,7 +113,7 @@ char *JStringValue(J *item)
 
 //**************************************************************************/
 /*!
-    @brief  Return the number repsentation of an item.
+    @brief  Return the number representation of an item.
     @param   item The JSON item.
     @returns The number, or 0.0, if NULL.
 */
@@ -151,7 +151,7 @@ JNUMBER JGetNumber(J *rsp, const char *field)
 
 //**************************************************************************/
 /*!
-    @brief  Return the integer repsentation of an item.
+    @brief  Return the integer representation of an item.
     @param   item The JSON item.
     @returns The number, or 0, if NULL.
 */

--- a/n_helpers.c
+++ b/n_helpers.c
@@ -182,19 +182,16 @@ void NotePrintln(const char *line)
 bool NotePrint(const char *text)
 {
     bool success = false;
+
     if (NoteIsDebugOutputActive()) {
         NoteDebug(text);
         return true;
     }
-    int inLog = 0;
-    if (inLog++ != 0) {
-        inLog--;
-        return false;
-    }
+
     J *req = NoteNewRequest("card.log");
     JAddStringToObject(req, "text", text);
     success = NoteRequest(req);
-    inLog--;
+
     return success;
 }
 
@@ -328,7 +325,7 @@ bool NoteRegion(char **retCountry, char **retArea, char **retZone, int *retZoneO
     if (retZoneOffset != NULL) {
         *retZoneOffset = curZoneOffsetMins;
     }
-    return true;;
+    return true;
 }
 
 //**************************************************************************/

--- a/n_serial.c
+++ b/n_serial.c
@@ -48,7 +48,7 @@ const char *serialNoteTransaction(char *json, char **jsonResponse)
         if (segLen > CARD_REQUEST_SERIAL_SEGMENT_MAX_LEN) {
             segLen = CARD_REQUEST_SERIAL_SEGMENT_MAX_LEN;
         }
-        _SerialTransmit((uint8_t *)&transmitBuf[segOff], segLen, false);
+        _SerialTransmit(&transmitBuf[segOff], segLen, false);
         segOff += segLen;
         segLeft -= segLen;
         if (segLeft == 0) {
@@ -212,8 +212,9 @@ bool serialNoteReset()
         _Debug("no notecard\n");
 #endif
         _DelayMs(500);
-        _SerialReset();
-
+        if (!_SerialReset()) {
+            return false;
+        }
     }
 
     // Done

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -62,6 +62,14 @@ add_test(NoteGetEnv_test)
 add_test(NotePayload_test)
 add_test(i2cNoteTransaction_test)
 add_test(i2cNoteReset_test)
+add_test(serialNoteTransaction_test)
+add_test(serialNoteReset_test)
+add_test(NoteSetFn_test)
+add_test(NoteDebug_test)
+add_test(NoteTransactionHooks_test)
+add_test(NoteSerialHooks_test)
+add_test(NotePrint_test)
+add_test(NotePrintln_test)
 
 if(COVERAGE)
     find_program(LCOV lcov REQUIRED)
@@ -77,11 +85,21 @@ if(COVERAGE)
         COMMAND ${CMAKE_CTEST_COMMAND}
         WORKING_DIRECTORY ${CMAKE_CURENT_BINARY_DIR}
     )
+    # These files are third party code that we aren't interested in testing
+    # ourselves, so we don't care about coverage for them.
+    set(
+        EXCLUDE_FROM_COVERAGE
+        "n_atof.c;n_b64.c;n_cjson.c;n_ftoa.c;n_md5.c;n_str.c"
+    )
+    foreach(EXCLUDE_FILE ${EXCLUDE_FROM_COVERAGE})
+        string(APPEND LCOV_EXCLUDE "--exclude '*/${EXCLUDE_FILE}' ")
+    endforeach()
+    separate_arguments(LCOV_EXCLUDE_LIST NATIVE_COMMAND "${LCOV_EXCLUDE}")
     # Run lcov to produce a coverage report in the coverage directory.
     add_custom_command(
         TARGET coverage POST_BUILD
-        COMMAND lcov --capture --no-external --directory ${NOTE_C_SRC_DIR} --output-file lcov.info --rc lcov_branch_coverage=1
-        COMMAND lcov --summary lcov.info
+        COMMAND lcov --capture --no-external --directory ${NOTE_C_SRC_DIR} --rc lcov_branch_coverage=1 ${LCOV_EXCLUDE_LIST} --output-file lcov.info
+        COMMAND lcov --summary --rc lcov_branch_coverage=1 lcov.info
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/coverage
     )
     # The tests have to be built before we can generate the coverage report.

--- a/test/src/NoteDebug_test.cpp
+++ b/test/src/NoteDebug_test.cpp
@@ -1,0 +1,103 @@
+/*!
+ * @file NoteDebug_test.cpp
+ *
+ * Written by the Blues Inc. team.
+ *
+ * Copyright (c) 2023 Blues Inc. MIT License. Use of this source code is
+ * governed by licenses granted by the copyright holder including that found in
+ * the
+ * <a href="https://github.com/blues/note-c/blob/master/LICENSE">LICENSE</a>
+ * file.
+ *
+ */
+
+#ifdef TEST
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "n_lib.h"
+
+namespace
+{
+
+typedef struct {
+    char debugBuf[32];
+    size_t debugBufIdx;
+    bool debugOutputCalled;
+} TestState;
+
+TestState state;
+
+size_t MyDebugOutput(const char *line)
+{
+    size_t len = 0;
+    state.debugOutputCalled = true;
+
+    if (line != NULL) {
+        len = strlcpy(state.debugBuf + state.debugBufIdx, line,
+                      sizeof(state.debugBuf) - state.debugBufIdx);
+        state.debugBufIdx += len;
+    }
+
+    return len;
+}
+
+TEST_CASE("NoteDebug")
+{
+    memset(&state, 0, sizeof(state));
+
+    SECTION("Hook not set") {
+        CHECK(!NoteIsDebugOutputActive());
+
+        NoteDebug(NULL);
+        CHECK(!state.debugOutputCalled);
+    }
+
+    SECTION("Hook set") {
+        NoteSetFnDebugOutput(MyDebugOutput);
+
+        SECTION("Active") {
+            CHECK(NoteIsDebugOutputActive());
+        }
+
+        SECTION("Hook called") {
+            NoteDebug(NULL);
+
+#ifdef NOTE_NODEBUG
+            CHECK(!state.debugOutputCalled);
+#else
+            CHECK(state.debugOutputCalled);
+#endif
+        }
+
+        SECTION("NoteDebugln") {
+            NoteDebugln("test");
+            CHECK(!strcmp(state.debugBuf, "test\r\n"));
+        }
+
+        SECTION("NoteDebugIntln") {
+            const char* expectedString;
+
+            SECTION("Just number") {
+                expectedString = "1\r\n";
+                NoteDebugIntln(NULL, 1);
+            }
+
+            SECTION("String and number") {
+                expectedString = "test1\r\n";
+                NoteDebugIntln("test", 1);
+            }
+
+#ifdef NOTE_NODEBUG
+            CHECK(!state.debugOutputCalled);
+#else
+            CHECK(state.debugOutputCalled);
+            CHECK(!strcmp(state.debugBuf, expectedString));
+#endif
+        }
+    }
+}
+
+}
+
+#endif // TEST

--- a/test/src/NotePrint_test.cpp
+++ b/test/src/NotePrint_test.cpp
@@ -1,0 +1,87 @@
+/*!
+ * @file NotePrint_test.cpp
+ *
+ * Written by the Blues Inc. team.
+ *
+ * Copyright (c) 2023 Blues Inc. MIT License. Use of this source code is
+ * governed by licenses granted by the copyright holder including that found in
+ * the
+ * <a href="https://github.com/blues/note-c/blob/master/LICENSE">LICENSE</a>
+ * file.
+ *
+ */
+
+#ifdef TEST
+
+#include <catch2/catch_test_macros.hpp>
+#include "fff.h"
+
+#include "n_lib.h"
+
+DEFINE_FFF_GLOBALS
+FAKE_VALUE_FUNC(bool, NoteIsDebugOutputActive)
+FAKE_VALUE_FUNC(J *, NoteNewRequest, const char *)
+FAKE_VALUE_FUNC(bool, NoteRequest, J *)
+FAKE_VOID_FUNC(NoteDebug, const char *)
+
+namespace
+{
+
+
+TEST_CASE("NotePrint")
+{
+    NoteSetFnDefault(malloc, free, NULL, NULL);
+
+    RESET_FAKE(NoteIsDebugOutputActive);
+    RESET_FAKE(NoteNewRequest);
+    RESET_FAKE(NoteRequest);
+    RESET_FAKE(NoteDebug);
+
+    const char msg[] = "Hello world!";
+
+    SECTION("Debug") {
+        NoteIsDebugOutputActive_fake.return_val = true;
+
+        CHECK(NotePrint(msg));
+        CHECK(NoteDebug_fake.call_count > 0);
+    }
+
+    SECTION("card.log") {
+        NoteIsDebugOutputActive_fake.return_val = false;
+
+        SECTION("NoteNewRequest fails") {
+            NoteNewRequest_fake.return_val = NULL;
+
+            CHECK(!NotePrint(msg));
+        }
+
+        SECTION("NoteNewRequest succeeds") {
+            J *req = JCreateObject();
+            REQUIRE(req != NULL);
+            NoteNewRequest_fake.return_val = req;
+
+            SECTION("NoteRequest fails") {
+                NoteRequest_fake.return_val = false;
+
+                CHECK(!NotePrint(msg));
+            }
+
+            SECTION("NoteRequest succeeds") {
+                NoteRequest_fake.return_val = true;
+
+                CHECK(NotePrint(msg));
+                CHECK(NoteRequest_fake.call_count > 0);
+            }
+
+            JDelete(req);
+        }
+
+        // Should only go through card.log, never NoteDebug.
+        CHECK(NoteDebug_fake.call_count == 0);
+
+    }
+}
+
+}
+
+#endif // TEST

--- a/test/src/NotePrintln_test.cpp
+++ b/test/src/NotePrintln_test.cpp
@@ -1,0 +1,55 @@
+/*!
+ * @file NotePrintln_test.cpp
+ *
+ * Written by the Blues Inc. team.
+ *
+ * Copyright (c) 2023 Blues Inc. MIT License. Use of this source code is
+ * governed by licenses granted by the copyright holder including that found in
+ * the
+ * <a href="https://github.com/blues/note-c/blob/master/LICENSE">LICENSE</a>
+ * file.
+ *
+ */
+
+#ifdef TEST
+
+#include <catch2/catch_test_macros.hpp>
+#include "fff.h"
+
+#include "n_lib.h"
+
+DEFINE_FFF_GLOBALS
+FAKE_VALUE_FUNC(bool, NotePrint, const char *)
+
+namespace
+{
+
+char printBuf[32];
+size_t printBufLen = 0;
+
+bool NotePrintSave(const char* text)
+{
+    strcpy(printBuf + printBufLen, text);
+    printBufLen += strlen(text);
+    printBuf[printBufLen] = '\0';
+
+    return true;
+}
+
+
+TEST_CASE("NotePrintln")
+{
+    NotePrint_fake.custom_fake = NotePrintSave;
+
+    const char msg[] = "Hello world!";
+    size_t len = strlen(msg);
+
+    NotePrintln(msg);
+
+    CHECK(!(memcmp(printBuf, msg, len)));
+    CHECK(!(memcmp(printBuf + len, c_newline, 2)));
+}
+
+}
+
+#endif // TEST

--- a/test/src/NoteSerialHooks_test.cpp
+++ b/test/src/NoteSerialHooks_test.cpp
@@ -1,0 +1,63 @@
+/*!
+ * @file NoteSerialHooks_test.cpp
+ *
+ * Written by the Blues Inc. team.
+ *
+ * Copyright (c) 2023 Blues Inc. MIT License. Use of this source code is
+ * governed by licenses granted by the copyright holder including that found in
+ * the
+ * <a href="https://github.com/blues/note-c/blob/master/LICENSE">LICENSE</a>
+ * file.
+ *
+ */
+
+#ifdef TEST
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "n_lib.h"
+
+namespace
+{
+
+bool txnStartCalled = false;
+bool txnStopCalled = false;
+
+bool MyTxnStart(uint32_t)
+{
+    txnStartCalled = true;
+    return true;
+}
+
+void MyTxnStop()
+{
+    txnStopCalled = true;
+    return;
+}
+
+TEST_CASE("NoteSerialHooks")
+{
+    SECTION("Hooks not set") {
+        NoteTransactionStart(0);
+        NoteTransactionStop();
+
+        CHECK(!txnStartCalled);
+        CHECK(!txnStopCalled);
+    }
+
+    SECTION("Hooks set") {
+        NoteSetFnTransaction(MyTxnStart, MyTxnStop);
+        NoteTransactionStart(0);
+        NoteTransactionStop();
+
+        CHECK(txnStartCalled);
+        CHECK(txnStopCalled);
+    }
+
+    txnStartCalled = false;
+    txnStopCalled = false;
+}
+
+}
+
+#endif // TEST

--- a/test/src/NoteSetFn_test.cpp
+++ b/test/src/NoteSetFn_test.cpp
@@ -1,0 +1,93 @@
+/*!
+ * @file NoteSetFn_test.cpp
+ *
+ * Written by the Blues Inc. team.
+ *
+ * Copyright (c) 2023 Blues Inc. MIT License. Use of this source code is
+ * governed by licenses granted by the copyright holder including that found in
+ * the
+ * <a href="https://github.com/blues/note-c/blob/master/LICENSE">LICENSE</a>
+ * file.
+ *
+ */
+
+#ifdef TEST
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "n_lib.h"
+
+namespace
+{
+
+bool mallocCalled = false;
+bool freeCalled = false;
+bool delayMsCalled = false;
+bool getMsCalled = false;
+
+void* MyMalloc(size_t)
+{
+    mallocCalled = true;
+    return NULL;
+}
+
+void MyFree(void *)
+{
+    freeCalled = true;
+}
+
+void MyDelayMs(uint32_t)
+{
+    delayMsCalled = true;
+}
+
+uint32_t MyGetMs()
+{
+    getMsCalled = true;
+    return 0;
+}
+
+TEST_CASE("NoteSetFn")
+{
+    NoteSetFnDefault(MyMalloc, MyFree, MyDelayMs, MyGetMs);
+
+    SECTION("NoteSetFnDefault: Hooks not overridden") {
+        // NoteSetFnDefault will only set the hooks if they're non-NULL, so
+        // trying to set them to NULL here should have no effect, since they
+        // were previously set to valid values.
+        NoteSetFnDefault(NULL, NULL, NULL, NULL);
+
+        void* buf = NoteMalloc(1);
+        NoteFree(buf);
+        NoteDelayMs(1);
+        NoteGetMs();
+
+        CHECK(mallocCalled);
+        CHECK(freeCalled);
+        CHECK(delayMsCalled);
+        CHECK(getMsCalled);
+    }
+
+    SECTION("NoteSetFn: Hooks overridden") {
+        NoteSetFn(NULL, NULL, NULL, NULL);
+
+        void* buf = NoteMalloc(1);
+        NoteFree(buf);
+        NoteDelayMs(1);
+        NoteGetMs();
+
+        CHECK(!mallocCalled);
+        CHECK(!freeCalled);
+        CHECK(!delayMsCalled);
+        CHECK(!getMsCalled);
+    }
+
+    mallocCalled = false;
+    freeCalled = false;
+    delayMsCalled = false;
+    getMsCalled = false;
+}
+
+}
+
+#endif // TEST

--- a/test/src/NoteTransactionHooks_test.cpp
+++ b/test/src/NoteTransactionHooks_test.cpp
@@ -1,0 +1,63 @@
+/*!
+ * @file NoteTransactionHooks_test.cpp
+ *
+ * Written by the Blues Inc. team.
+ *
+ * Copyright (c) 2023 Blues Inc. MIT License. Use of this source code is
+ * governed by licenses granted by the copyright holder including that found in
+ * the
+ * <a href="https://github.com/blues/note-c/blob/master/LICENSE">LICENSE</a>
+ * file.
+ *
+ */
+
+#ifdef TEST
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "n_lib.h"
+
+namespace
+{
+
+bool txnStartCalled = false;
+bool txnStopCalled = false;
+
+bool MyTxnStart(uint32_t)
+{
+    txnStartCalled = true;
+    return true;
+}
+
+void MyTxnStop()
+{
+    txnStopCalled = true;
+    return;
+}
+
+TEST_CASE("NoteTransactionHooks")
+{
+    SECTION("Hooks not set") {
+        NoteTransactionStart(0);
+        NoteTransactionStop();
+
+        CHECK(!txnStartCalled);
+        CHECK(!txnStopCalled);
+    }
+
+    SECTION("Hooks set") {
+        NoteSetFnTransaction(MyTxnStart, MyTxnStop);
+        NoteTransactionStart(0);
+        NoteTransactionStop();
+
+        CHECK(txnStartCalled);
+        CHECK(txnStopCalled);
+    }
+
+    txnStartCalled = false;
+    txnStopCalled = false;
+}
+
+}
+
+#endif // TEST

--- a/test/src/i2cNoteReset_test.cpp
+++ b/test/src/i2cNoteReset_test.cpp
@@ -63,8 +63,8 @@ TEST_CASE("i2cNoteReset")
         // Make sure I2C bus is reset after failed receive.
         CHECK(NoteI2CReset_fake.call_count == 2);
         CHECK(NoteI2CTransmit_fake.call_count == 1);
-        // Receive will be retried 3 times.
-        CHECK(NoteI2CReceive_fake.call_count == 3);
+        // Receive will be retried.
+        CHECK(NoteI2CReceive_fake.call_count > 1);
     }
 
     SECTION("Nothing to read") {

--- a/test/src/serialNoteReset_test.cpp
+++ b/test/src/serialNoteReset_test.cpp
@@ -1,0 +1,120 @@
+/*!
+ * @file serialNoteReset_test.cpp
+ *
+ * Written by the Blues Inc. team.
+ *
+ * Copyright (c) 2023 Blues Inc. MIT License. Use of this source code is
+ * governed by licenses granted by the copyright holder including that found in
+ * the
+ * <a href="https://github.com/blues/note-c/blob/master/LICENSE">LICENSE</a>
+ * file.
+ *
+ */
+
+#ifdef TEST
+
+#include <catch2/catch_test_macros.hpp>
+#include "fff.h"
+
+#include "n_lib.h"
+
+DEFINE_FFF_GLOBALS
+FAKE_VALUE_FUNC(bool, NoteSerialReset)
+FAKE_VOID_FUNC(NoteSerialTransmit, uint8_t *, size_t, bool)
+FAKE_VALUE_FUNC(bool, NoteSerialAvailable)
+FAKE_VALUE_FUNC(char, NoteSerialReceive)
+FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
+
+namespace
+{
+
+long unsigned int NoteGetMsMock()
+{
+    static long unsigned int ret = 500;
+
+    // Cycle through returning 0, 1, and 500. 500 ms is the timeout of the
+    // receive loop in serialNoteReset.
+    switch (ret) {
+    case 0:
+        ret = 1;
+        break;
+    case 1:
+        ret = 500;
+        break;
+    case 500:
+        ret = 0;
+        break;
+    }
+
+    return ret;
+}
+
+TEST_CASE("serialNoteReset")
+{
+    RESET_FAKE(NoteSerialReset);
+    RESET_FAKE(NoteSerialTransmit);
+    RESET_FAKE(NoteSerialAvailable);
+    RESET_FAKE(NoteSerialReceive);
+    RESET_FAKE(NoteGetMs);
+
+    SECTION("NoteSerialReset fails") {
+        NoteSerialReset_fake.return_val = false;
+
+        CHECK(!serialNoteReset());
+        CHECK(NoteSerialReset_fake.call_count == 1);
+        CHECK(NoteSerialTransmit_fake.call_count == 0);
+    }
+
+    SECTION("Serial never available") {
+        NoteSerialReset_fake.return_val = true;
+        NoteSerialAvailable_fake.return_val = false;
+        NoteGetMs_fake.custom_fake = NoteGetMsMock;
+
+        CHECK(!serialNoteReset());
+        // serialNoteReset has retry logic, so we expect retries.
+        CHECK(NoteSerialTransmit_fake.call_count > 1);
+        CHECK(NoteSerialReceive_fake.call_count == 0);
+    }
+
+    SECTION("Character received") {
+        NoteGetMs_fake.custom_fake = NoteGetMsMock;
+        bool serialAvailRetVals[] = {true, false};
+        SET_RETURN_SEQ(NoteSerialAvailable, serialAvailRetVals, 2);
+
+        SECTION("Non-control character received") {
+            NoteSerialReceive_fake.return_val = 'a';
+
+            SECTION("Retry") {
+                NoteSerialReset_fake.return_val = true;
+
+                CHECK(!serialNoteReset());
+                // Expect retries.
+                CHECK(NoteSerialTransmit_fake.call_count > 1);
+            }
+
+            SECTION("NoteSerialReset fails before retry possible") {
+                bool noteSerialResetRetVals[] = {true, false};
+                SET_RETURN_SEQ(NoteSerialReset, noteSerialResetRetVals, 2);
+
+                CHECK(!serialNoteReset());
+                // No retries.
+                CHECK(NoteSerialTransmit_fake.call_count == 1);
+            }
+        }
+
+        SECTION("Only control character received") {
+            NoteSerialReset_fake.return_val = true;
+            NoteSerialReceive_fake.return_val = '\n';
+
+            CHECK(serialNoteReset());
+            // There should be no retrying.
+            CHECK(NoteSerialTransmit_fake.call_count == 1);
+        }
+
+        CHECK(NoteSerialReceive_fake.call_count > 0);
+    }
+}
+
+}
+
+#endif // TEST

--- a/test/src/serialNoteTransaction_test.cpp
+++ b/test/src/serialNoteTransaction_test.cpp
@@ -1,0 +1,210 @@
+/*!
+ * @file serialNoteTransaction_test.cpp
+ *
+ * Written by the Blues Inc. team.
+ *
+ * Copyright (c) 2023 Blues Inc. MIT License. Use of this source code is
+ * governed by licenses granted by the copyright holder including that found in
+ * the
+ * <a href="https://github.com/blues/note-c/blob/master/LICENSE">LICENSE</a>
+ * file.
+ *
+ */
+
+#ifdef TEST
+
+#include <catch2/catch_test_macros.hpp>
+#include "fff.h"
+
+#include "n_lib.h"
+
+DEFINE_FFF_GLOBALS
+FAKE_VALUE_FUNC(void *, NoteMalloc, size_t)
+FAKE_VALUE_FUNC(bool, NoteSerialAvailable)
+FAKE_VALUE_FUNC(char, NoteSerialReceive)
+FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
+FAKE_VOID_FUNC(NoteSerialTransmit, uint8_t *, size_t, bool)
+
+namespace
+{
+
+char transmitBuf[CARD_REQUEST_SERIAL_SEGMENT_MAX_LEN * 2];
+size_t transmitBufLen = 0;
+bool resetTransmitBufLen = false;
+
+void NoteSerialTransmitAppend(uint8_t *buf, size_t len, bool)
+{
+    if (resetTransmitBufLen) {
+        transmitBufLen = 0;
+        resetTransmitBufLen = false;
+    }
+
+    if (buf[len - 1] == '\n') {
+        resetTransmitBufLen = true;
+    }
+
+    if (transmitBufLen + len > sizeof(transmitBuf)) {
+        return;
+    }
+
+    memcpy(transmitBuf + transmitBufLen, buf, len);
+    transmitBufLen += len;
+}
+
+#define SERIAL_MULTI_CHUNK_RECV_BYTES (ALLOC_CHUNK * 2)
+
+char NoteSerialReceiveMultiChunk()
+{
+    static uint32_t left = SERIAL_MULTI_CHUNK_RECV_BYTES;
+
+    if (left-- > 1) {
+        return 1;
+    } else {
+        left = SERIAL_MULTI_CHUNK_RECV_BYTES;
+        return '\n';
+    }
+}
+
+TEST_CASE("serialNoteTransaction")
+{
+    NoteSetFnDefault(NULL, free, NULL, NULL);
+
+    RESET_FAKE(NoteMalloc);
+    RESET_FAKE(NoteSerialAvailable);
+    RESET_FAKE(NoteSerialTransmit);
+    RESET_FAKE(NoteSerialReceive);
+    RESET_FAKE(NoteGetMs);
+
+    char noteAddReq[] = "{\"req\": \"note.add\"}";
+
+    SECTION("Transmit buffer allocation fails") {
+        NoteMalloc_fake.return_val = NULL;
+
+        REQUIRE(serialNoteTransaction(noteAddReq, NULL) != NULL);
+        REQUIRE(NoteMalloc_fake.call_count == 1);
+    }
+
+    SECTION("No response expected") {
+        NoteMalloc_fake.custom_fake = malloc;
+        NoteSerialAvailable_fake.return_val = true;
+        NoteSerialTransmit_fake.custom_fake = NoteSerialTransmitAppend;
+        char *request = NULL;
+        uint32_t reqLen;
+
+        SECTION("One transmission") {
+            reqLen = CARD_REQUEST_SERIAL_SEGMENT_MAX_LEN - 2;
+            request = (char*)malloc(reqLen + 1);
+            REQUIRE(request != NULL);
+            memset(request, 1, reqLen);
+            request[reqLen] = '\0';
+
+            REQUIRE(serialNoteTransaction(request, NULL) == NULL);
+            // The request length is less than
+            // CARD_REQUEST_SERIAL_SEGMENT_MAX_LEN, so it should all be sent in
+            // one call to NoteSerialTransmit.
+            REQUIRE(NoteSerialTransmit_fake.call_count == 1);
+            REQUIRE(!memcmp(transmitBuf, request, reqLen - 2));
+            REQUIRE(!memcmp(transmitBuf + reqLen, c_newline, c_newline_len));
+        }
+
+        SECTION("Multiple transmissions") {
+            reqLen = CARD_REQUEST_SERIAL_SEGMENT_MAX_LEN;
+            request = (char*)malloc(reqLen + 1);
+            REQUIRE(request != NULL);
+            memset(request, 1, reqLen);
+            request[reqLen] = '\0';
+
+            REQUIRE(serialNoteTransaction(request, NULL) == NULL);
+            // The request is 1 byte greater than
+            // CARD_REQUEST_SERIAL_SEGMENT_MAX_LEN, so it should require two
+            // calls to NoteSerialTransmit.
+            REQUIRE(NoteSerialTransmit_fake.call_count == 2);
+            REQUIRE(!memcmp(transmitBuf, request, reqLen - 2));
+            REQUIRE(!memcmp(transmitBuf + reqLen, c_newline, c_newline_len));
+        }
+
+        free(request);
+    }
+
+    SECTION("Response expected") {
+        char* resp = NULL;
+
+        SECTION("Response buffer allocation fails") {
+            NoteSerialAvailable_fake.return_val = true;
+            uint8_t *transmitBuf = (uint8_t *)malloc(strlen(noteAddReq) +
+                                   c_newline_len);
+            REQUIRE(transmitBuf != NULL);
+            void* mallocReturnVals[2] = {transmitBuf, NULL};
+            SET_RETURN_SEQ(NoteMalloc, mallocReturnVals, 2);
+            const char* err;
+
+            REQUIRE((err = serialNoteTransaction(noteAddReq, &resp)) != NULL);
+            REQUIRE(NoteSerialTransmit_fake.call_count == 1);
+            REQUIRE(NoteSerialReceive_fake.call_count == 0);
+            REQUIRE(NoteMalloc_fake.call_count == 2);
+        }
+
+        SECTION("NoteSerialReceive fails") {
+            NoteSerialAvailable_fake.return_val = true;
+            NoteMalloc_fake.custom_fake = malloc;
+            NoteSerialReceive_fake.return_val = 0;
+
+            REQUIRE(serialNoteTransaction(noteAddReq, &resp) != NULL);
+            REQUIRE(NoteSerialTransmit_fake.call_count == 1);
+            REQUIRE(NoteSerialReceive_fake.call_count == 1);
+        }
+
+        SECTION("Force timeout before receive") {
+            NoteSerialAvailable_fake.return_val = false;
+            NoteMalloc_fake.custom_fake = malloc;
+            NoteSerialReceive_fake.return_val = '{';
+            long unsigned int getMsReturnVals[] = {
+                0, 100, NOTECARD_TRANSACTION_TIMEOUT_SEC * 1000 + 1
+            };
+            SET_RETURN_SEQ(NoteGetMs, getMsReturnVals, 3);
+            const char* err;
+
+            REQUIRE((err = serialNoteTransaction(noteAddReq, &resp)) != NULL);
+            // Make sure we actually timed out by checking the error message.
+            REQUIRE(strstr(err, "timeout") != NULL);
+            REQUIRE(NoteSerialTransmit_fake.call_count == 1);
+            REQUIRE(NoteSerialReceive_fake.call_count == 0);
+        }
+
+        SECTION("Check response") {
+            SECTION("One receipt") {
+                NoteSerialAvailable_fake.return_val = true;
+                NoteMalloc_fake.custom_fake = malloc;
+                NoteSerialReceive_fake.return_val = '\n';
+
+                REQUIRE(serialNoteTransaction(noteAddReq, &resp) == NULL);
+                REQUIRE(NoteSerialReceive_fake.call_count == 1);
+            }
+
+            SECTION("Multiple chunks") {
+                NoteSerialAvailable_fake.return_val = true;
+                NoteMalloc_fake.custom_fake = malloc;
+                NoteSerialReceive_fake.custom_fake = NoteSerialReceiveMultiChunk;
+
+                REQUIRE(serialNoteTransaction(noteAddReq, &resp) == NULL);
+                REQUIRE(NoteSerialReceive_fake.call_count == SERIAL_MULTI_CHUNK_RECV_BYTES);
+            }
+
+            // The response should be all 1s followed by a newline.
+            size_t respSz = strlen(resp);
+            for (size_t i = 0; i < respSz; ++i) {
+                if (i != respSz - 1) {
+                    REQUIRE(resp[i] == 1);
+                } else {
+                    REQUIRE(resp[i] == '\n');
+                }
+            }
+        }
+
+        free(resp);
+    }
+}
+
+}
+
+#endif // TEST


### PR DESCRIPTION
- Fix some typos in n_cjson_helpers.c Doxygen comments.
- Check return value of _SerialReset in retry loop of serialNoteReset.
- Exclude third party code (e.g. n_md5.c) from coverage report.
- Remove unnecessary "inLog" code from NotePrint.
- Get rid of the need for some casting in i2cNoteReset and serialNoteTransaction.
- Add new unit tests for serialNoteTransaction, serialNoteReset, NoteSetFn, NoteDebug, NoteTransaction hooks, NoteSerial hooks, NotePrint, and NotePrintln.