### PR TITLE
Add additional crcError testing.

### DIFF
--- a/test/src/crcError_test.cpp
+++ b/test/src/crcError_test.cpp
@@ -73,6 +73,13 @@ TEST_CASE("crcError")
 
             NoteFree(jsonWithCrc);
         }
+
+        SECTION("Trailing CRLF") {
+            char json[] = "{\"req\":\"hub.sync\",\"crc\":\"0001:10BAC79A\"}\r\n";
+
+            // Trailing \r\n should be ignored.
+            CHECK(!crcError(json, seqNo));
+        }
     }
 }
 


### PR DESCRIPTION
Specifically, add a test that makes sure \r\n is stripped properly.