### PR TITLE
Namespace test macros with NOTE_C_ prefix.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if(BUILD_TESTS)
 
     target_compile_definitions(
         note_c
-        PUBLIC TEST
+        PUBLIC NOTE_C_TEST
     )
 
     # If we don't weaken the functions we're mocking in the tests, the linker

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,10 @@ if(BUILD_TESTS)
         note_c
         PUBLIC NOTE_C_TEST
     )
+    target_include_directories(
+        note_c
+        PRIVATE ${CMAKE_CURRENT_LIST_DIR}/test/include
+    )
 
     # If we don't weaken the functions we're mocking in the tests, the linker
     # will complain about multiple function definitions: the mocked one and the

--- a/n_helpers.c
+++ b/n_helpers.c
@@ -68,8 +68,8 @@ static short normalYearDaysByMonth[] = {0, 31, 59, 90, 120, 151, 181, 212, 243, 
 static const char *daynames[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 
 // Forwards
-STATIC bool timerExpiredSecs(uint32_t *timer, uint32_t periodSecs);
-STATIC int ytodays(int year);
+NOTE_C_STATIC bool timerExpiredSecs(uint32_t *timer, uint32_t periodSecs);
+NOTE_C_STATIC int ytodays(int year);
 
 //**************************************************************************/
 /*!
@@ -127,7 +127,7 @@ void NoteTimeRefreshMins(uint32_t mins)
   @param   seconds The UNIX Epoch time.
 */
 /**************************************************************************/
-STATIC void setTime(JTIME seconds)
+NOTE_C_STATIC void setTime(JTIME seconds)
 {
     timeBaseSec = seconds;
     timeBaseSetAtMs = _GetMs();
@@ -444,7 +444,7 @@ bool NoteLocalTimeST(uint16_t *retYear, uint8_t *retMonth, uint8_t *retDay, uint
 }
 
 // Figure out how many days at start of the year
-STATIC int ytodays(int year)
+NOTE_C_STATIC int ytodays(int year)
 {
     int days = 0;
     if (0 < year) {
@@ -1621,7 +1621,7 @@ bool NoteSetContact(char *nameBuf, char *orgBuf, char *roleBuf, char *emailBuf)
 // A simple suppression timer based on a millisecond system clock.  This clock is reset to 0
 // after boot and every wake.  This returns true if the specified interval has elapsed, in seconds,
 // and it updates the timer if it expires so that we will go another period.
-STATIC bool timerExpiredSecs(uint32_t *timer, uint32_t periodSecs)
+NOTE_C_STATIC bool timerExpiredSecs(uint32_t *timer, uint32_t periodSecs)
 {
     bool expired = false;
 

--- a/n_helpers.c
+++ b/n_helpers.c
@@ -16,6 +16,12 @@
 #include <stdarg.h>
 #include "n_lib.h"
 
+#ifdef NOTE_C_TEST
+#include "test_static.h"
+#else
+#define NOTE_C_STATIC static
+#endif
+
 // When interfacing with the Notecard, it is generally encouraged that the JSON object manipulation and
 // calls to the note-arduino library are done directly at point of need.  However, there are cases in which
 // it's convenient to have a wrapper.  The most common reason is when it's best to have a suppression timer

--- a/note.h
+++ b/note.h
@@ -73,15 +73,6 @@
 // originates from the Notecard, which synchronizes the time from both the cell network and GPS.
 typedef unsigned long int JTIME;
 
-// If we're building the tests, NOTE_C_STATIC is defined to nothing. This allows
-// the tests to access the static functions in note-c. Among other things, this
-// let's us mock these normally static functions.
-#ifdef NOTE_C_TEST
-#define NOTE_C_STATIC
-#else
-#define NOTE_C_STATIC static
-#endif
-
 // C-callable functions
 #ifdef __cplusplus
 extern "C" {
@@ -336,12 +327,6 @@ bool NotePayloadGetSegment(NotePayloadDesc *desc, const char segtype[NP_SEGTYPE_
 #define TSTRING(N)      _tstring(N)         // UTF-8 text of N bytes maximum (fixed-length reserved buffer)
 #define TSTRINGV        _tstring(0)         // variable-length string
 bool NoteTemplate(const char *notefileID, J *templateBody);
-
-// Make these normally static functions externally visible if building tests.
-#ifdef NOTE_C_TEST
-bool timerExpiredSecs(uint32_t *timer, uint32_t periodSecs);
-void setTime(JTIME seconds);
-#endif
 
 // End of C-callable functions
 #ifdef __cplusplus

--- a/note.h
+++ b/note.h
@@ -73,13 +73,13 @@
 // originates from the Notecard, which synchronizes the time from both the cell network and GPS.
 typedef unsigned long int JTIME;
 
-// If we're building the tests, STATIC is defined to nothing. This allows the
-// tests to access the static functions in note-c. Among other things, this
+// If we're building the tests, NOTE_C_STATIC is defined to nothing. This allows
+// the tests to access the static functions in note-c. Among other things, this
 // let's us mock these normally static functions.
-#ifdef TEST
-#define STATIC
+#ifdef NOTE_C_TEST
+#define NOTE_C_STATIC
 #else
-#define STATIC static
+#define NOTE_C_STATIC static
 #endif
 
 // C-callable functions
@@ -338,7 +338,7 @@ bool NotePayloadGetSegment(NotePayloadDesc *desc, const char segtype[NP_SEGTYPE_
 bool NoteTemplate(const char *notefileID, J *templateBody);
 
 // Make these normally static functions externally visible if building tests.
-#ifdef TEST
+#ifdef NOTE_C_TEST
 bool timerExpiredSecs(uint32_t *timer, uint32_t periodSecs);
 void setTime(JTIME seconds);
 #endif

--- a/test/include/test_static.h
+++ b/test/include/test_static.h
@@ -1,0 +1,10 @@
+#pragma once
+
+// If we're building the tests, NOTE_C_STATIC is defined to nothing. This allows
+// the tests to access the static functions in note-c. Among other things, this
+// let's us mock these normally static functions.
+#define NOTE_C_STATIC
+
+// Make these normally static functions externally visible if building tests.
+bool timerExpiredSecs(uint32_t *timer, uint32_t periodSecs);
+void setTime(JTIME seconds);

--- a/test/src/JAddBinaryToObject_test.cpp
+++ b/test/src/JAddBinaryToObject_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/JAllocString_test.cpp
+++ b/test/src/JAllocString_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/JAtoI_test.cpp
+++ b/test/src/JAtoI_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/JBoolValue_test.cpp
+++ b/test/src/JBoolValue_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/JContainsString_test.cpp
+++ b/test/src/JContainsString_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/JGetBinaryFromObject_test.cpp
+++ b/test/src/JGetBinaryFromObject_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/JGetBool_test.cpp
+++ b/test/src/JGetBool_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/JGetInt_test.cpp
+++ b/test/src/JGetInt_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/JGetItemName_test.cpp
+++ b/test/src/JGetItemName_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/JGetNumber_test.cpp
+++ b/test/src/JGetNumber_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/JGetObject_test.cpp
+++ b/test/src/JGetObject_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/JGetString_test.cpp
+++ b/test/src/JGetString_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/JGetType_test.cpp
+++ b/test/src/JGetType_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/JIntValue_test.cpp
+++ b/test/src/JIntValue_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/JIsExactString_test.cpp
+++ b/test/src/JIsExactString_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/JIsNullString_test.cpp
+++ b/test/src/JIsNullString_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/JIsPresent_test.cpp
+++ b/test/src/JIsPresent_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/JItoA_test.cpp
+++ b/test/src/JItoA_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/JNumberValue_test.cpp
+++ b/test/src/JNumberValue_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/JStringValue_test.cpp
+++ b/test/src/JStringValue_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/JType_test.cpp
+++ b/test/src/JType_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/NoteAdd_test.cpp
+++ b/test/src/NoteAdd_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteClearLocation_test.cpp
+++ b/test/src/NoteClearLocation_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteDebugSyncStatus_test.cpp
+++ b/test/src/NoteDebugSyncStatus_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteDebug_test.cpp
+++ b/test/src/NoteDebug_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/NoteDebugf_test.cpp
+++ b/test/src/NoteDebugf_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/NoteErrorClean_test.cpp
+++ b/test/src/NoteErrorClean_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/NoteFactoryReset_test.cpp
+++ b/test/src/NoteFactoryReset_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteGetContact_test.cpp
+++ b/test/src/NoteGetContact_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteGetEnvNumber_test.cpp
+++ b/test/src/NoteGetEnvNumber_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteGetEnv_test.cpp
+++ b/test/src/NoteGetEnv_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteGetLocationMode_test.cpp
+++ b/test/src/NoteGetLocationMode_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteGetLocation_test.cpp
+++ b/test/src/NoteGetLocation_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteGetNetStatus_test.cpp
+++ b/test/src/NoteGetNetStatus_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteGetServiceConfig_test.cpp
+++ b/test/src/NoteGetServiceConfig_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteGetStatus_test.cpp
+++ b/test/src/NoteGetStatus_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteGetTemperature_test.cpp
+++ b/test/src/NoteGetTemperature_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteGetVersion_test.cpp
+++ b/test/src/NoteGetVersion_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteGetVoltage_test.cpp
+++ b/test/src/NoteGetVoltage_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteIsConnected_test.cpp
+++ b/test/src/NoteIsConnected_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteLocalTimeST_test.cpp
+++ b/test/src/NoteLocalTimeST_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteLocationValid_test.cpp
+++ b/test/src/NoteLocationValid_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteNewCommand_test.cpp
+++ b/test/src/NoteNewCommand_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteNewRequest_test.cpp
+++ b/test/src/NoteNewRequest_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NotePayloadRetrieveAfterSleep_test.cpp
+++ b/test/src/NotePayloadRetrieveAfterSleep_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NotePayloadSaveAndSleep_test.cpp
+++ b/test/src/NotePayloadSaveAndSleep_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NotePayload_test.cpp
+++ b/test/src/NotePayload_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NotePrint_test.cpp
+++ b/test/src/NotePrint_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NotePrintf_test.cpp
+++ b/test/src/NotePrintf_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NotePrintln_test.cpp
+++ b/test/src/NotePrintln_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteRegion_test.cpp
+++ b/test/src/NoteRegion_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteRequestResponseJSON_test.cpp
+++ b/test/src/NoteRequestResponseJSON_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteRequestResponse_test.cpp
+++ b/test/src/NoteRequestResponse_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteRequestWithRetry_test.cpp
+++ b/test/src/NoteRequestWithRetry_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteRequest_test.cpp
+++ b/test/src/NoteRequest_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteSendToRoute_test.cpp
+++ b/test/src/NoteSendToRoute_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteSerialHooks_test.cpp
+++ b/test/src/NoteSerialHooks_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/NoteSetContact_test.cpp
+++ b/test/src/NoteSetContact_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteSetEnvDefaultNumber_test.cpp
+++ b/test/src/NoteSetEnvDefaultNumber_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteSetEnvDefault_test.cpp
+++ b/test/src/NoteSetEnvDefault_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteSetFnI2CMutex_test.cpp
+++ b/test/src/NoteSetFnI2CMutex_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/NoteSetFnI2C_test.cpp
+++ b/test/src/NoteSetFnI2C_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteSetFnMutex_test.cpp
+++ b/test/src/NoteSetFnMutex_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/NoteSetFnNoteMutex_test.cpp
+++ b/test/src/NoteSetFnNoteMutex_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/NoteSetFnSerial_test.cpp
+++ b/test/src/NoteSetFnSerial_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteSetFn_test.cpp
+++ b/test/src/NoteSetFn_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/NoteSetLocationMode_test.cpp
+++ b/test/src/NoteSetLocationMode_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteSetLocation_test.cpp
+++ b/test/src/NoteSetLocation_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteSetProductID_test.cpp
+++ b/test/src/NoteSetProductID_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteSetSerialNumber_test.cpp
+++ b/test/src/NoteSetSerialNumber_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteSetSyncMode_test.cpp
+++ b/test/src/NoteSetSyncMode_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteSetUploadMode_test.cpp
+++ b/test/src/NoteSetUploadMode_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteSleep_test.cpp
+++ b/test/src/NoteSleep_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteTemplate_test.cpp
+++ b/test/src/NoteTemplate_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteTimeSet_test.cpp
+++ b/test/src/NoteTimeSet_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteTime_test.cpp
+++ b/test/src/NoteTime_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteTransactionHooks_test.cpp
+++ b/test/src/NoteTransactionHooks_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/src/NoteTransaction_test.cpp
+++ b/test/src/NoteTransaction_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteUserAgent_test.cpp
+++ b/test/src/NoteUserAgent_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/NoteWake_test.cpp
+++ b/test/src/NoteWake_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/i2cNoteReset_test.cpp
+++ b/test/src/i2cNoteReset_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/i2cNoteTransaction_test.cpp
+++ b/test/src/i2cNoteTransaction_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/serialNoteReset_test.cpp
+++ b/test/src/serialNoteReset_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"

--- a/test/src/serialNoteTransaction_test.cpp
+++ b/test/src/serialNoteTransaction_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef TEST
+#ifdef NOTE_C_TEST
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"


### PR DESCRIPTION
Checked that the same number of tests were run before and after this change, to make sure I didn't miss any in the changeover to NOTE_C_TEST.