### PR TITLE
Add optional memory checking with valgrind.

### DIFF
--- a/.github/actions/run_unit_tests/Dockerfile
+++ b/.github/actions/run_unit_tests/Dockerfile
@@ -40,4 +40,4 @@ RUN ["dash", "-c", "\
  && rm -rf Catch2-3.2.1  v3.2.1.tar.gz \
 "]
 
-ENTRYPOINT ["./scripts/run_unit_tests.sh", "--coverage"]
+ENTRYPOINT ["./scripts/run_unit_tests.sh", "--coverage", "--mem-check"]

--- a/.github/actions/run_unit_tests/Dockerfile
+++ b/.github/actions/run_unit_tests/Dockerfile
@@ -17,6 +17,7 @@ RUN ["dash", "-c", "\
      ca-certificates \
      curl \
      lcov \
+     valgrind \
  && apt-get clean \
  && apt-get purge \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 option(BUILD_TESTS "Build tests." ON)
 option(BUILD_SHARED_LIBS "Build note-c as a shared library." ON)
 option(COVERAGE "Compile for test coverage reporting." OFF)
+option(MEM_CHECK "Run tests with Valgrind." OFF)
 
 add_compile_options(
     -Wall
@@ -50,8 +51,16 @@ if(BUILD_TESTS)
         TEST
     )
 
-    # Including this here rather than in test/CMakeLists.txt allows us to run
+    # Including CTest here rather than in test/CMakeLists.txt allows us to run
     # ctest from the root build directory (e.g. build/ instead of build/test/).
+    # We also need to set MEMORYCHECK_COMMAND_OPTIONS before including this.
+    # See: https://stackoverflow.com/a/60741757
+    if(MEM_CHECK)
+        # Go ahead and make sure we can find valgrind while we're here.
+        find_program(VALGRIND valgrind REQUIRED)
+        message(STATUS "Found valgrind: ${VALGRIND}")
+        set(MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --error-exitcode=1")
+    endif(MEM_CHECK)
     include(CTest)
 
     # If we don't weaken the functions we're mocking in the tests, the linker

--- a/test/src/NoteGetEnv_test.cpp
+++ b/test/src/NoteGetEnv_test.cpp
@@ -47,7 +47,9 @@ TEST_CASE("NoteGetEnv")
     }
 
     SECTION("Response is invalid") {
-        NoteNewRequest_fake.return_val = JCreateObject();
+        J *req = JCreateObject();
+        REQUIRE(req != NULL);
+        NoteNewRequest_fake.return_val = req;
 
         SECTION("Response is NULL") {
             NoteRequestResponse_fake.return_val = NULL;
@@ -74,6 +76,8 @@ TEST_CASE("NoteGetEnv")
         CHECK(NoteRequestResponse_fake.call_count == 1);
         // Ensure the default value was copied into outBuf.
         CHECK(!strcmp(outBuf, defaultVal));
+
+        JDelete(req);
     }
 
     SECTION("Response is valid") {


### PR DESCRIPTION
Turn it on for the GitHub action that runs unit tests. Also, resolve a memory leak in NoteGetEnv_test.cpp.