### PR TITLE
feat: add automatic crc support, supported by notecard firmware as of 2023-06-10

### DIFF
--- a/.github/actions/run_unit_tests/Dockerfile
+++ b/.github/actions/run_unit_tests/Dockerfile
@@ -12,7 +12,7 @@ ARG UID=1000
 ARG USER="blues"
 
 # POSIX compatible (Linux/Unix) base image.
-FROM debian:stable-slim
+FROM --platform=linux/amd64 debian:stable-slim
 
 # Import Global Argument(s)
 ARG DEBIAN_FRONTEND

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "unwantedRecommendations": [
+        "ms-vscode.cmake-tools",
+        "ms-vscode.cpptools-extension-pack",
+        "ms-azuretools.vscode-docker"
+    ]
+}

--- a/n_cjson.c
+++ b/n_cjson.c
@@ -711,7 +711,7 @@ fail:
 }
 
 /* Convert a 16-bit number to 4 hex digits, null-terminating it */
-void htoa16(uint16_t n, unsigned char *p)
+void n_htoa16(uint16_t n, unsigned char *p)
 {
     int i;
     for (i=0; i<4; i++) {
@@ -826,7 +826,7 @@ static Jbool print_string_ptr(const unsigned char * const input, printbuffer * c
             default:
                 /* escape and print as unicode codepoint */
                 *output_pointer++ = 'u';
-                htoa16(*input_pointer, output_pointer);
+                n_htoa16(*input_pointer, output_pointer);
                 output_pointer += 4;
                 break;
             }

--- a/n_cjson.c
+++ b/n_cjson.c
@@ -89,7 +89,6 @@ typedef struct {
 static error global_error = { NULL, 0 };
 
 // Forwards
-void htoa16(uint16_t n, unsigned char *p);
 static J *JNew_Item(void);
 
 N_CJSON_PUBLIC(const char *) JGetErrorPtr(void)

--- a/n_hooks.c
+++ b/n_hooks.c
@@ -469,14 +469,14 @@ void NoteDelayMs(uint32_t ms)
     }
 }
 
-#if NOTE_SHOW_MALLOC
+#if NOTE_SHOW_MALLOC || (!NOTE_LOWMEM)
 //**************************************************************************/
 /*!
-  @brief  If set for low-memory platforms, show a malloc call.
-  @param   len the number of bytes of memory allocated by the last call.
+  @brief  Convert number to a hex string
+  @param   the number
+  @param   the buffer to return it into
 */
 /**************************************************************************/
-void htoa32(uint32_t n, char *p);
 void htoa32(uint32_t n, char *p)
 {
     int i;
@@ -491,6 +491,15 @@ void htoa32(uint32_t n, char *p)
     }
     *p = '\0';
 }
+#endif
+
+#if NOTE_SHOW_MALLOC
+//**************************************************************************/
+/*!
+  @brief  If set for low-memory platforms, show a malloc call.
+  @param   len the number of bytes of memory allocated by the last call.
+*/
+/**************************************************************************/
 void *malloc_show(size_t len)
 {
     char str[16];

--- a/n_hooks.c
+++ b/n_hooks.c
@@ -477,7 +477,7 @@ void NoteDelayMs(uint32_t ms)
   @param   the buffer to return it into
 */
 /**************************************************************************/
-void htoa32(uint32_t n, char *p)
+void n_htoa32(uint32_t n, char *p)
 {
     int i;
     for (i=0; i<8; i++) {
@@ -510,7 +510,7 @@ void *malloc_show(size_t len)
     if (p == NULL) {
         hookDebugOutput("FAIL");
     } else {
-        htoa32((uint32_t)p, str);
+        n_htoa32((uint32_t)p, str);
         hookDebugOutput(str);
     }
     return p;
@@ -546,7 +546,7 @@ void NoteFree(void *p)
     if (hookFree != NULL) {
 #if NOTE_SHOW_MALLOC
         char str[16];
-        htoa32((uint32_t)p, str);
+        n_htoa32((uint32_t)p, str);
         hookDebugOutput("free");
         hookDebugOutput(str);
 #endif

--- a/n_lib.h
+++ b/n_lib.h
@@ -98,9 +98,9 @@ const char *NoteJSONTransaction(char *json, char **jsonResponse);
 bool NoteIsDebugOutputActive(void);
 
 // Utilities
-void htoa32(uint32_t n, char *p);
-void htoa16(uint16_t n, unsigned char *p);
-uint64_t atoh(char *p, int maxlen);
+void n_htoa32(uint32_t n, char *p);
+void n_htoa16(uint16_t n, unsigned char *p);
+uint64_t n_atoh(char *p, int maxlen);
 
 // Constants, a global optimization to save static string memory
 extern const char *c_null;

--- a/n_lib.h
+++ b/n_lib.h
@@ -97,6 +97,11 @@ bool NoteHardReset(void);
 const char *NoteJSONTransaction(char *json, char **jsonResponse);
 bool NoteIsDebugOutputActive(void);
 
+// Utilities
+void htoa32(uint32_t n, char *p);
+void htoa16(uint16_t n, unsigned char *p);
+uint64_t atoh(char *p, int maxlen);
+
 // Constants, a global optimization to save static string memory
 extern const char *c_null;
 #define c_null_len 4

--- a/n_md5.c
+++ b/n_md5.c
@@ -29,7 +29,7 @@
 #include "n_lib.h"
 
 // Forwards
-void htoa8(unsigned char n, unsigned char *p);
+void n_htoa8(unsigned char n, unsigned char *p);
 static void putu32 (unsigned long data, unsigned char *addr);
 static unsigned long getu32 (const unsigned char *addr);
 
@@ -54,7 +54,7 @@ static void putu32 (unsigned long data, unsigned char *addr)
 }
 
 /* Convert an 8-bit number to 2 hex digits, null-terminating it */
-void htoa8(unsigned char n, unsigned char *p)
+void n_htoa8(unsigned char n, unsigned char *p)
 {
     unsigned char nibble = (n >> 4) & 0xf;
     if (nibble >= 10) {
@@ -304,7 +304,7 @@ void NoteMD5HashString(unsigned char *data, unsigned long len, char *strbuf, uns
     NoteMD5Hash(data, len, hash);
     char hashstr[NOTE_MD5_HASH_SIZE*3] = {0};
     for (int i=0; i<NOTE_MD5_HASH_SIZE; i++) {
-        htoa8(hash[i], (unsigned char *)&hashstr[i*2]);
+        n_htoa8(hash[i], (unsigned char *)&hashstr[i*2]);
     }
     hashstr[NOTE_MD5_HASH_SIZE*2+1] = 0;
     strlcpy(strbuf, hashstr, buflen);
@@ -315,7 +315,7 @@ void NoteMD5HashToString(unsigned char *hash, char *strbuf, unsigned long buflen
 {
     char hashstr[NOTE_MD5_HASH_SIZE*3] = {0};
     for (int i=0; i<NOTE_MD5_HASH_SIZE; i++) {
-        htoa8(hash[i], (unsigned char *)&hashstr[i*2]);
+        n_htoa8(hash[i], (unsigned char *)&hashstr[i*2]);
     }
     strlcpy(strbuf, hashstr, buflen);
 }

--- a/n_request.c
+++ b/n_request.c
@@ -19,11 +19,25 @@ static int suppressShowTransactions = 0;
 // Flag that gets set whenever an error occurs that should force a reset
 static bool resetRequired = true;
 
+// CRC data
+#ifndef NOTE_LOWMEM
+static uint16_t lastRequestSeqno = 0;
+static bool lastRequestCrcAdded = false;
+static uint16_t lastRequestRetries;
+static uint16_t lastRequestRetriesAllowed = 10;
+#define CRC_FIELD_LENGTH		22	// ,"crc":"SSSS:CCCCCCCC"
+#define	CRC_FIELD_NAME_OFFSET	1
+#define	CRC_FIELD_NAME_TEST		"\"crc\":\""
+int32_t crc32(const void* data, size_t length);
+char *crcAdd(char *json, uint16_t seqno);
+bool crcError(char *json, uint16_t shouldBeSeqno);
+#endif
+
 /**************************************************************************/
 /*!
-    @brief  Create an error response document.
-    @param   errmsg
-               The error message from the Notecard
+  @brief  Create an error response document.
+  @param   errmsg
+  The error message from the Notecard
   @returns a `J` cJSON object with the error response.
 */
 /**************************************************************************/
@@ -43,7 +57,7 @@ static J *errDoc(const char *errmsg)
 
 /**************************************************************************/
 /*!
-    @brief  Suppress showing transaction details.
+  @brief  Suppress showing transaction details.
 */
 /**************************************************************************/
 void NoteSuspendTransactionDebug()
@@ -53,7 +67,7 @@ void NoteSuspendTransactionDebug()
 
 /**************************************************************************/
 /*!
-    @brief  Resume showing transaction details.
+  @brief  Resume showing transaction details.
 */
 /**************************************************************************/
 void NoteResumeTransactionDebug()
@@ -63,8 +77,8 @@ void NoteResumeTransactionDebug()
 
 /**************************************************************************/
 /*!
-    @brief  Create a new request object to populate before sending to the Notecard.
-    @param   request is The name of the request, for example `hub.set`.
+  @brief  Create a new request object to populate before sending to the Notecard.
+  @param   request is The name of the request, for example `hub.set`.
   @returns a `J` cJSON object with the request name pre-populated.
 */
 /**************************************************************************/
@@ -79,8 +93,8 @@ J *NoteNewRequest(const char *request)
 
 /**************************************************************************/
 /*!
-    @brief  Create a new command object to populate before sending to the Notecard.
-    @param   request is the name of the command, for example `hub.set`.
+  @brief  Create a new command object to populate before sending to the Notecard.
+  @param   request is the name of the command, for example `hub.set`.
   @returns a `J` cJSON object with the request name pre-populated.
 */
 /**************************************************************************/
@@ -95,16 +109,16 @@ J *NoteNewCommand(const char *request)
 
 /**************************************************************************/
 /*!
-    @brief  Send a request to the Notecard.
-            Frees the request structure from memory after sending the request.
-    @param   req
-               The `J` cJSON request object.
+  @brief  Send a request to the Notecard.
+  Frees the request structure from memory after sending the request.
+  @param   req
+  The `J` cJSON request object.
   @returns a boolean. Returns `true` if successful or `false` if an error
-            occurs, such as an out-of-memory or if an error was returned from
-            the transaction in the c_err field. If sending a `cmd` a 'true'
-            response indicates that the 'cmd` was sent without error, but
-            since the Notecard sends no response it does not guarantee that
-            the 'cmd' was received and processed by the Notecard.
+  occurs, such as an out-of-memory or if an error was returned from
+  the transaction in the c_err field. If sending a `cmd` a 'true'
+  response indicates that the 'cmd` was sent without error, but
+  since the Notecard sends no response it does not guarantee that
+  the 'cmd' was received and processed by the Notecard.
 */
 /**************************************************************************/
 bool NoteRequest(J *req)
@@ -123,18 +137,18 @@ bool NoteRequest(J *req)
 
 /**************************************************************************/
 /*!
-    @brief  Send a request to the Notecard.
-            Frees the request structure from memory after sending the request.
-            Retries the request for up to the specified timeoutSeconds if there is
-            no response, or if the response indicates an io error.
-    @param   req
-               The `J` cJSON request object.
-    @param   timeoutSeconds
-               Upper limit for retries if there is no response, or if the
-               response contains an io error.
+  @brief  Send a request to the Notecard.
+  Frees the request structure from memory after sending the request.
+  Retries the request for up to the specified timeoutSeconds if there is
+  no response, or if the response indicates an io error.
+  @param   req
+  The `J` cJSON request object.
+  @param   timeoutSeconds
+  Upper limit for retries if there is no response, or if the
+  response contains an io error.
   @returns a boolean. Returns `true` if successful or `false` if an error
-            occurs, such as an out-of-memory or if an error was returned from
-            the transaction in the c_err field.
+  occurs, such as an out-of-memory or if an error was returned from
+  the transaction in the c_err field.
 */
 /**************************************************************************/
 bool NoteRequestWithRetry(J *req, uint32_t timeoutSeconds)
@@ -154,12 +168,12 @@ bool NoteRequestWithRetry(J *req, uint32_t timeoutSeconds)
 
 /**************************************************************************/
 /*!
-    @brief  Send a request to the Notecard and return the response.
-            Frees the request structure from memory after sending the request.
-    @param   req
-               The `J` cJSON request object.
+  @brief  Send a request to the Notecard and return the response.
+  Frees the request structure from memory after sending the request.
+  @param   req
+  The `J` cJSON request object.
   @returns a `J` cJSON object with the response, or NULL if there is
-             insufficient memory.
+  insufficient memory.
 */
 /**************************************************************************/
 J *NoteRequestResponse(J *req)
@@ -182,17 +196,17 @@ J *NoteRequestResponse(J *req)
 
 /**************************************************************************/
 /*!
-    @brief  Send a request to the Notecard and return the response.
-            Frees the request structure from memory after sending the request.
-            Retries the request for up to the specified timeoutSeconds if there is
-            no response, or if the response indicates an io error.
-    @param   req
-               The `J` cJSON request object.
-    @param   timeoutSeconds
-               Upper limit for retries if there is no response, or if the
-               response contains an io error.
+  @brief  Send a request to the Notecard and return the response.
+  Frees the request structure from memory after sending the request.
+  Retries the request for up to the specified timeoutSeconds if there is
+  no response, or if the response indicates an io error.
+  @param   req
+  The `J` cJSON request object.
+  @param   timeoutSeconds
+  Upper limit for retries if there is no response, or if the
+  response contains an io error.
   @returns a `J` cJSON object with the response, or NULL if there is
-             insufficient memory.
+  insufficient memory.
 */
 /**************************************************************************/
 J *NoteRequestResponseWithRetry(J *req, uint32_t timeoutSeconds)
@@ -246,12 +260,12 @@ J *NoteRequestResponseWithRetry(J *req, uint32_t timeoutSeconds)
 
 /**************************************************************************/
 /*!
-    @brief  Given a JSON string, send a request to the Notecard.
-            Frees the request structure from memory after sending the request.
-    @param   reqJSON
-               A c-string containing the JSON request object.
+  @brief  Given a JSON string, send a request to the Notecard.
+  Frees the request structure from memory after sending the request.
+  @param   reqJSON
+  A c-string containing the JSON request object.
   @returns a c-string with the JSON response from the Notecard. After
-             parsed by the developer, should be freed with `JFree`.
+  parsed by the developer, should be freed with `JFree`.
 */
 /**************************************************************************/
 char *NoteRequestResponseJSON(char *reqJSON)
@@ -283,13 +297,13 @@ char *NoteRequestResponseJSON(char *reqJSON)
 
 /**************************************************************************/
 /*!
-    @brief  Initiate a transaction to the Notecard and return the response.
-            Does NOT free the request structure from memory after sending
-            the request.
-    @param   req
-               The `J` cJSON request object.
+  @brief  Initiate a transaction to the Notecard and return the response.
+  Does NOT free the request structure from memory after sending
+  the request.
+  @param   req
+  The `J` cJSON request object.
   @returns a `J` cJSON object with the response, or NULL if there is
-             insufficient memory.
+  insufficient memory.
 */
 /**************************************************************************/
 J *NoteTransaction(J *req)
@@ -346,18 +360,101 @@ J *NoteTransaction(J *req)
         return rsp;
     }
 
-    if (suppressShowTransactions == 0) {
-        _Debugln(json);
+    // If it is a request (as opposed to a command), include a CRC so that the
+    // request might be retried if it is received in a corrupted state.  (We can
+    // only do this on requests because for cmd's there is no 'response channel'
+    // where we can find out that the cmd failed.  Note that a Seqno is included
+    // as part of the CRC data so that two identical requests occurring within the
+    // modulus of seqno never are mistaken as being the same request being retried.
+#ifndef NOTE_LOWMEM
+    lastRequestCrcAdded = false;
+    if (!noResponseExpected) {
+        char *newJson = crcAdd(json, lastRequestSeqno);
+        if (newJson != NULL) {
+            JFree(json);
+            json = newJson;
+            lastRequestCrcAdded = true;
+            lastRequestRetries = 0;
+        }
+    }
+#endif
+
+    // If we're performing retries, this is where we come back to
+    const char *errStr;
+    char *responseJSON = NULL;
+    while (true) {
+
+        // Bump the number of retries performed for this specific transaction
+        // Trace
+        if (suppressShowTransactions == 0) {
+            _Debugln(json);
+        }
+
+        // Perform the transaction
+        if (noResponseExpected) {
+            errStr = _Transaction(json, NULL);
+        } else {
+            errStr = _Transaction(json, &responseJSON);
+        }
+
+        // CRC processing
+#ifndef NOTE_LOWMEM
+
+        // If no retry possibility, break out
+        if (!lastRequestCrcAdded || lastRequestRetries >= lastRequestRetriesAllowed) {
+            break;
+        }
+
+        // If there's an I/O error on the transaction, retry
+        if (errStr != NULL) {
+            resetRequired = !_Reset();
+            lastRequestRetries++;
+            _Debugln("retrying I/O error detected by host");
+            _DelayMs(500);
+            continue;
+        }
+
+        // Examine the response JSON to see if it's got the CRC, and retry if so.  Note
+        // that the CRC is stripped from the responseJSON as a side-effect of this method.
+        if (crcError(responseJSON, lastRequestSeqno)) {
+            _Free(responseJSON);
+            lastRequestRetries++;
+            _Debugln("retrying CRC error on notecard response detected by host");
+            _DelayMs(500);
+            continue;
+        }
+
+        // There's a possibility that we got back a response that has an I/O error.  In order
+        // to determine this, we'll need to unmarshal it.  As such, do this first by brute
+        // force and then 'correctly'.
+        if (strstr((char *)responseJSON, c_ioerr) == NULL) {
+            break;
+        }
+        J *rsp = JParse(responseJSON);
+        if (rsp == NULL) {
+            break;
+        }
+        bool isIoError = NoteErrorContains(JGetString(rsp, c_err), c_ioerr);
+        JDelete(rsp);
+        if (isIoError) {
+            _Free(responseJSON);
+            lastRequestRetries++;
+            _Debugln("retrying I/O error detected by notecard");
+            _DelayMs(500);
+            continue;
+        }
+
+#endif	// CRC Processing
+
+        // Transaction completed
+        break;
+
     }
 
-    // Perform the transaction
-    char *responseJSON = NULL;
-    const char *errStr;
-    if (noResponseExpected) {
-        errStr = _Transaction(json, NULL);
-    } else {
-        errStr = _Transaction(json, &responseJSON);
-    }
+    // Bump the request sequence number now that we've processed this request, success or error
+#ifndef NOTE_LOWMEM
+    lastRequestSeqno++;
+#endif
 
     // Free the json
     JFree(json);
@@ -417,8 +514,8 @@ J *NoteTransaction(J *req)
 
 /**************************************************************************/
 /*!
-    @brief  Mark that a reset will be required before doing further I/O on
-            a given port.
+  @brief  Mark that a reset will be required before doing further I/O on
+  a given port.
 */
 /**************************************************************************/
 void NoteResetRequired()
@@ -428,9 +525,9 @@ void NoteResetRequired()
 
 /**************************************************************************/
 /*!
-    @brief  Initialize or re-initialize the module, returning false if
-            anything fails.
-    @returns a boolean. `true` if the reset was successful, `false`, if not.
+  @brief  Initialize or re-initialize the module, returning false if
+  anything fails.
+  @returns a boolean. `true` if the reset was successful, `false`, if not.
 */
 /**************************************************************************/
 bool NoteReset()
@@ -443,13 +540,13 @@ bool NoteReset()
 
 /**************************************************************************/
 /*!
-    @brief  Check to see if a Notecard error is present in a JSON string.
-    @param   errstr
-               The error string.
-    @param   errtype
-               The error type string.
+  @brief  Check to see if a Notecard error is present in a JSON string.
+  @param   errstr
+  The error string.
+  @param   errtype
+  The error type string.
   @returns boolean. `true` if the string contains the error provided, `false`
-             if not.
+  if not.
 */
 /**************************************************************************/
 bool NoteErrorContains(const char *errstr, const char *errtype)
@@ -459,9 +556,9 @@ bool NoteErrorContains(const char *errstr, const char *errtype)
 
 /**************************************************************************/
 /*!
-    @brief  Clean error strings out of the specified buffer.
-    @param   begin
-               The string buffer to clear of error strings.
+  @brief  Clean error strings out of the specified buffer.
+  @param   begin
+  The string buffer to clear of error strings.
 */
 /**************************************************************************/
 void NoteErrorClean(char *begin)
@@ -483,3 +580,157 @@ void NoteErrorClean(char *begin)
         memmove(beginBrace, afterBrace, end-afterBrace);
     }
 }
+
+#ifndef NOTE_LOWMEM
+/**************************************************************************/
+/*!
+  @brief  atoh - Convert a string to hex
+  @param   p
+  The character data to convert
+  @param   maxlen
+  The maximum length of that character data
+  @returns The number as converted from hex
+*/
+/**************************************************************************/
+uint64_t atoh(char *p, int maxlen)
+{
+    uint64_t n = 0;
+    char *ep = p+maxlen;
+    while (p < ep) {
+        char ch = *p++;
+        bool digit = (ch >= '0' && ch <= '9');
+        bool lcase = (ch >= 'a' && ch <= 'f');
+        bool space = (ch == ' ');
+        bool ucase = (ch >= 'A' && ch <= 'F');
+        if (!digit && !lcase && !space && !ucase) {
+            break;
+        }
+        n *= 16;
+        if (digit) {
+            n += ch - '0';
+        } else if (lcase) {
+            n += 10 + (ch - 'a');
+        } else if (ucase) {
+            n += 10 + (ch - 'A');
+        }
+    }
+    return (n);
+}
+#endif
+
+#ifndef NOTE_LOWMEM
+/**************************************************************************/
+/*!
+  @brief  crc32 - Small lookup-table half-byte CRC32 algorithm
+  https://create.stephan-brumme.com/crc32/#half-byte
+  @param   data
+  The data used to calculate the CRC
+  @param   length
+  The length of that data
+  @returns The CRC32 of the data
+*/
+/**************************************************************************/
+static uint32_t lut[16] = {
+    0x00000000,0x1DB71064,0x3B6E20C8,0x26D930AC,0x76DC4190,0x6B6B51F4,0x4DB26158,0x5005713C,
+    0xEDB88320,0xF00F9344,0xD6D6A3E8,0xCB61B38C,0x9B64C2B0,0x86D3D2D4,0xA00AE278,0xBDBDF21C
+};
+int32_t crc32(const void* data, size_t length)
+{
+    uint32_t previousCrc32 = 0;
+    uint32_t crc = ~previousCrc32;
+    unsigned char* current = (unsigned char*) data;
+    while (length--) {
+        crc = lut[(crc ^  *current      ) & 0x0F] ^ (crc >> 4);
+        crc = lut[(crc ^ (*current >> 4)) & 0x0F] ^ (crc >> 4);
+        current++;
+    }
+    return ~crc;
+}
+#endif
+
+#ifndef NOTE_LOWMEM
+/**************************************************************************/
+/*!
+  @brief  crcAdd
+  @param   json
+  The JSON transaction to CRC and to add the CRC to
+  @param   seqno
+  A 16-bit sequence number to include as a part of the CRC
+  @returns new JSON with crc added, else NULL if failure
+*/
+/**************************************************************************/
+char *crcAdd(char *json, uint16_t seqno)
+{
+
+    // Allocate a block the size of the input json plus the size of
+    // the field to be added.  Note that the input JSON ends in '"}' and
+    // this will be replaced with a combination of 4 hex digits of the
+    // seqno plus 4 hex digits of the CRC32, and the '}' will be
+    // transformed into ',"crc":"SSSSCCCCCCCC"}' where SSSS is the
+    // seqno and CCCCCCCC is the crc32.  Note that the comma is
+    // replaced with a space if the input json doesn't contain
+    // any fields, so that we always return compliant JSON.
+    size_t jsonLen = strlen(json);
+    if (jsonLen < 2 || json[jsonLen-1] != '}') {
+        return NULL;
+    }
+    char *newJson = (char *) _Malloc(jsonLen+CRC_FIELD_LENGTH);
+    if (newJson == NULL) {
+        return NULL;
+    }
+    bool isEmptyObject = (memchr(json, ':', jsonLen) == NULL);
+    size_t newJsonLen = jsonLen-1;
+    memcpy(newJson, json, newJsonLen);
+    newJson[newJsonLen++] = (isEmptyObject ? ' ' : ',');	// Replace }
+    newJson[newJsonLen++] = '"';							// +1
+    newJson[newJsonLen++] = 'c';							// +2
+    newJson[newJsonLen++] = 'r';							// +3
+    newJson[newJsonLen++] = 'c';							// +4
+    newJson[newJsonLen++] = '"';							// +5
+    newJson[newJsonLen++] = ':';							// +6
+    newJson[newJsonLen++] = '"';							// +7
+    htoa16(seqno, (uint8_t *) &newJson[newJsonLen]);
+    newJsonLen += 4;										// +11
+    newJson[newJsonLen++] = ':';							// +12
+    htoa32(crc32(json, jsonLen), &newJson[newJsonLen]);
+    newJsonLen += 8;										// +20
+    newJson[newJsonLen++] = '"';							// +21
+    newJson[newJsonLen++] = '}';							// +22 == CRC_FIELD_LENGTH
+    newJson[newJsonLen] = '\0';								// null-terminated as it came in
+    return newJson;
+}
+#endif
+
+#ifndef NOTE_LOWMEM
+/**************************************************************************/
+/*!
+  @brief  crcError
+  @param   json
+  The JSON transaction for which the CRC should be checked.  Note
+  that if a CRC field is not present in the JSON, it is considered
+  as a valid transaction because old notecards do not have the code
+  with which to calculate and piggyback a CRC field.  Note that the
+  CRC is stripped from the input JSON regardless of whether or not
+  there was an error.
+  @returns nothing
+*/
+/**************************************************************************/
+bool crcError(char *json, uint16_t shouldBeSeqno)
+{
+    size_t jsonLen = strlen(json);
+    if (jsonLen < CRC_FIELD_LENGTH+2 || json[jsonLen-1] != '}') {
+        return false;
+    }
+    size_t fieldOffset = ((jsonLen-1) - CRC_FIELD_LENGTH);
+    if (memcmp(&json[fieldOffset+CRC_FIELD_NAME_OFFSET], CRC_FIELD_NAME_TEST, sizeof(CRC_FIELD_NAME_TEST)-1) != 0) {
+        return false;
+    }
+    char *p = &json[fieldOffset + CRC_FIELD_NAME_OFFSET + (sizeof(CRC_FIELD_NAME_TEST)-1)];
+    uint16_t actualSeqno = (uint16_t) atoh(p, 4);
+    uint32_t actualCrc32 = (uint32_t) atoh(p+5, 8);
+    json[fieldOffset++] = '}';
+    json[fieldOffset] = '\0';
+    uint32_t shouldBeCrc32 = crc32(json, fieldOffset);
+    return (shouldBeSeqno != actualSeqno || shouldBeCrc32 != actualCrc32);
+}
+#endif

--- a/n_request.c
+++ b/n_request.c
@@ -674,7 +674,7 @@ char *crcAdd(char *json, uint16_t seqno)
     if (jsonLen < 2 || json[jsonLen-1] != '}') {
         return NULL;
     }
-    char *newJson = (char *) _Malloc(jsonLen+CRC_FIELD_LENGTH);
+    char *newJson = (char *) _Malloc(jsonLen+CRC_FIELD_LENGTH+1);
     if (newJson == NULL) {
         return NULL;
     }

--- a/n_request.c
+++ b/n_request.c
@@ -401,7 +401,7 @@ J *NoteTransaction(J *req)
 #ifndef NOTE_LOWMEM
 
         // If no retry possibility, break out
-        if (!lastRequestCrcAdded || lastRequestRetries >= lastRequestRetriesAllowed) {
+        if (noResponseExpected || !lastRequestCrcAdded || lastRequestRetries >= lastRequestRetriesAllowed) {
             break;
         }
 

--- a/n_request.c
+++ b/n_request.c
@@ -584,7 +584,7 @@ void NoteErrorClean(char *begin)
 #ifndef NOTE_LOWMEM
 /**************************************************************************/
 /*!
-  @brief  atoh - Convert a string to hex
+  @brief  n_atoh - Convert a string to hex
   @param   p
   The character data to convert
   @param   maxlen
@@ -592,7 +592,7 @@ void NoteErrorClean(char *begin)
   @returns The number as converted from hex
 */
 /**************************************************************************/
-uint64_t atoh(char *p, int maxlen)
+uint64_t n_atoh(char *p, int maxlen)
 {
     uint64_t n = 0;
     char *ep = p+maxlen;
@@ -689,10 +689,10 @@ char *crcAdd(char *json, uint16_t seqno)
     newJson[newJsonLen++] = '"';							// +5
     newJson[newJsonLen++] = ':';							// +6
     newJson[newJsonLen++] = '"';							// +7
-    htoa16(seqno, (uint8_t *) &newJson[newJsonLen]);
+    n_htoa16(seqno, (uint8_t *) &newJson[newJsonLen]);
     newJsonLen += 4;										// +11
     newJson[newJsonLen++] = ':';							// +12
-    htoa32(crc32(json, jsonLen), &newJson[newJsonLen]);
+    n_htoa32(crc32(json, jsonLen), &newJson[newJsonLen]);
     newJsonLen += 8;										// +20
     newJson[newJsonLen++] = '"';							// +21
     newJson[newJsonLen++] = '}';							// +22 == CRC_FIELD_LENGTH
@@ -726,8 +726,8 @@ bool crcError(char *json, uint16_t shouldBeSeqno)
         return false;
     }
     char *p = &json[fieldOffset + CRC_FIELD_NAME_OFFSET + (sizeof(CRC_FIELD_NAME_TEST)-1)];
-    uint16_t actualSeqno = (uint16_t) atoh(p, 4);
-    uint32_t actualCrc32 = (uint32_t) atoh(p+5, 8);
+    uint16_t actualSeqno = (uint16_t) n_atoh(p, 4);
+    uint32_t actualCrc32 = (uint32_t) n_atoh(p+5, 8);
     json[fieldOffset++] = '}';
     json[fieldOffset] = '\0';
     uint32_t shouldBeCrc32 = crc32(json, fieldOffset);

--- a/note.h
+++ b/note.h
@@ -136,17 +136,32 @@ void NoteSetFnNoteMutex(mutexFn lockNotefn, mutexFn unlockNotefn);
 void NoteSetFnDefault(mallocFn mallocfn, freeFn freefn, delayMsFn delayfn, getMsFn millisfn);
 void NoteSetFn(mallocFn mallocfn, freeFn freefn, delayMsFn delayfn, getMsFn millisfn);
 void NoteSetFnSerial(serialResetFn resetfn, serialTransmitFn writefn, serialAvailableFn availfn, serialReceiveFn readfn);
-
-#define NOTE_I2C_ADDR_DEFAULT	0x17
-#ifndef NOTE_I2C_MAX_DEFAULT
-#define NOTE_I2C_MAX_DEFAULT	30
-#endif
-#ifndef NOTE_I2C_MAX_MAX
-#define NOTE_I2C_MAX_MAX		127
-#endif
 void NoteSetFnI2C(uint32_t i2caddr, uint32_t i2cmax, i2cResetFn resetfn, i2cTransmitFn transmitfn, i2cReceiveFn receivefn);
 void NoteSetFnDisabled(void);
 void NoteSetI2CAddress(uint32_t i2caddress);
+
+// The Notecard, whose default I2C address is below, uses a serial-to-i2c protocol whose "byte count"
+// must fit into a single byte and which must not include a 2-byte header field.  This is why the
+// maximum that can be transmitted by note-c in a single I2C I/O is 255 - 2 = 253 bytes.
+#define NOTE_I2C_ADDR_DEFAULT	0x17
+#ifndef NOTE_I2C_MAX_MAX
+#define NOTE_I2C_MAX_MAX		253
+#endif
+
+// In ARDUINO implementations, which to date is the largest use of this library, the Wire package
+// is implemented in a broad variety of ways by different vendors.  The default implementation
+// has a mere 32-byte static I2C buffer, which means that the maximum to be transmitted in a
+// single I/O (given our 2-byte serial-to-i2c protocol header) is 30 bytes.  However, if we know
+// the specific platform (such as STM32DUINO) we can relax this restriction
+#if defined(NOTE_I2C_MAX_DEFAULT)
+// user is overriding it at compile time
+#elif defined(ARDUINO_ARCH_STM32)
+// we know that stm32duino dynamically allocates I/O buffer
+#define NOTE_I2C_MAX_DEFAULT NOTE_I2C_MAX_MAX
+#else
+// default to what's known to be safe for all Arduino implementations
+#define NOTE_I2C_MAX_DEFAULT	30
+#endif
 
 // User agent
 J *NoteUserAgent(void);

--- a/note.h
+++ b/note.h
@@ -39,6 +39,7 @@
 
 // In case they're not yet defined
 #include <float.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -140,19 +141,28 @@ void NoteSetFnI2C(uint32_t i2caddr, uint32_t i2cmax, i2cResetFn resetfn, i2cTran
 void NoteSetFnDisabled(void);
 void NoteSetI2CAddress(uint32_t i2caddress);
 
-// The Notecard, whose default I2C address is below, uses a serial-to-i2c protocol whose "byte count"
-// must fit into a single byte and which must not include a 2-byte header field.  This is why the
-// maximum that can be transmitted by note-c in a single I2C I/O is 255 - 2 = 253 bytes.
+// The Notecard, whose default I2C address is below, uses a serial-to-i2c
+// protocol whose "byte count" must fit into a single byte and which must not
+// include a 2-byte header field.  This is why the maximum that can be
+// transmitted by note-c in a single I2C I/O is 255 - 2 = 253 bytes.
 #define NOTE_I2C_ADDR_DEFAULT	0x17
-#ifndef NOTE_I2C_MAX_MAX
-#define NOTE_I2C_MAX_MAX		253
+
+// Serial-to-i2c protocol header size in bytes
+#ifndef NOTE_I2C_HEADER_SIZE
+#define NOTE_I2C_HEADER_SIZE 2
 #endif
 
-// In ARDUINO implementations, which to date is the largest use of this library, the Wire package
-// is implemented in a broad variety of ways by different vendors.  The default implementation
-// has a mere 32-byte static I2C buffer, which means that the maximum to be transmitted in a
-// single I/O (given our 2-byte serial-to-i2c protocol header) is 30 bytes.  However, if we know
-// the specific platform (such as STM32DUINO) we can relax this restriction
+// Maximum bytes capable of being transmitted in a single read/write operation
+#ifndef NOTE_I2C_MAX_MAX
+#define NOTE_I2C_MAX_MAX (UCHAR_MAX - NOTE_I2C_HEADER_SIZE)
+#endif
+
+// In ARDUINO implementations, which to date is the largest use of this library,
+// the Wire package is implemented in a broad variety of ways by different
+// vendors.  The default implementation has a mere 32-byte static I2C buffer,
+// which means that the maximum to be transmitted in a single I/O (given our
+// 2-byte serial-to-i2c protocol header) is 30 bytes.  However, if we know
+// the specific platform (such as STM32DUINO) we can relax this restriction.
 #if defined(NOTE_I2C_MAX_DEFAULT)
 // user is overriding it at compile time
 #elif defined(ARDUINO_ARCH_STM32)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -151,7 +151,7 @@ if(NOTE_C_COVERAGE)
         COMMAND mkdir -p coverage
         # Zero out the coverage counters from any previous runs.
         COMMAND lcov --zerocounters --directory ${NOTE_C_SRC_DIR}
-        COMMAND ${CMAKE_CTEST_COMMAND}
+        COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
         WORKING_DIRECTORY ${CMAKE_CURENT_BINARY_DIR}
     )
     # These files are third party code that we aren't interested in testing

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -137,6 +137,8 @@ add_test(NoteGetTemperature_test)
 add_test(NoteGetContact_test)
 add_test(NoteSetContact_test)
 add_test(NoteDebugSyncStatus_test)
+add_test(crcAdd_test)
+add_test(crcError_test)
 
 if(NOTE_C_COVERAGE)
     find_program(LCOV lcov REQUIRED)

--- a/test/include/test_static.h
+++ b/test/include/test_static.h
@@ -1,10 +1,22 @@
 #pragma once
 
+#include "n_lib.h"
+
 // If we're building the tests, NOTE_C_STATIC is defined to nothing. This allows
 // the tests to access the static functions in note-c. Among other things, this
 // let's us mock these normally static functions.
 #define NOTE_C_STATIC
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Make these normally static functions externally visible if building tests.
 bool timerExpiredSecs(uint32_t *timer, uint32_t periodSecs);
 void setTime(JTIME seconds);
+char *crcAdd(char *json, uint16_t seqno);
+bool crcError(char *json, uint16_t shouldBeSeqno);
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/src/NoteTransaction_test.cpp
+++ b/test/src/NoteTransaction_test.cpp
@@ -17,12 +17,14 @@
 #include "fff.h"
 
 #include "n_lib.h"
+#include "test_static.h"
 
 DEFINE_FFF_GLOBALS
 FAKE_VALUE_FUNC(bool, NoteReset)
 FAKE_VALUE_FUNC(const char *, NoteJSONTransaction, char *, char **)
 FAKE_VALUE_FUNC(bool, NoteTransactionStart, uint32_t)
 FAKE_VALUE_FUNC(J *, NoteUserAgent)
+FAKE_VALUE_FUNC(bool, crcError, char *, uint16_t)
 
 namespace
 {
@@ -53,6 +55,19 @@ const char *NoteJSONTransactionBadJSON(char *, char **resp)
     return NULL;
 }
 
+const char *NoteJSONTransactionIOError(char *, char **resp)
+{
+    static char respString[] = "{\"err\": \"{io}\"}";
+
+    if (resp) {
+        char* respBuf = reinterpret_cast<char *>(malloc(sizeof(respString)));
+        memcpy(respBuf, respString, sizeof(respString));
+        *resp = respBuf;
+    }
+
+    return NULL;
+}
+
 TEST_CASE("NoteTransaction")
 {
     NoteSetFnDefault(malloc, free, NULL, NULL);
@@ -60,11 +75,13 @@ TEST_CASE("NoteTransaction")
     RESET_FAKE(NoteReset);
     RESET_FAKE(NoteJSONTransaction);
     RESET_FAKE(NoteTransactionStart);
+    RESET_FAKE(crcError);
 
     // NoteReset's mock should succeed unless the test explicitly instructs
     // it to fail.
     NoteReset_fake.return_val = true;
     NoteTransactionStart_fake.return_val = true;
+    crcError_fake.return_val = false;
 
     SECTION("Passing a NULL request returns NULL") {
         CHECK(NoteTransaction(NULL) == NULL);
@@ -108,6 +125,35 @@ TEST_CASE("NoteTransaction")
         CHECK(NoteJSONTransaction_fake.call_count >= 1);
 
         // Ensure there's an error in the response.
+        CHECK(resp != NULL);
+        CHECK(NoteResponseError(resp));
+
+        JDelete(req);
+        JDelete(resp);
+    }
+
+    SECTION("Bad CRC") {
+        J *req = NoteNewRequest("note.add");
+        REQUIRE(req != NULL);
+        NoteJSONTransaction_fake.custom_fake = NoteJSONTransactionValid;
+        crcError_fake.return_val = true;
+
+        J *resp = NoteTransaction(req);
+
+        CHECK(resp != NULL);
+        CHECK(NoteResponseError(resp));
+
+        JDelete(req);
+        JDelete(resp);
+    }
+
+    SECTION("I/O error") {
+        J *req = NoteNewRequest("note.add");
+        REQUIRE(req != NULL);
+        NoteJSONTransaction_fake.custom_fake = NoteJSONTransactionIOError;
+
+        J *resp = NoteTransaction(req);
+
         CHECK(resp != NULL);
         CHECK(NoteResponseError(resp));
 

--- a/test/src/NoteTransaction_test.cpp
+++ b/test/src/NoteTransaction_test.cpp
@@ -103,7 +103,10 @@ TEST_CASE("NoteTransaction")
 
         J *resp = NoteTransaction(req);
 
-        CHECK(NoteJSONTransaction_fake.call_count == 1);
+        // Ensure the mock is called at least once
+        // Here the error causes multiple invocations by retries
+        CHECK(NoteJSONTransaction_fake.call_count >= 1);
+
         // Ensure there's an error in the response.
         CHECK(resp != NULL);
         CHECK(NoteResponseError(resp));

--- a/test/src/crcAdd_test.cpp
+++ b/test/src/crcAdd_test.cpp
@@ -1,0 +1,71 @@
+/*!
+ * @file crcAdd_test.cpp
+ *
+ * Written by the Blues Inc. team.
+ *
+ * Copyright (c) 2023 Blues Inc. MIT License. Use of this source code is
+ * governed by licenses granted by the copyright holder including that found in
+ * the
+ * <a href="https://github.com/blues/note-c/blob/master/LICENSE">LICENSE</a>
+ * file.
+ *
+ */
+
+#ifdef NOTE_C_TEST
+
+#include <catch2/catch_test_macros.hpp>
+#include "fff.h"
+
+#include "n_lib.h"
+#include "test_static.h"
+
+DEFINE_FFF_GLOBALS
+FAKE_VALUE_FUNC(void *, NoteMalloc, size_t)
+
+namespace
+{
+
+TEST_CASE("crcAdd")
+{
+    NoteSetFnDefault(malloc, free, NULL, NULL);
+
+    RESET_FAKE(NoteMalloc);
+
+    char validReq[] = "{\"req\": \"hub.sync\"}";
+    uint16_t seqNo = 1;
+
+    SECTION("NoteMalloc fails") {
+        NoteMalloc_fake.return_val = NULL;
+
+        CHECK(crcAdd(validReq, seqNo) == NULL);
+    }
+
+    SECTION("NoteMalloc succeeds") {
+        NoteMalloc_fake.custom_fake = malloc;
+
+        char emptyStringReq[] = "";
+        char invalidJsonReq[] = "{\"req\":";
+
+        SECTION("Empty string") {
+            CHECK(crcAdd(emptyStringReq, seqNo) == NULL);
+        }
+
+        SECTION("Invalid JSON") {
+            CHECK(crcAdd(invalidJsonReq, seqNo) == NULL);
+        }
+
+        SECTION("Valid JSON") {
+            const char expectedNewJson[] = "{\"req\": \"hub.sync\",\"crc\":\"0001:DF2B9115\"}";
+            char *newJson = crcAdd(validReq, seqNo);
+
+            REQUIRE(newJson != NULL);
+            CHECK(strcmp(expectedNewJson, newJson) == 0);
+
+            NoteFree(newJson);
+        }
+    }
+}
+
+}
+
+#endif // TEST

--- a/test/src/crcError_test.cpp
+++ b/test/src/crcError_test.cpp
@@ -1,0 +1,81 @@
+/*!
+ * @file crcError_test.cpp
+ *
+ * Written by the Blues Inc. team.
+ *
+ * Copyright (c) 2023 Blues Inc. MIT License. Use of this source code is
+ * governed by licenses granted by the copyright holder including that found in
+ * the
+ * <a href="https://github.com/blues/note-c/blob/master/LICENSE">LICENSE</a>
+ * file.
+ *
+ */
+
+#ifdef NOTE_C_TEST
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "test_static.h"
+
+namespace
+{
+
+TEST_CASE("crcError")
+{
+    NoteSetFnDefault(malloc, free, NULL, NULL);
+
+    uint16_t seqNo = 1;
+
+    SECTION("Empty string") {
+        char json[] = "";
+
+        CHECK(!crcError(json, seqNo));
+    }
+
+    SECTION("Invalid JSON") {
+        char json[] = "{\"req\":";
+
+        CHECK(!crcError(json, seqNo));
+    }
+
+    SECTION("No CRC field") {
+        char json[] = "{\"req\": \"hub.sync\"}";
+
+        CHECK(!crcError(json, seqNo));
+    }
+
+    SECTION("CRC field at unexpected position") {
+        char json[] = "{\"crc\":\"0009:10BAC79A\",\"req\": \"hub.sync\"}";
+
+        CHECK(!crcError(json, seqNo));
+    }
+
+    SECTION("Valid JSON and CRC field present") {
+
+        SECTION("CRC doesn't match") {
+            char json[] = "{\"req\":\"hub.sync\",\"crc\":\"0001:DEADBEEF\"}";
+
+            CHECK(crcError(json, seqNo));
+        }
+
+        SECTION("Sequence number doesn't match") {
+            char json[] = "{\"req\":\"hub.sync\",\"crc\":\"0009:10BAC79A\"}";
+
+            CHECK(crcError(json, seqNo));
+        }
+
+        SECTION("Everything matches") {
+            char json[] = "{\"req\":\"hub.sync\"}";
+            char *jsonWithCrc = crcAdd(json, seqNo);
+            REQUIRE(jsonWithCrc != NULL);
+
+            CHECK(!crcError(jsonWithCrc, seqNo));
+
+            NoteFree(jsonWithCrc);
+        }
+    }
+}
+
+}
+
+#endif // TEST


### PR DESCRIPTION
The feature, which works only for 'requests' and not 'commands', works like this:
- every request's JSON is tagged with an additional field "crc" containing a sequence number and crc32 of the request
- notecard firmware prior to the new firmware ignores the extra json field
- the new firmware, as it sees this field, verifies the crc and sends an {io} error response back to the host if it doesn't match
- if the crc is present AND it matches, the firmware then attaches an analogous crc to the response back to note-c, containing the exact same sequence number that it received on the request
- note-c, when it receives the response, verifies this crc
- in note-c, if the sequence number is ever unexpected or the crc mismatches or it gets an {io} error, it automatically retries up to 10 times

Net-net, this should increase the robustness of host/notecard requests with no real downside. 