### PR TITLE
Zero the coverage counters before every coverage run.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -148,6 +148,8 @@ if(NOTE_C_COVERAGE)
     add_custom_target(
         coverage
         COMMAND mkdir -p coverage
+        # Zero out the coverage counters from any previous runs.
+        COMMAND lcov --zerocounters --directory ${NOTE_C_SRC_DIR}
         COMMAND ${CMAKE_CTEST_COMMAND}
         WORKING_DIRECTORY ${CMAKE_CURENT_BINARY_DIR}
     )


### PR DESCRIPTION
Prior to this change, coverage was cumulative across `make coverage` runs. For example, you'd see a line report that it was executed N times instead of just once, where N is the number of times `make coverage` was run.