### PR TITLE
Feature/fix getms overflow

### DIFF
--- a/n_i2c.c
+++ b/n_i2c.c
@@ -191,7 +191,7 @@ const char *i2cNoteTransaction(char *json, char **jsonResponse)
         }
 
         // If we've timed out and nothing's available, exit
-        if (_GetMs() >= startMs + (NOTECARD_TRANSACTION_TIMEOUT_SEC*1000)) {
+        if (_GetMs() - startMs >= NOTECARD_TRANSACTION_TIMEOUT_SEC*1000) {
             _Free(jsonbuf);
 #ifdef ERRDBG
             _Debug("reply to request didn't arrive from module in time\n");

--- a/n_request.c
+++ b/n_request.c
@@ -203,7 +203,8 @@ J *NoteRequestResponseWithRetry(J *req, uint32_t timeoutSeconds)
     J *rsp;
 
     // Calculate expiry time in milliseconds
-    uint32_t expiresMs = _GetMs() + (timeoutSeconds * 1000);
+    uint32_t expiresMs = _GetMs();
+    uint32_t timeouMilliSeconds = timeoutSeconds * 1000;
 
     while(true) {
         // Execute the transaction
@@ -224,7 +225,7 @@ J *NoteRequestResponseWithRetry(J *req, uint32_t timeoutSeconds)
         }
 
         // Exit loop on timeout
-        if (_GetMs() >= expiresMs) {
+        if (_GetMs() - expiresMs >= timeouMilliSeconds) {
             break;
         }
     }

--- a/n_serial.c
+++ b/n_serial.c
@@ -190,7 +190,7 @@ bool serialNoteReset()
         bool somethingFound = false;
         bool nonControlCharFound = false;
         uint32_t startMs = _GetMs();
-        while (_GetMs() < startMs+500) {
+        while (_GetMs() - startMs < 500) {
             while (_SerialAvailable()) {
                 somethingFound = true;
                 if (_SerialReceive() >= ' ') {

--- a/n_serial.c
+++ b/n_serial.c
@@ -73,7 +73,7 @@ const char *serialNoteTransaction(char *json, char **jsonResponse)
     // in our error handling.
     uint32_t startMs;
     for (startMs = _GetMs(); !_SerialAvailable(); ) {
-        if (_GetMs() >= startMs + (NOTECARD_TRANSACTION_TIMEOUT_SEC*1000)) {
+        if (_GetMs() - startMs >= NOTECARD_TRANSACTION_TIMEOUT_SEC*1000) {
 #ifdef ERRDBG
             _Debug("reply to request didn't arrive from module in time\n");
 #endif
@@ -101,7 +101,7 @@ const char *serialNoteTransaction(char *json, char **jsonResponse)
     while (ch != '\n') {
         if (!_SerialAvailable()) {
             ch = 0;
-            if (_GetMs() >= startMs + (NOTECARD_TRANSACTION_TIMEOUT_SEC*1000)) {
+            if (_GetMs() - startMs >= NOTECARD_TRANSACTION_TIMEOUT_SEC*1000) {
 #ifdef ERRDBG
                 jsonbuf[jsonbufLen] = '\0';
                 _Debug("received only partial reply after timeout:\n");

--- a/test/src/i2cNoteTransaction_test.cpp
+++ b/test/src/i2cNoteTransaction_test.cpp
@@ -167,6 +167,27 @@ TEST_CASE("i2cNoteTransaction")
             CHECK(NoteI2CReceive_fake.call_count == 1);
         }
 
+        SECTION("Force overflow timeout") {
+            NoteMalloc_fake.custom_fake = malloc;
+            NoteI2CReceive_fake.custom_fake = NoteI2CReceiveNothing;
+
+	    const long unsigned int max_uint32 = 4294967295;
+
+	    // Setup overflow condition in array:
+	    // 1. First value is NOTECARD_TRANSACTION_TIMEOUT_SEC seconds before overflow.
+	    // 2. Second value is 0 seconds after overflow.
+            long unsigned int getMsReturnVals[] = {
+		    max_uint32 - NOTECARD_TRANSACTION_TIMEOUT_SEC * 1000,
+		    0
+	    };
+
+            SET_RETURN_SEQ(NoteGetMs, getMsReturnVals, 2);
+
+            CHECK(i2cNoteTransaction(noteAddReq, &resp) != NULL);
+            CHECK(NoteI2CTransmit_fake.call_count == 1);
+            CHECK(NoteI2CReceive_fake.call_count == 1);
+        }
+
         SECTION("Check response") {
             SECTION("One receipt") {
                 NoteMalloc_fake.custom_fake = malloc;

--- a/test/src/serialNoteReset_test.cpp
+++ b/test/src/serialNoteReset_test.cpp
@@ -113,6 +113,22 @@ TEST_CASE("serialNoteReset")
 
         CHECK(NoteSerialReceive_fake.call_count > 0);
     }
+
+    SECTION("Overflow in NoteGetMs happens") {
+
+        NoteSerialReset_fake.return_val = true;
+        NoteSerialReceive_fake.return_val = ' ' - 1;
+
+        bool serialAvailRetVals[] = {true, false};
+        SET_RETURN_SEQ(NoteSerialAvailable, serialAvailRetVals, 2);
+
+	const long unsigned int max_uint32 = 4294967295;
+        long unsigned int getMsReturnVals[] = {max_uint32 - 500, max_uint32 - 400, 0};
+
+        SET_RETURN_SEQ(NoteGetMs, getMsReturnVals, 3);
+
+        CHECK(serialNoteReset());
+    }
 }
 
 }

--- a/test/src/serialNoteTransaction_test.cpp
+++ b/test/src/serialNoteTransaction_test.cpp
@@ -171,6 +171,33 @@ TEST_CASE("serialNoteTransaction")
             REQUIRE(NoteSerialReceive_fake.call_count == 0);
         }
 
+        SECTION("Force overflow timeout before receive") {
+            NoteSerialAvailable_fake.return_val = false;
+            NoteMalloc_fake.custom_fake = malloc;
+            NoteSerialReceive_fake.return_val = '{';
+
+            const long unsigned int max_uint32 = 4294967295;
+
+            // Setup overflow condition in array:
+            // 1. First value is NOTECARD_TRANSACTION_TIMEOUT_SEC seconds before overflow
+            // 2. Second value is NOTECARD_TRANSACTION_TIMEOUT_SEC - 1 seconds before overflow
+            // 3. Third value is just after overflow
+            long unsigned int getMsReturnVals[] = {
+                    max_uint32 - NOTECARD_TRANSACTION_TIMEOUT_SEC * 1000,
+                    max_uint32 - (NOTECARD_TRANSACTION_TIMEOUT_SEC - 1) * 1000,
+                    0
+            };
+
+            SET_RETURN_SEQ(NoteGetMs, getMsReturnVals, 3);
+            const char* err;
+
+            REQUIRE((err = serialNoteTransaction(noteAddReq, &resp)) != NULL);
+            // Make sure we actually timed out by checking the error message.
+            REQUIRE(strstr(err, "timeout") != NULL);
+            REQUIRE(NoteSerialTransmit_fake.call_count == 1);
+            REQUIRE(NoteSerialReceive_fake.call_count == 0);
+        }
+
         SECTION("Check response") {
             SECTION("One receipt") {
                 NoteSerialAvailable_fake.return_val = true;


### PR DESCRIPTION
Greetings!

At IRNAS we are building a product with Notecards and we have decided to build our Zephyr driver on top of you note-c library. 

During code review of my Notecard driver code one of my colleague commented that I should check, if the note-c library correctly handles overflow that would happen every ~49 days in below code:


```c
/* zephyr_millis is passed to note-c as a implementation of NoteGetMs() */
static uint32_t zephyr_millis(void)
{
	return (uint32_t)k_uptime_get();
}

static int notecard_init(const struct device *dev)
{
	k_heap_init(&notecard_heap, notecard_heap_memory, CONFIG_NOTECARD_HEAP_SIZE);
	k_mutex_init(&notecard_mutex);

	NoteSetFnDebugOutput(zephyr_log_print);

	/* Set platform specific hooks. */
	NoteSetFn(zephyr_malloc, zephyr_free, zephyr_delay, zephyr_millis);
	return 0;
}
```

I checked the note-c code and I saw that this is not correctly handled in (almost) all uses of `NoteGetMs()` (defined as `_GetMs()`).

When using timing functions that can rollover to measure elapsed time, the difference approach should be used; that way overflows are ignored and elapsed duration is correctly calculated.

I went ahead and fixed the uses of _GetMs(). I used `scripts/run_unit_tests.sh` to run the unit tests.

I made several commit pairs in the following convention: 
* first commit in a pair introduces a new unit test that trigger overflow condition, because of it the unit tests hangs.
* second commit fixes the overflow.

Three things to note:
* I am not sure that I covered all possible execution paths in the tests, I learned about one hour ago how Catch2 `SECTION` macro works and I am sure that added tests could be written differently to cover more possible paths due to other `SECTION`s.
* I did not change logic in `NoteTimeST()` which uses `_GetMs()`. It looks like it handles the wraparound, but I would suggest that someone looks over it again.
* I ran the the `scripts/run_astyle.sh` before commiting, but it did nothing, I am not sure if it works or maybe I followed your style in the code that well that no changes are needed.

