### PR TITLE
Add a scripts/git_hooks directory with a pre-push hook.

### DIFF
--- a/scripts/git_hooks/pre-push
+++ b/scripts/git_hooks/pre-push
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+PRE_PUSH_HOOK_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+NOTE_C_DIR=$PRE_PUSH_HOOK_DIR/../..
+SCRIPTS_DIR=$NOTE_C_DIR/scripts
+
+$SCRIPTS_DIR/run_astyle.sh
+if [ $? -ne 0 ]; then
+    echo "run_astyle.sh failed."
+    exit 1
+fi
+
+$SCRIPTS_DIR/run_doxygen.sh
+if [ $? -ne 0 ]; then
+    echo "run_doxygen.sh failed."
+    exit 1
+fi
+
+$SCRIPTS_DIR/run_unit_tests.sh
+if [ $? -ne 0 ]; then
+    echo "run_unit_tests.sh failed."
+    exit 1
+fi

--- a/scripts/run_astyle.sh
+++ b/scripts/run_astyle.sh
@@ -17,8 +17,8 @@ EXCLUDE_FILES=(
     test/include/fff.h
 )
 
-if [[ `git status --porcelain --untracked=no` ]]; then
-    echo "Local changes detected. Please commit, stash, or discard any working tree changes prior to running this script."
+if [[ `git diff` ]]; then
+    echo "Local unstaged changes detected. Please stage, commit, stash, or discard any changes prior to running this script."
     exit 1
 fi
 
@@ -33,7 +33,7 @@ done
 
 # If there are new formatting changes after running astyle, exit with a non-zero
 # value.
-if [[ `git status --porcelain --untracked=no` ]]; then
+if [[ `git diff` ]]; then
     echo "New formatting changes left in working tree."
     exit 1
 else


### PR DESCRIPTION
Developers can install these hook in .git/hooks/ in their local note-c repo. The pre-push hook runs the unit tests (without valgrind, because it's slow), builds the Doxygen docs, and runs astyle. If any of those fail, the hook fails, and the push won't go through. This should save us some churn on CI builds on GitHub.