### PR TITLE
Fix JNtoA in the case where the number won't fit in the provided buffer.

### DIFF
--- a/n_ftoa.c
+++ b/n_ftoa.c
@@ -63,7 +63,8 @@ char * JNtoA(JNUMBER f, char * buf, int precision)
     }
     fmtflt(buf, &len, JNTOA_MAX, f, -1, precision, flags, &overflow);
     if (overflow) {
-        strcpy(buf, "*");
+        len = 0;
+        buf[len++] = '0';
     }
     buf[len] = '\0';
     return buf;


### PR DESCRIPTION
Prior to this commit, we'd get some invalid JSON back in this case. Now we'll get 0 back.