### PR TITLE
Don't bother weakening mocked symbols for unit tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,28 +15,29 @@ if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
 endif()
 
 option(NOTE_C_BUILD_TESTS "Build tests." OFF)
-option(BUILD_SHARED_LIBS "Build shared libraries instead of static." OFF)
 option(NOTE_C_COVERAGE "Compile for test NOTE_C_COVERAGE reporting." OFF)
 option(NOTE_C_MEM_CHECK "Run tests with Valgrind." OFF)
 
 set(NOTE_C_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-add_library(
+add_library(note_c SHARED)
+target_sources(
     note_c
-    ${NOTE_C_SRC_DIR}/n_atof.c
-    ${NOTE_C_SRC_DIR}/n_cjson.c
-    ${NOTE_C_SRC_DIR}/n_const.c
-    ${NOTE_C_SRC_DIR}/n_helpers.c
-    ${NOTE_C_SRC_DIR}/n_i2c.c
-    ${NOTE_C_SRC_DIR}/n_printf.c
-    ${NOTE_C_SRC_DIR}/n_serial.c
-    ${NOTE_C_SRC_DIR}/n_ua.c
-    ${NOTE_C_SRC_DIR}/n_b64.c
-    ${NOTE_C_SRC_DIR}/n_cjson_helpers.c
-    ${NOTE_C_SRC_DIR}/n_ftoa.c
-    ${NOTE_C_SRC_DIR}/n_hooks.c
-    ${NOTE_C_SRC_DIR}/n_md5.c
-    ${NOTE_C_SRC_DIR}/n_request.c
-    ${NOTE_C_SRC_DIR}/n_str.c
+    PRIVATE
+        ${NOTE_C_SRC_DIR}/n_atof.c
+        ${NOTE_C_SRC_DIR}/n_cjson.c
+        ${NOTE_C_SRC_DIR}/n_const.c
+        ${NOTE_C_SRC_DIR}/n_helpers.c
+        ${NOTE_C_SRC_DIR}/n_i2c.c
+        ${NOTE_C_SRC_DIR}/n_printf.c
+        ${NOTE_C_SRC_DIR}/n_serial.c
+        ${NOTE_C_SRC_DIR}/n_ua.c
+        ${NOTE_C_SRC_DIR}/n_b64.c
+        ${NOTE_C_SRC_DIR}/n_cjson_helpers.c
+        ${NOTE_C_SRC_DIR}/n_ftoa.c
+        ${NOTE_C_SRC_DIR}/n_hooks.c
+        ${NOTE_C_SRC_DIR}/n_md5.c
+        ${NOTE_C_SRC_DIR}/n_request.c
+        ${NOTE_C_SRC_DIR}/n_str.c
 )
 target_compile_options(
     note_c
@@ -71,60 +72,6 @@ if(NOTE_C_BUILD_TESTS)
     target_include_directories(
         note_c
         PRIVATE ${CMAKE_CURRENT_LIST_DIR}/test/include
-    )
-
-    # If we don't weaken the functions we're mocking in the tests, the linker
-    # will complain about multiple function definitions: the mocked one and the
-    # "real" one from note-c. Weakening the real function causes the mock
-    # function, if defined, to override the real one. If no mock is defined, the
-    # real one will be used. So, every time a developer needs to mock a function
-    # in a test, they need to make sure it's included in the MOCKED_FNS list
-    # below.
-    set(
-        MOCKED_FNS
-        "NoteReset;
-         NoteJSONTransaction;
-         NoteTransaction;
-         NoteGetMs;
-         NoteRequestResponse;
-         NoteMalloc;
-         NoteI2CTransmit;
-         NoteI2CReceive;
-         NoteLockI2C;
-         NoteUnlockI2C;
-         NoteI2CReset;
-         NoteSerialAvailable;
-         NoteSerialTransmit;
-         NoteSerialReceive;
-         NoteSerialReset;
-         NoteIsDebugOutputActive;
-         NoteDebug;
-         NotePrint;
-         NoteNewCommand;
-         NoteRequest;
-         JCreateObject;
-         NoteTransactionStart;
-         NoteUserAgent;
-         serialNoteReset;
-         serialNoteTransaction;
-         i2cNoteReset;
-         i2cNoteTransaction;
-         JCreateStringValue;
-         NoteSetEnvDefault;
-         NoteSleep;
-         NotePayloadRetrieveAfterSleep;
-         NoteTimeValidST;
-         NoteTimeST;
-         NoteRegion"
-    )
-    foreach(MOCKED_FN ${MOCKED_FNS})
-        string(APPEND OBJCOPY_WEAKEN "-W ${MOCKED_FN} ")
-    endforeach()
-    separate_arguments(OBJCOPY_WEAKEN_LIST NATIVE_COMMAND "${OBJCOPY_WEAKEN}")
-    add_custom_command(TARGET note_c POST_BUILD
-        COMMAND ${CMAKE_OBJCOPY} ${OBJCOPY_WEAKEN_LIST}
-        $<TARGET_FILE:note_c>
-        COMMENT "Weakening mocked functions."
     )
 
     add_subdirectory(test)

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -22,8 +22,7 @@ fi
 
 pushd $ROOT_SRC_DIR $@ > /dev/null
 
-# Shared library makes the build smaller.
-CMAKE_OPTIONS="-DNOTE_C_BUILD_TESTS=1 -DBUILD_SHARED_LIBS=1"
+CMAKE_OPTIONS="-DNOTE_C_BUILD_TESTS=1"
 BUILD_OPTIONS=""
 CTEST_OPTIONS=""
 if [[ $COVERAGE -eq 1 ]]; then


### PR DESCRIPTION
Instead, force note-c to always be built as a shared library. Then, when the test binaries are built, the mocks for any note-c functions supersede any of their "real" counterparts in the shared library. This means that the mock will always be called and not the "real" function. See: https://stackoverflow.com/a/4434602/3646689

The reason we were weakening the mocked symbols in the first place is that you have to if you build note-c as a static lib. If you don't, the mocks will cause multiple definition errors. If you weaken the function being mocked, though, the mock is able to override the "real" function. Forcing note-c to be a shared lib is an easier solution.