### PR TITLE
Fix warning about scope of vars declared within switch case

### DIFF
--- a/n_cjson_helpers.c
+++ b/n_cjson_helpers.c
@@ -547,6 +547,7 @@ int JGetType(J *rsp, const char *field)
         return JTYPE_NUMBER;
     case JRaw:
     case JString:
+      {
         v = item->valuestring;
         if (v == NULL || v[0] == 0) {
             return JTYPE_STRING_BLANK;
@@ -576,6 +577,7 @@ int JGetType(J *rsp, const char *field)
             return JTYPE_STRING_BOOL_FALSE;
         }
         return JTYPE_STRING;
+      }
     case JObject:
         return JTYPE_OBJECT;
     case JArray:


### PR DESCRIPTION
IAR was complaining that jumping to the later cases bypassed the init of vlen and value