### PR TITLE
Add a STATIC macro for static functions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,11 @@ if(BUILD_TESTS)
     endif(MEM_CHECK)
     include(CTest)
 
+    target_compile_definitions(
+        note_c
+        PUBLIC TEST
+    )
+
     # If we don't weaken the functions we're mocking in the tests, the linker
     # will complain about multiple function definitions: the mocked one and the
     # "real" one from note-c. Weakening the real function causes the mock

--- a/n_helpers.c
+++ b/n_helpers.c
@@ -68,8 +68,8 @@ static short normalYearDaysByMonth[] = {0, 31, 59, 90, 120, 151, 181, 212, 243, 
 static const char *daynames[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 
 // Forwards
-static bool timerExpiredSecs(uint32_t *timer, uint32_t periodSecs);
-static int ytodays(int year);
+STATIC bool timerExpiredSecs(uint32_t *timer, uint32_t periodSecs);
+STATIC int ytodays(int year);
 
 //**************************************************************************/
 /*!
@@ -127,7 +127,7 @@ void NoteTimeRefreshMins(uint32_t mins)
   @param   seconds The UNIX Epoch time.
 */
 /**************************************************************************/
-static void setTime(JTIME seconds)
+STATIC void setTime(JTIME seconds)
 {
     timeBaseSec = seconds;
     timeBaseSetAtMs = _GetMs();
@@ -444,7 +444,7 @@ bool NoteLocalTimeST(uint16_t *retYear, uint8_t *retMonth, uint8_t *retDay, uint
 }
 
 // Figure out how many days at start of the year
-static int ytodays(int year)
+STATIC int ytodays(int year)
 {
     int days = 0;
     if (0 < year) {
@@ -1614,7 +1614,7 @@ bool NoteSetContact(char *nameBuf, char *orgBuf, char *roleBuf, char *emailBuf)
 // A simple suppression timer based on a millisecond system clock.  This clock is reset to 0
 // after boot and every wake.  This returns true if the specified interval has elapsed, in seconds,
 // and it updates the timer if it expires so that we will go another period.
-static bool timerExpiredSecs(uint32_t *timer, uint32_t periodSecs)
+STATIC bool timerExpiredSecs(uint32_t *timer, uint32_t periodSecs)
 {
     bool expired = false;
 

--- a/note.h
+++ b/note.h
@@ -73,6 +73,15 @@
 // originates from the Notecard, which synchronizes the time from both the cell network and GPS.
 typedef unsigned long int JTIME;
 
+// If we're building the tests, STATIC is defined to nothing. This allows the
+// tests to access the static functions in note-c. Among other things, this
+// let's us mock these normally static functions.
+#ifdef TEST
+#define STATIC
+#else
+#define STATIC static
+#endif
+
 // C-callable functions
 #ifdef __cplusplus
 extern "C" {
@@ -325,6 +334,12 @@ bool NotePayloadGetSegment(NotePayloadDesc *desc, const char segtype[NP_SEGTYPE_
 #define TSTRING(N)      _tstring(N)         // UTF-8 text of N bytes maximum (fixed-length reserved buffer)
 #define TSTRINGV        _tstring(0)         // variable-length string
 bool NoteTemplate(const char *notefileID, J *templateBody);
+
+// Make these normally static functions externally visible if building tests.
+#ifdef TEST
+bool timerExpiredSecs(uint32_t *timer, uint32_t periodSecs);
+void setTime(JTIME seconds);
+#endif
 
 // End of C-callable functions
 #ifdef __cplusplus

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,9 +46,6 @@ macro(add_test TEST_NAME)
         PRIVATE note_c
         PRIVATE Catch2::Catch2WithMain
     )
-    target_compile_definitions(${TEST_NAME}
-        PRIVATE TEST
-    )
 
     list(APPEND TEST_TARGETS ${TEST_NAME})
 


### PR DESCRIPTION
If the TEST macro is defined, STATIC is defined to nothing. If TEST isn't defined, STATIC is defined to static.