### PR TITLE
Zak mem drain

### DIFF
--- a/n_helpers.c
+++ b/n_helpers.c
@@ -396,6 +396,9 @@ const char * NoteBinaryStoreReceive(uint8_t *buffer, uint32_t bufLen,
 
     // Ensure transaction was successful
     if (err) {
+        // Reset when a problem is detected, otherwise `note-c`
+        // will attempt to allocate memory to receive the response.
+        _Reset();
         return ERRSTR(err, c_err);
     }
 
@@ -403,6 +406,9 @@ const char * NoteBinaryStoreReceive(uint8_t *buffer, uint32_t bufLen,
     if (available) {
         const char *err = ERRSTR("unexpected data available", c_err);
         NOTE_C_LOG_ERROR(err);
+        // Reset when a problem is detected, otherwise `note-c`
+        // will attempt to allocate memory to receive the response.
+        _Reset();
         return err;
     }
 
@@ -418,6 +424,9 @@ const char * NoteBinaryStoreReceive(uint8_t *buffer, uint32_t bufLen,
     if (decodedLen != decLen) {
         const char *err = ERRSTR("length mismatch after decoding", c_err);
         NOTE_C_LOG_ERROR(err);
+        // Reset when a problem is detected, otherwise `note-c`
+        // will attempt to allocate memory to receive the response.
+        _Reset();
         return err;
     }
 

--- a/n_i2c.c
+++ b/n_i2c.c
@@ -258,7 +258,7 @@ bool i2cNoteReset()
         bool nonControlCharFound = false;
 
         // Read I2C data for at least `CARD_RESET_DRAIN_MS` continuously
-        for (const size_t startMs = _GetMs() ; (_GetMs() - startMs) < CARD_RESET_DRAIN_MS ;) {
+        for (size_t startMs = _GetMs() ; (_GetMs() - startMs) < CARD_RESET_DRAIN_MS ;) {
 
             // Read the next chunk of available data
             uint32_t available = 0;
@@ -281,11 +281,13 @@ bool i2cNoteReset()
                 somethingFound = true;
                 // The Notecard responds to a bare `\n` with `\r\n`. If we get
                 // any other characters back, it means the host and Notecard
-                // aren't synced up yet, and we need to transmit `\n` again.
+                // aren't synced up yet and we need to transmit `\n` again.
                 for (size_t i = 0; i < chunkLen ; ++i) {
                     char ch = buffer[i];
                     if (ch != '\n' && ch != '\r') {
                         nonControlCharFound = true;
+                        // Reset the timer with each non-control character
+                        startMs = _GetMs();
                     }
                 }
             }

--- a/n_serial.c
+++ b/n_serial.c
@@ -162,7 +162,7 @@ bool serialNoteReset()
                 somethingFound = true;
                 // The Notecard responds to a bare `\n` with `\r\n`. If we get
                 // any other characters back, it means the host and Notecard
-                // aren't synced up yet, and we need to transmit `\n` again.
+                // aren't synced up yet and we need to transmit `\n` again.
                 char ch = _SerialReceive();
                 if (ch != '\n' && ch != '\r') {
                     nonControlCharFound = true;


### PR DESCRIPTION
ensure reset will consume all available bytes,
    regardless of the amount. Previously, the 5-second
    timeout would prevent reset from consuming large
    outstanding, binary data payloads.