### PR TITLE
Fix bug in NoteSleep.

### DIFF
--- a/n_helpers.c
+++ b/n_helpers.c
@@ -1114,7 +1114,7 @@ bool NoteSleep(char *stateb64, uint32_t seconds, const char *modes)
     if (req != NULL) {
         // Add the base64 item in a wonderful way that doesn't strdup the huge string
         if (stateb64 != NULL) {
-            J *stringReferenceItem = JCreateStringValue(stateb64);
+            J *stringReferenceItem = JCreateStringReference(stateb64);
             if (stringReferenceItem != NULL) {
                 JAddItemToObject(req, "payload", stringReferenceItem);
             }


### PR DESCRIPTION
The payload was being added to the sleep request with JCreateStringValue instead of JCreateStringReference. If the sleep fails and code keeps executing on the host, NoteRequest will JDelete the request and attempt to free the payload, which can lead to an invalid free (e.g. payload is on stack).