### PR TITLE
Prefix CMake options with NOTE_C.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,10 @@ if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
     file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
 endif()
 
-option(BUILD_TESTS "Build tests." OFF)
-option(BUILD_SHARED_LIBS "Build note-c as a shared library." OFF)
-option(COVERAGE "Compile for test coverage reporting." OFF)
-option(MEM_CHECK "Run tests with Valgrind." OFF)
+option(NOTE_C_BUILD_TESTS "Build tests." OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries instead of static." OFF)
+option(NOTE_C_COVERAGE "Compile for test NOTE_C_COVERAGE reporting." OFF)
+option(NOTE_C_MEM_CHECK "Run tests with Valgrind." OFF)
 
 set(NOTE_C_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(
@@ -51,17 +51,17 @@ target_include_directories(
     PUBLIC ${NOTE_C_SRC_DIR}
 )
 
-if(BUILD_TESTS)
+if(NOTE_C_BUILD_TESTS)
     # Including CTest here rather than in test/CMakeLists.txt allows us to run
     # ctest from the root build directory (e.g. build/ instead of build/test/).
     # We also need to set MEMORYCHECK_COMMAND_OPTIONS before including this.
     # See: https://stackoverflow.com/a/60741757
-    if(MEM_CHECK)
+    if(NOTE_C_MEM_CHECK)
         # Go ahead and make sure we can find valgrind while we're here.
         find_program(VALGRIND valgrind REQUIRED)
         message(STATUS "Found valgrind: ${VALGRIND}")
         set(MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --error-exitcode=1")
-    endif(MEM_CHECK)
+    endif(NOTE_C_MEM_CHECK)
     include(CTest)
 
     target_compile_definitions(
@@ -128,4 +128,4 @@ if(BUILD_TESTS)
     )
 
     add_subdirectory(test)
-endif(BUILD_TESTS)
+endif(NOTE_C_BUILD_TESTS)

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -23,15 +23,15 @@ fi
 pushd $ROOT_SRC_DIR $@ > /dev/null
 
 # Shared library makes the build smaller.
-CMAKE_OPTIONS="-DBUILD_TESTS=1 -DBUILD_SHARED_LIBS=1"
+CMAKE_OPTIONS="-DNOTE_C_BUILD_TESTS=1 -DBUILD_SHARED_LIBS=1"
 BUILD_OPTIONS=""
 CTEST_OPTIONS=""
 if [[ $COVERAGE -eq 1 ]]; then
-    CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCOVERAGE=1"
+    CMAKE_OPTIONS="${CMAKE_OPTIONS} -DNOTE_C_COVERAGE=1"
     BUILD_OPTIONS="${BUILD_OPTIONS} coverage"
 fi
 if [[ $MEM_CHECK -eq 1 ]]; then
-    CMAKE_OPTIONS="${CMAKE_OPTIONS} -DMEM_CHECK=1"
+    CMAKE_OPTIONS="${CMAKE_OPTIONS} -DNOTE_C_MEM_CHECK=1"
     CTEST_OPTIONS="${CTEST_OPTIONS} -T memcheck"
 
     # This fixes a problem when running valgrind in a Docker container when the

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -137,7 +137,7 @@ add_test(NoteGetContact_test)
 add_test(NoteSetContact_test)
 add_test(NoteDebugSyncStatus_test)
 
-if(COVERAGE)
+if(NOTE_C_COVERAGE)
     find_program(LCOV lcov REQUIRED)
     message(STATUS "Found lcov: ${LCOV}")
 
@@ -177,4 +177,4 @@ if(COVERAGE)
         DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
         ${CMAKE_CURRENT_BINARY_DIR}/coverage
     )
-endif(COVERAGE)
+endif(NOTE_C_COVERAGE)


### PR DESCRIPTION
This prevents collisions with other CMake options when, for example, note-c is included in another CMake project via add_subdirectory.