### PR TITLE
Standardize private function naming.

### DIFF
--- a/n_helpers.c
+++ b/n_helpers.c
@@ -82,7 +82,7 @@ static const char *daynames[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
 // Forwards
 NOTE_C_STATIC void setTime(JTIME seconds);
 NOTE_C_STATIC bool timerExpiredSecs(uint32_t *timer, uint32_t periodSecs);
-NOTE_C_STATIC int ytodays(int year);
+NOTE_C_STATIC int yToDays(int year);
 
 static const char NOTE_C_BINARY_EOP = '\n';
 
@@ -823,7 +823,7 @@ bool NotePrint(const char *text)
 {
     bool success = false;
 
-    if (NoteIsDebugOutputActive()) {
+    if (noteIsDebugOutputActive()) {
         NoteDebug(text);
         return true;
     }
@@ -1042,7 +1042,7 @@ bool NoteLocalTimeST(uint16_t *retYear, uint8_t *retMonth, uint8_t *retDay,
     if (retWeekday != NULL) {
         *retWeekday = (char *) daynames[(days + 1) % 7];
     }
-    for (year = days / 365; days < (i = ytodays(year) + 365L * year); ) {
+    for (year = days / 365; days < (i = yToDays(year) + 365L * year); ) {
         --year;
     }
     days -= i;
@@ -1091,7 +1091,7 @@ bool NoteLocalTimeST(uint16_t *retYear, uint8_t *retMonth, uint8_t *retDay,
 }
 
 // Figure out how many days at start of the year
-NOTE_C_STATIC int ytodays(int year)
+NOTE_C_STATIC int yToDays(int year)
 {
     int days = 0;
     if (0 < year) {

--- a/n_hooks.c
+++ b/n_hooks.c
@@ -246,7 +246,7 @@ void NoteSetFnDebugOutput(debugOutputFn fn)
   provided.
 */
 /**************************************************************************/
-bool NoteIsDebugOutputActive(void)
+bool noteIsDebugOutputActive(void)
 {
     return hookDebugOutput != NULL;
 }
@@ -607,7 +607,7 @@ void NoteUnlockI2C(void)
   @brief  Lock the Notecard using the platform-specific hook.
 */
 /**************************************************************************/
-void NoteLockNote(void)
+void noteLockNote(void)
 {
     if (hookLockNote != NULL) {
         hookLockNote();
@@ -619,7 +619,7 @@ void NoteLockNote(void)
   @brief  Unlock the Notecard using the platform-specific hook.
 */
 /**************************************************************************/
-void NoteUnlockNote(void)
+void noteUnlockNote(void)
 {
     if (hookUnlockNote != NULL) {
         hookUnlockNote();
@@ -631,7 +631,7 @@ void NoteUnlockNote(void)
   @brief  Indicate that we're initiating a transaction using the platform-specific hook.
 */
 /**************************************************************************/
-bool NoteTransactionStart(uint32_t timeoutMs)
+bool noteTransactionStart(uint32_t timeoutMs)
 {
     if (hookTransactionStart != NULL) {
         return hookTransactionStart(timeoutMs);
@@ -644,7 +644,7 @@ bool NoteTransactionStart(uint32_t timeoutMs)
   @brief  Indicate that we've completed a transaction using the platform-specific hook.
 */
 /**************************************************************************/
-void NoteTransactionStop(void)
+void noteTransactionStop(void)
 {
     if (hookTransactionStop != NULL) {
         hookTransactionStop();
@@ -657,7 +657,7 @@ void NoteTransactionStop(void)
   @returns A string
 */
 /**************************************************************************/
-const char *NoteActiveInterface(void)
+const char *noteActiveInterface(void)
 {
     switch (hookActiveInterface) {
     case interfaceSerial:
@@ -674,7 +674,7 @@ const char *NoteActiveInterface(void)
   @returns A boolean indicating whether the Serial bus was reset successfully.
 */
 /**************************************************************************/
-bool NoteSerialReset(void)
+bool noteSerialReset(void)
 {
     if (hookActiveInterface == interfaceSerial && hookSerialReset != NULL) {
         return hookSerialReset();
@@ -690,7 +690,7 @@ bool NoteSerialReset(void)
   @param   flush `true` to flush the bytes upon transmit.
 */
 /**************************************************************************/
-void NoteSerialTransmit(uint8_t *text, size_t len, bool flush)
+void noteSerialTransmit(uint8_t *text, size_t len, bool flush)
 {
     if (hookActiveInterface == interfaceSerial && hookSerialTransmit != NULL) {
         hookSerialTransmit(text, len, flush);
@@ -704,7 +704,7 @@ void NoteSerialTransmit(uint8_t *text, size_t len, bool flush)
   @returns A boolean indicating whether the Serial bus is available to read.
 */
 /**************************************************************************/
-bool NoteSerialAvailable(void)
+bool noteSerialAvailable(void)
 {
     if (hookActiveInterface == interfaceSerial && hookSerialAvailable != NULL) {
         return hookSerialAvailable();
@@ -719,7 +719,7 @@ bool NoteSerialAvailable(void)
   @returns A character from the Serial bus.
 */
 /**************************************************************************/
-char NoteSerialReceive(void)
+char noteSerialReceive(void)
 {
     if (hookActiveInterface == interfaceSerial && hookSerialReceive != NULL) {
         return hookSerialReceive();
@@ -733,7 +733,7 @@ char NoteSerialReceive(void)
   @returns A boolean indicating whether the I2C bus was reset successfully.
 */
 /**************************************************************************/
-bool NoteI2CReset(uint16_t DevAddress)
+bool noteI2CReset(uint16_t DevAddress)
 {
     if (hookActiveInterface == interfaceI2C && hookI2CReset != NULL) {
         return hookI2CReset(DevAddress);
@@ -751,7 +751,7 @@ bool NoteI2CReset(uint16_t DevAddress)
   if the bus is not active.
 */
 /**************************************************************************/
-const char *NoteI2CTransmit(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size)
+const char *noteI2CTransmit(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size)
 {
     if (hookActiveInterface == interfaceI2C && hookI2CTransmit != NULL) {
         return hookI2CTransmit(DevAddress, pBuffer, Size);
@@ -770,7 +770,7 @@ const char *NoteI2CTransmit(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size
   if the bus is not active.
 */
 /**************************************************************************/
-const char *NoteI2CReceive(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size, uint32_t *available)
+const char *noteI2CReceive(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size, uint32_t *available)
 {
     if (hookActiveInterface == interfaceI2C && hookI2CReceive != NULL) {
         return hookI2CReceive(DevAddress, pBuffer, Size, available);
@@ -832,7 +832,7 @@ uint32_t NoteI2CMax(void)
   @returns A boolean indicating whether the Notecard has been reset successfully.
 */
 /**************************************************************************/
-bool NoteHardReset(void)
+bool noteHardReset(void)
 {
     if (notecardReset == NULL) {
         return true;
@@ -859,7 +859,7 @@ bool NoteHardReset(void)
   or the hook has not been set.
 */
 /**************************************************************************/
-const char *NoteJSONTransaction(const char *request, size_t reqLen, char **response, size_t timeoutMs)
+const char *noteJSONTransaction(const char *request, size_t reqLen, char **response, size_t timeoutMs)
 {
     if (notecardTransaction == NULL || hookActiveInterface == interfaceNone) {
         return "i2c or serial interface must be selected";
@@ -885,7 +885,7 @@ const char *NoteJSONTransaction(const char *request, size_t reqLen, char **respo
   @returns  A c-string with an error, or `NULL` if no error ocurred.
 */
 /**************************************************************************/
-const char *NoteChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay,
+const char *noteChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay,
                                size_t timeoutMs, uint32_t *available)
 {
     if (notecardChunkedReceive == NULL || hookActiveInterface == interfaceNone) {
@@ -904,7 +904,7 @@ const char *NoteChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay,
   @returns  A c-string with an error, or `NULL` if no error ocurred.
 */
 /**************************************************************************/
-const char *NoteChunkedTransmit(uint8_t *buffer, uint32_t size, bool delay)
+const char *noteChunkedTransmit(uint8_t *buffer, uint32_t size, bool delay)
 {
     if (notecardChunkedTransmit == NULL || hookActiveInterface == interfaceNone) {
         return "i2c or serial interface must be selected";

--- a/n_lib.h
+++ b/n_lib.h
@@ -112,23 +112,23 @@ const char *serialChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay, si
 const char *serialChunkedTransmit(uint8_t *buffer, uint32_t size, bool delay);
 
 // Hooks
-void NoteLockNote(void);
-void NoteUnlockNote(void);
-bool NoteTransactionStart(uint32_t timeoutMs);
-void NoteTransactionStop(void);
-const char *NoteActiveInterface(void);
-bool NoteSerialReset(void);
-void NoteSerialTransmit(uint8_t *, size_t, bool);
-bool NoteSerialAvailable(void);
-char NoteSerialReceive(void);
-bool NoteI2CReset(uint16_t DevAddress);
-const char *NoteI2CTransmit(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size);
-const char *NoteI2CReceive(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size, uint32_t *avail);
-bool NoteHardReset(void);
-const char *NoteJSONTransaction(const char *request, size_t reqLen, char **response, size_t timeoutMs);
-const char *NoteChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay, size_t timeoutMs, uint32_t *available);
-const char *NoteChunkedTransmit(uint8_t *buffer, uint32_t size, bool delay);
-bool NoteIsDebugOutputActive(void);
+void noteLockNote(void);
+void noteUnlockNote(void);
+bool noteTransactionStart(uint32_t timeoutMs);
+void noteTransactionStop(void);
+const char *noteActiveInterface(void);
+bool noteSerialReset(void);
+void noteSerialTransmit(uint8_t *, size_t, bool);
+bool noteSerialAvailable(void);
+char noteSerialReceive(void);
+bool noteI2CReset(uint16_t DevAddress);
+const char *noteI2CTransmit(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size);
+const char *noteI2CReceive(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size, uint32_t *avail);
+bool noteHardReset(void);
+const char *noteJSONTransaction(const char *request, size_t reqLen, char **response, size_t timeoutMs);
+const char *noteChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay, size_t timeoutMs, uint32_t *available);
+const char *noteChunkedTransmit(uint8_t *buffer, uint32_t size, bool delay);
+bool noteIsDebugOutputActive(void);
 
 // Utilities
 void n_htoa32(uint32_t n, char *p);
@@ -190,21 +190,21 @@ extern const char *c_badbinerr;
 
 // Readability wrappers.  Anything starting with _ is simply calling the wrapper
 // function.
-#define _LockNote NoteLockNote
-#define _UnlockNote NoteUnlockNote
-#define _TransactionStart NoteTransactionStart
-#define _TransactionStop NoteTransactionStop
-#define _SerialReset NoteSerialReset
-#define _SerialTransmit NoteSerialTransmit
-#define _SerialAvailable NoteSerialAvailable
-#define _SerialReceive NoteSerialReceive
-#define _I2CReset NoteI2CReset
-#define _I2CTransmit NoteI2CTransmit
-#define _I2CReceive NoteI2CReceive
-#define _Reset NoteHardReset
-#define _Transaction NoteJSONTransaction
-#define _ChunkedReceive NoteChunkedReceive
-#define _ChunkedTransmit NoteChunkedTransmit
+#define _LockNote noteLockNote
+#define _UnlockNote noteUnlockNote
+#define _TransactionStart noteTransactionStart
+#define _TransactionStop noteTransactionStop
+#define _SerialReset noteSerialReset
+#define _SerialTransmit noteSerialTransmit
+#define _SerialAvailable noteSerialAvailable
+#define _SerialReceive noteSerialReceive
+#define _I2CReset noteI2CReset
+#define _I2CTransmit noteI2CTransmit
+#define _I2CReceive noteI2CReceive
+#define _Reset noteHardReset
+#define _Transaction noteJSONTransaction
+#define _ChunkedReceive noteChunkedReceive
+#define _ChunkedTransmit noteChunkedTransmit
 #define _Malloc NoteMalloc
 #define _Free NoteFree
 #define _GetMs NoteGetMs

--- a/n_ua.c
+++ b/n_ua.c
@@ -129,7 +129,7 @@ __attribute__((weak)) J *NoteUserAgent()
 
     JAddStringToObject(ua, "agent", n_agent);
     JAddStringToObject(ua, "compiler", compiler);
-    JAddStringToObject(ua, "req_interface", NoteActiveInterface());
+    JAddStringToObject(ua, "req_interface", noteActiveInterface());
 
     // Add CPU Details
     if (n_cpu_cores != 0) {

--- a/test/src/NoteBinaryStoreReceive_test.cpp
+++ b/test/src/NoteBinaryStoreReceive_test.cpp
@@ -24,10 +24,10 @@ FAKE_VALUE_FUNC(uint32_t, NoteBinaryCodecDecode, const uint8_t *, uint32_t, uint
                 uint32_t)
 FAKE_VALUE_FUNC(const char *, NoteBinaryStoreEncodedLength, uint32_t *)
 FAKE_VALUE_FUNC(J *, noteTransactionShouldLock, J *, bool)
-FAKE_VALUE_FUNC(const char *, NoteChunkedReceive, uint8_t *, uint32_t *, bool,
+FAKE_VALUE_FUNC(const char *, noteChunkedReceive, uint8_t *, uint32_t *, bool,
                 size_t, uint32_t *)
-FAKE_VOID_FUNC(NoteLockNote)
-FAKE_VOID_FUNC(NoteUnlockNote)
+FAKE_VOID_FUNC(noteLockNote)
+FAKE_VOID_FUNC(noteUnlockNote)
 
 // Most of these variables have to be global because they're accessed in
 // lambda functions used as fakes for various note-c functions. They can't be
@@ -127,22 +127,22 @@ SCENARIO("NoteBinaryStoreReceive")
         }
     }
 
-    GIVEN("NoteChunkedReceive returns an error") {
-        NoteChunkedReceive_fake.return_val = "some error";
+    GIVEN("noteChunkedReceive returns an error") {
+        noteChunkedReceive_fake.return_val = "some error";
 
         WHEN("NoteBinaryStoreReceive is called") {
             const char *err = NoteBinaryStoreReceive(buf, bufLen, decodedOffset, decodedLen);
 
-            REQUIRE(NoteChunkedReceive_fake.call_count > 0);
+            REQUIRE(noteChunkedReceive_fake.call_count > 0);
             THEN("An error is returned") {
                 CHECK(err != NULL);
             }
         }
     }
 
-    GIVEN("NoteChunkedReceive indicates there's unexpectedly more data "
+    GIVEN("noteChunkedReceive indicates there's unexpectedly more data "
           "available") {
-        NoteChunkedReceive_fake.custom_fake = [](uint8_t *, uint32_t *, bool,
+        noteChunkedReceive_fake.custom_fake = [](uint8_t *, uint32_t *, bool,
         size_t, uint32_t *available) -> const char* {
             *available = 1;
 
@@ -152,7 +152,7 @@ SCENARIO("NoteBinaryStoreReceive")
         WHEN("NoteBinaryStoreReceive is called") {
             const char *err = NoteBinaryStoreReceive(buf, bufLen, decodedOffset, decodedLen);
 
-            REQUIRE(NoteChunkedReceive_fake.call_count > 0);
+            REQUIRE(noteChunkedReceive_fake.call_count > 0);
             THEN("An error is returned") {
                 CHECK(err != NULL);
             }
@@ -163,7 +163,7 @@ SCENARIO("NoteBinaryStoreReceive")
         NoteBinaryCodecDecode_fake.custom_fake = [](const uint8_t *encData, uint32_t encDataLen, uint8_t *decBuf, uint32_t) -> uint32_t {
             return cobsDecode((uint8_t *)encData, encDataLen, '\n', decBuf);
         };
-        NoteChunkedReceive_fake.custom_fake = [](uint8_t *buffer, uint32_t *size,
+        noteChunkedReceive_fake.custom_fake = [](uint8_t *buffer, uint32_t *size,
         bool, size_t, uint32_t *available) -> const char* {
             uint32_t outLen = NoteBinaryCodecEncode((uint8_t *)rawMsg, rawMsgLen, buffer, *size);
 
@@ -186,7 +186,7 @@ SCENARIO("NoteBinaryStoreReceive")
             WHEN("NoteBinaryStoreReceive is called") {
                 const char *err = NoteBinaryStoreReceive(buf, bufLen, decodedOffset, decodedLen);
 
-                REQUIRE(NoteChunkedReceive_fake.call_count > 0);
+                REQUIRE(noteChunkedReceive_fake.call_count > 0);
                 REQUIRE(noteTransactionShouldLock_fake.call_count > 0);
                 THEN("An error is returned") {
                     CHECK(err != NULL);
@@ -203,7 +203,7 @@ SCENARIO("NoteBinaryStoreReceive")
             WHEN("NoteBinaryStoreReceive is called") {
                 const char *err = NoteBinaryStoreReceive(buf, bufLen, decodedOffset, decodedLen);
 
-                REQUIRE(NoteChunkedReceive_fake.call_count > 0);
+                REQUIRE(noteChunkedReceive_fake.call_count > 0);
                 REQUIRE(noteTransactionShouldLock_fake.call_count > 0);
                 THEN("An error is returned") {
                     CHECK(err != NULL);
@@ -216,7 +216,7 @@ SCENARIO("NoteBinaryStoreReceive")
                 uint32_t decodedLen = rawMsgLen;
                 const char *err = NoteBinaryStoreReceive(buf, bufLen, decodedOffset, decodedLen);
 
-                REQUIRE(NoteChunkedReceive_fake.call_count > 0);
+                REQUIRE(noteChunkedReceive_fake.call_count > 0);
                 THEN("No error is returned") {
                     CHECK(err == NULL);
                 }
@@ -229,15 +229,15 @@ SCENARIO("NoteBinaryStoreReceive")
         }
     }
 
-    CHECK(NoteLockNote_fake.call_count == NoteUnlockNote_fake.call_count);
+    CHECK(noteLockNote_fake.call_count == noteUnlockNote_fake.call_count);
 
     RESET_FAKE(noteTransactionShouldLock);
     RESET_FAKE(NoteBinaryCodecDecode);
     RESET_FAKE(NoteBinaryStoreEncodedLength);
-    RESET_FAKE(NoteChunkedReceive);
-    RESET_FAKE(NoteLockNote);
+    RESET_FAKE(noteChunkedReceive);
+    RESET_FAKE(noteLockNote);
     RESET_FAKE(NoteNewRequest);
-    RESET_FAKE(NoteUnlockNote);
+    RESET_FAKE(noteUnlockNote);
 }
 
 }

--- a/test/src/NoteBinaryStoreTransmit_test.cpp
+++ b/test/src/NoteBinaryStoreTransmit_test.cpp
@@ -22,9 +22,9 @@ DEFINE_FFF_GLOBALS
 FAKE_VALUE_FUNC(J *, NoteNewRequest, const char *)
 FAKE_VALUE_FUNC(J *, NoteRequestResponse, J *)
 FAKE_VALUE_FUNC(J *, noteTransactionShouldLock, J *, bool)
-FAKE_VALUE_FUNC(const char *, NoteChunkedTransmit, uint8_t *, uint32_t, bool)
-FAKE_VOID_FUNC(NoteLockNote)
-FAKE_VOID_FUNC(NoteUnlockNote)
+FAKE_VALUE_FUNC(const char *, noteChunkedTransmit, uint8_t *, uint32_t, bool)
+FAKE_VOID_FUNC(noteLockNote)
+FAKE_VOID_FUNC(noteUnlockNote)
 
 uint8_t buf[32] = {0xDE, 0xAD, 0xBE, 0xEF};
 uint32_t dataLen = 4;
@@ -247,11 +247,11 @@ SCENARIO("NoteBinaryStoreTransmit")
             }
         }
 
-        AND_GIVEN("NoteChunkedTransmit fails") {
+        AND_GIVEN("noteChunkedTransmit fails") {
             noteTransactionShouldLock_fake.custom_fake = [](J *req, bool) -> J * {
                 return JCreateObject();
             };
-            NoteChunkedTransmit_fake.return_val = "some error";
+            noteChunkedTransmit_fake.return_val = "some error";
 
             WHEN("NoteBinaryStoreTransmit is called") {
                 const char *err = NoteBinaryStoreTransmit(buf, dataLen, bufLen, 0);
@@ -271,7 +271,7 @@ SCENARIO("NoteBinaryStoreTransmit")
             noteTransactionShouldLock_fake.custom_fake = [](J *req, bool) -> J * {
                 return JCreateObject();
             };
-            NoteChunkedTransmit_fake.return_val = NULL;
+            noteChunkedTransmit_fake.return_val = NULL;
 
             auto initial = [](J *req) -> J * {
                 JDelete(req);
@@ -392,14 +392,14 @@ SCENARIO("NoteBinaryStoreTransmit")
         }
     }
 
-    CHECK(NoteLockNote_fake.call_count == NoteUnlockNote_fake.call_count);
+    CHECK(noteLockNote_fake.call_count == noteUnlockNote_fake.call_count);
 
     RESET_FAKE(NoteNewRequest);
     RESET_FAKE(NoteRequestResponse);
     RESET_FAKE(noteTransactionShouldLock);
-    RESET_FAKE(NoteChunkedTransmit);
-    RESET_FAKE(NoteLockNote);
-    RESET_FAKE(NoteUnlockNote);
+    RESET_FAKE(noteChunkedTransmit);
+    RESET_FAKE(noteLockNote);
+    RESET_FAKE(noteUnlockNote);
 }
 
 }

--- a/test/src/NoteDebug_test.cpp
+++ b/test/src/NoteDebug_test.cpp
@@ -47,7 +47,7 @@ SCENARIO("NoteDebug")
     memset(&state, 0, sizeof(state));
 
     SECTION("Hook not set") {
-        CHECK(!NoteIsDebugOutputActive());
+        CHECK(!noteIsDebugOutputActive());
 
         NoteDebug(NULL);
         CHECK(!state.debugOutputCalled);
@@ -57,7 +57,7 @@ SCENARIO("NoteDebug")
         NoteSetFnDebugOutput(MyDebugOutput);
 
         SECTION("Active") {
-            CHECK(NoteIsDebugOutputActive());
+            CHECK(noteIsDebugOutputActive());
         }
 
         SECTION("Hook called") {

--- a/test/src/NotePrint_test.cpp
+++ b/test/src/NotePrint_test.cpp
@@ -19,7 +19,7 @@
 #include "n_lib.h"
 
 DEFINE_FFF_GLOBALS
-FAKE_VALUE_FUNC(bool, NoteIsDebugOutputActive)
+FAKE_VALUE_FUNC(bool, noteIsDebugOutputActive)
 FAKE_VALUE_FUNC(J *, NoteNewRequest, const char *)
 FAKE_VALUE_FUNC(bool, NoteRequest, J *)
 FAKE_VOID_FUNC(NoteDebug, const char *)
@@ -34,14 +34,14 @@ SCENARIO("NotePrint")
     const char msg[] = "Hello world!";
 
     SECTION("Debug") {
-        NoteIsDebugOutputActive_fake.return_val = true;
+        noteIsDebugOutputActive_fake.return_val = true;
 
         CHECK(NotePrint(msg));
         CHECK(NoteDebug_fake.call_count > 0);
     }
 
     SECTION("card.log") {
-        NoteIsDebugOutputActive_fake.return_val = false;
+        noteIsDebugOutputActive_fake.return_val = false;
 
         SECTION("NoteNewRequest fails") {
             NoteNewRequest_fake.return_val = NULL;
@@ -75,7 +75,7 @@ SCENARIO("NotePrint")
 
     }
 
-    RESET_FAKE(NoteIsDebugOutputActive);
+    RESET_FAKE(noteIsDebugOutputActive);
     RESET_FAKE(NoteNewRequest);
     RESET_FAKE(NoteRequest);
     RESET_FAKE(NoteDebug);

--- a/test/src/NoteRequestResponseJSON_test.cpp
+++ b/test/src/NoteRequestResponseJSON_test.cpp
@@ -19,11 +19,11 @@
 #include "n_lib.h"
 
 DEFINE_FFF_GLOBALS
-FAKE_VALUE_FUNC(bool, NoteTransactionStart, uint32_t)
-FAKE_VOID_FUNC(NoteTransactionStop)
-FAKE_VOID_FUNC(NoteLockNote)
-FAKE_VOID_FUNC(NoteUnlockNote)
-FAKE_VALUE_FUNC(const char *, NoteJSONTransaction, const char *, size_t, char **, size_t)
+FAKE_VALUE_FUNC(bool, noteTransactionStart, uint32_t)
+FAKE_VOID_FUNC(noteTransactionStop)
+FAKE_VOID_FUNC(noteLockNote)
+FAKE_VOID_FUNC(noteUnlockNote)
+FAKE_VALUE_FUNC(const char *, noteJSONTransaction, const char *, size_t, char **, size_t)
 
 namespace
 {
@@ -32,7 +32,7 @@ SCENARIO("NoteRequestResponseJSON")
 {
     NoteSetFnDefault(malloc, free, NULL, NULL);
 
-    NoteTransactionStart_fake.return_val = true;
+    noteTransactionStart_fake.return_val = true;
 
     GIVEN("The request is NULL") {
         WHEN("NoteRequestResponseJSON is called") {
@@ -50,10 +50,10 @@ SCENARIO("NoteRequestResponseJSON")
         WHEN("NoteRequestResponseJSON is called") {
             char *rsp = NoteRequestResponseJSON(req);
 
-            THEN("NoteJSONTransaction is called with NULL for the response "
+            THEN("noteJSONTransaction is called with NULL for the response "
                  "parameter") {
-                REQUIRE(NoteJSONTransaction_fake.call_count > 0);
-                CHECK(NoteJSONTransaction_fake.arg2_history[0] == NULL);
+                REQUIRE(noteJSONTransaction_fake.call_count > 0);
+                CHECK(noteJSONTransaction_fake.arg2_history[0] == NULL);
             }
         }
     }
@@ -70,18 +70,18 @@ SCENARIO("NoteRequestResponseJSON")
         WHEN("NoteRequestResponseJSON is called") {
             char *rsp = NoteRequestResponseJSON(req);
 
-            THEN("NoteJSONTransaction is called once for each command") {
-                CHECK(NoteJSONTransaction_fake.call_count == command_count);
+            THEN("noteJSONTransaction is called once for each command") {
+                CHECK(noteJSONTransaction_fake.call_count == command_count);
             }
 
-            THEN("NoteJSONTransaction is called with the correct pointer and "
+            THEN("noteJSONTransaction is called with the correct pointer and "
                  "length for each command") {
-                CHECK(NoteJSONTransaction_fake.arg0_history[0] == req);
-                CHECK(NoteJSONTransaction_fake.arg1_history[0] ==
+                CHECK(noteJSONTransaction_fake.arg0_history[0] == req);
+                CHECK(noteJSONTransaction_fake.arg1_history[0] ==
                       (sizeof(cmd1) - 1));
-                CHECK(NoteJSONTransaction_fake.arg0_history[1] ==
+                CHECK(noteJSONTransaction_fake.arg0_history[1] ==
                       (req + sizeof(cmd1) - 1));
-                CHECK(NoteJSONTransaction_fake.arg1_history[1] ==
+                CHECK(noteJSONTransaction_fake.arg1_history[1] ==
                       (sizeof(cmd2) - 1));
             }
         }
@@ -93,10 +93,10 @@ SCENARIO("NoteRequestResponseJSON")
         WHEN("NoteRequestResponseJSON is called") {
             char *rsp = NoteRequestResponseJSON(req);
 
-            THEN("NoteJSONTransaction is called with a valid pointer for the "
+            THEN("noteJSONTransaction is called with a valid pointer for the "
                  "response parameter") {
-                REQUIRE(NoteJSONTransaction_fake.call_count > 0);
-                CHECK(NoteJSONTransaction_fake.arg2_history[0] != NULL);
+                REQUIRE(noteJSONTransaction_fake.call_count > 0);
+                CHECK(noteJSONTransaction_fake.arg2_history[0] != NULL);
             }
         }
     }
@@ -110,10 +110,10 @@ SCENARIO("NoteRequestResponseJSON")
 
             THEN("The request is still treated as a regular request and not a "
                  "command") {
-                REQUIRE(NoteJSONTransaction_fake.call_count > 0);
+                REQUIRE(noteJSONTransaction_fake.call_count > 0);
                 // The response parameter is non-NULL, meaning we expect a
                 // response (i.e. it's not a command).
-                CHECK(NoteJSONTransaction_fake.arg2_history[0] != NULL);
+                CHECK(noteJSONTransaction_fake.arg2_history[0] != NULL);
             }
         }
     }
@@ -124,8 +124,8 @@ SCENARIO("NoteRequestResponseJSON")
         WHEN("NoteRequestResponseJSON is called") {
             char *rsp = NoteRequestResponseJSON(req);
 
-            THEN("NoteJSONTransaction isn't called") {
-                CHECK(NoteJSONTransaction_fake.call_count == 0);
+            THEN("noteJSONTransaction isn't called") {
+                CHECK(noteJSONTransaction_fake.call_count == 0);
             }
 
             THEN("NULL is returned") {
@@ -141,38 +141,38 @@ SCENARIO("NoteRequestResponseJSON")
             char *rsp = NoteRequestResponseJSON(req);
 
             THEN("The Notecard is locked and unlocked") {
-                REQUIRE(NoteJSONTransaction_fake.call_count > 0);
-                CHECK(NoteLockNote_fake.call_count == 1);
-                CHECK(NoteUnlockNote_fake.call_count == 1);
+                REQUIRE(noteJSONTransaction_fake.call_count > 0);
+                CHECK(noteLockNote_fake.call_count == 1);
+                CHECK(noteUnlockNote_fake.call_count == 1);
             }
 
             THEN("The transaction start/stop function are used to prepare the "
                  "Notecard for the transaction") {
-                REQUIRE(NoteJSONTransaction_fake.call_count > 0);
-                CHECK(NoteTransactionStart_fake.call_count == 1);
-                CHECK(NoteTransactionStop_fake.call_count == 1);
+                REQUIRE(noteJSONTransaction_fake.call_count > 0);
+                CHECK(noteTransactionStart_fake.call_count == 1);
+                CHECK(noteTransactionStop_fake.call_count == 1);
             }
         }
 
         AND_GIVEN("The transaction with the Notecard fails to start") {
-            NoteTransactionStart_fake.return_val = false;
+            noteTransactionStart_fake.return_val = false;
 
             WHEN("NoteRequestResponseJSON is called") {
                 char *rsp = NoteRequestResponseJSON(req);
 
                 THEN("NULL is returned") {
-                    REQUIRE(NoteTransactionStart_fake.call_count > 0);
+                    REQUIRE(noteTransactionStart_fake.call_count > 0);
                     CHECK(rsp == NULL);
                 }
             }
         }
     }
 
-    RESET_FAKE(NoteTransactionStart);
-    RESET_FAKE(NoteTransactionStop);
-    RESET_FAKE(NoteLockNote);
-    RESET_FAKE(NoteUnlockNote);
-    RESET_FAKE(NoteJSONTransaction);
+    RESET_FAKE(noteTransactionStart);
+    RESET_FAKE(noteTransactionStop);
+    RESET_FAKE(noteLockNote);
+    RESET_FAKE(noteUnlockNote);
+    RESET_FAKE(noteJSONTransaction);
 }
 
 }

--- a/test/src/NoteReset_test.cpp
+++ b/test/src/NoteReset_test.cpp
@@ -19,7 +19,7 @@
 #include "n_lib.h"
 
 DEFINE_FFF_GLOBALS
-FAKE_VALUE_FUNC(bool, NoteHardReset)
+FAKE_VALUE_FUNC(bool, noteHardReset)
 
 namespace
 {
@@ -29,20 +29,20 @@ SCENARIO("NoteReset")
     GIVEN("NoteReset is called") {
         NoteReset();
 
-        THEN("NoteHardReset is invoked") {
-            CHECK(NoteHardReset_fake.call_count > 0);
+        THEN("noteHardReset is invoked") {
+            CHECK(noteHardReset_fake.call_count > 0);
         }
 
-        WHEN("`NoteHardReset` returns `false`") {
-            NoteHardReset_fake.return_val = false;
+        WHEN("`noteHardReset` returns `false`") {
+            noteHardReset_fake.return_val = false;
             THEN("`NoteReset` also returns `false`") {
                 bool result = NoteReset();
                 CHECK(result == false);
             }
         }
 
-        WHEN("`NoteHardReset` returns `true`") {
-            NoteHardReset_fake.return_val = true;
+        WHEN("`noteHardReset` returns `true`") {
+            noteHardReset_fake.return_val = true;
             THEN("`NoteReset` also returns `true`") {
                 bool result = NoteReset();
                 CHECK(result == true);
@@ -50,7 +50,7 @@ SCENARIO("NoteReset")
         }
     }
 
-    RESET_FAKE(NoteHardReset);
+    RESET_FAKE(noteHardReset);
 }
 
 }

--- a/test/src/NoteSerialHooks_test.cpp
+++ b/test/src/NoteSerialHooks_test.cpp
@@ -38,8 +38,8 @@ void MyTxnStop()
 SCENARIO("NoteSerialHooks")
 {
     SECTION("Hooks not set") {
-        NoteTransactionStart(0);
-        NoteTransactionStop();
+        noteTransactionStart(0);
+        noteTransactionStop();
 
         CHECK(!txnStartCalled);
         CHECK(!txnStopCalled);
@@ -47,8 +47,8 @@ SCENARIO("NoteSerialHooks")
 
     SECTION("Hooks set") {
         NoteSetFnTransaction(MyTxnStart, MyTxnStop);
-        NoteTransactionStart(0);
-        NoteTransactionStop();
+        noteTransactionStart(0);
+        noteTransactionStop();
 
         CHECK(txnStartCalled);
         CHECK(txnStopCalled);

--- a/test/src/NoteSetFnI2C_test.cpp
+++ b/test/src/NoteSetFnI2C_test.cpp
@@ -59,21 +59,21 @@ SCENARIO("NoteSetFnI2C")
 
     NoteSetFnI2C(i2cAddr, i2cMax, I2CReset, I2CTransmit, I2CReceive);
 
-    CHECK(NoteI2CReset(i2cAddr));
+    CHECK(noteI2CReset(i2cAddr));
     CHECK(i2cResetCalled == 1);
 
-    CHECK(NoteI2CTransmit(i2cAddr, (uint8_t *)req, strlen(req)) == NULL);
+    CHECK(noteI2CTransmit(i2cAddr, (uint8_t *)req, strlen(req)) == NULL);
     CHECK(i2cTransmitCalled == 1);
 
-    CHECK(NoteI2CReceive(i2cAddr, NULL, 0, NULL) == NULL);
+    CHECK(noteI2CReceive(i2cAddr, NULL, 0, NULL) == NULL);
     CHECK(i2cReceiveCalled == 1);
 
-    CHECK(strcmp(NoteActiveInterface(), "i2c") == 0);
+    CHECK(strcmp(noteActiveInterface(), "i2c") == 0);
 
-    CHECK(NoteHardReset());
+    CHECK(noteHardReset());
     CHECK(i2cNoteReset_fake.call_count == 1);
 
-    CHECK(NoteJSONTransaction(req, strlen(req), &resp, CARD_INTER_TRANSACTION_TIMEOUT_SEC) == NULL);
+    CHECK(noteJSONTransaction(req, strlen(req), &resp, CARD_INTER_TRANSACTION_TIMEOUT_SEC) == NULL);
     CHECK(i2cNoteTransaction_fake.call_count == 1);
 
     CHECK(NoteI2CAddress() == i2cAddr);
@@ -90,21 +90,21 @@ SCENARIO("NoteSetFnI2C")
     NoteSetI2CAddress(0);
     NoteSetFnDisabled();
 
-    CHECK(NoteI2CReset(i2cAddr));
+    CHECK(noteI2CReset(i2cAddr));
     CHECK(i2cResetCalled == 1);
 
-    CHECK(NoteI2CTransmit(i2cAddr, (uint8_t *)req, strlen(req)) != NULL);
+    CHECK(noteI2CTransmit(i2cAddr, (uint8_t *)req, strlen(req)) != NULL);
     CHECK(i2cTransmitCalled == 1);
 
-    CHECK(NoteI2CReceive(i2cAddr, NULL, 0, NULL) != NULL);
+    CHECK(noteI2CReceive(i2cAddr, NULL, 0, NULL) != NULL);
     CHECK(i2cReceiveCalled == 1);
 
-    CHECK(strcmp(NoteActiveInterface(), "unknown") == 0);
+    CHECK(strcmp(noteActiveInterface(), "unknown") == 0);
 
-    CHECK(NoteHardReset());
+    CHECK(noteHardReset());
     CHECK(i2cNoteReset_fake.call_count == 1);
 
-    CHECK(NoteJSONTransaction(req, strlen(req), &resp, CARD_INTER_TRANSACTION_TIMEOUT_SEC) != NULL);
+    CHECK(noteJSONTransaction(req, strlen(req), &resp, CARD_INTER_TRANSACTION_TIMEOUT_SEC) != NULL);
     CHECK(i2cNoteTransaction_fake.call_count == 1);
 
     CHECK(NoteI2CAddress() == NOTE_I2C_ADDR_DEFAULT);

--- a/test/src/NoteSetFnMutex_test.cpp
+++ b/test/src/NoteSetFnMutex_test.cpp
@@ -55,10 +55,10 @@ SCENARIO("NoteSetFnMutex")
     NoteUnlockI2C();
     CHECK(unlockI2CCalled == 1);
 
-    NoteLockNote();
+    noteLockNote();
     CHECK(lockNoteCalled == 1);
 
-    NoteUnlockNote();
+    noteUnlockNote();
     CHECK(unlockNoteCalled == 1);
 
     // Unset the callbacks and ensure they aren't called again.
@@ -70,10 +70,10 @@ SCENARIO("NoteSetFnMutex")
     NoteUnlockI2C();
     CHECK(unlockI2CCalled == 1);
 
-    NoteLockNote();
+    noteLockNote();
     CHECK(lockNoteCalled == 1);
 
-    NoteUnlockNote();
+    noteUnlockNote();
     CHECK(unlockNoteCalled == 1);
 }
 

--- a/test/src/NoteSetFnNoteMutex_test.cpp
+++ b/test/src/NoteSetFnNoteMutex_test.cpp
@@ -37,19 +37,19 @@ SCENARIO("NoteSetFnNoteMutex")
 {
     NoteSetFnNoteMutex(LockNote, UnlockNote);
 
-    NoteLockNote();
+    noteLockNote();
     CHECK(lockNoteCalled == 1);
 
-    NoteUnlockNote();
+    noteUnlockNote();
     CHECK(unlockNoteCalled == 1);
 
     // Unset the callbacks and ensure they aren't called again.
     NoteSetFnNoteMutex(NULL, NULL);
 
-    NoteLockNote();
+    noteLockNote();
     CHECK(lockNoteCalled == 1);
 
-    NoteUnlockNote();
+    noteUnlockNote();
     CHECK(unlockNoteCalled == 1);
 }
 

--- a/test/src/NoteSetFnSerial_test.cpp
+++ b/test/src/NoteSetFnSerial_test.cpp
@@ -30,24 +30,24 @@ uint8_t serialTransmitCalled = 0;
 uint8_t serialAvailableCalled = 0;
 uint8_t serialReceiveCalled = 0;
 
-bool SerialReset()
+bool serialReset()
 {
     ++serialResetCalled;
     return true;
 }
 
-void SerialTransmit(uint8_t *, size_t, bool)
+void serialTransmit(uint8_t *, size_t, bool)
 {
     ++serialTransmitCalled;
 }
 
-bool SerialAvailable()
+bool serialAvailable()
 {
     ++serialAvailableCalled;
     return true;
 }
 
-char SerialReceive()
+char serialReceive()
 {
     ++serialReceiveCalled;
     return 'a';
@@ -61,51 +61,51 @@ SCENARIO("NoteSetFnSerial")
     serialNoteReset_fake.return_val = true;
     serialNoteTransaction_fake.return_val = NULL;
 
-    NoteSetFnSerial(SerialReset, SerialTransmit, SerialAvailable,
-                    SerialReceive);
+    NoteSetFnSerial(serialReset, serialTransmit, serialAvailable,
+                    serialReceive);
 
-    CHECK(NoteSerialReset());
+    CHECK(noteSerialReset());
     CHECK(serialResetCalled == 1);
 
-    NoteSerialTransmit((uint8_t *)req, strlen(req), false);
+    noteSerialTransmit((uint8_t *)req, strlen(req), false);
     CHECK(serialTransmitCalled == 1);
 
-    CHECK(NoteSerialAvailable());
+    CHECK(noteSerialAvailable());
     CHECK(serialAvailableCalled == 1);
 
-    CHECK(NoteSerialReceive() == 'a');
+    CHECK(noteSerialReceive() == 'a');
     CHECK(serialReceiveCalled == 1);
 
-    CHECK(strcmp(NoteActiveInterface(), "serial") == 0);
+    CHECK(strcmp(noteActiveInterface(), "serial") == 0);
 
-    CHECK(NoteHardReset());
+    CHECK(noteHardReset());
     CHECK(serialNoteReset_fake.call_count == 1);
 
-    CHECK(NoteJSONTransaction(req, strlen(req), &resp, CARD_INTER_TRANSACTION_TIMEOUT_SEC) == NULL);
+    CHECK(noteJSONTransaction(req, strlen(req), &resp, CARD_INTER_TRANSACTION_TIMEOUT_SEC) == NULL);
     CHECK(serialNoteTransaction_fake.call_count == 1);
 
     // Unset the callbacks and ensure they aren't called again.
     NoteSetFnSerial(NULL, NULL, NULL, NULL);
     NoteSetFnDisabled();
 
-    CHECK(NoteSerialReset());
+    CHECK(noteSerialReset());
     CHECK(serialResetCalled == 1);
 
-    NoteSerialTransmit((uint8_t *)req, strlen(req), false);
+    noteSerialTransmit((uint8_t *)req, strlen(req), false);
     CHECK(serialTransmitCalled == 1);
 
-    CHECK(!NoteSerialAvailable());
+    CHECK(!noteSerialAvailable());
     CHECK(serialAvailableCalled == 1);
 
-    CHECK(NoteSerialReceive() == 0);
+    CHECK(noteSerialReceive() == 0);
     CHECK(serialReceiveCalled == 1);
 
-    CHECK(strcmp(NoteActiveInterface(), "unknown") == 0);
+    CHECK(strcmp(noteActiveInterface(), "unknown") == 0);
 
-    CHECK(NoteHardReset());
+    CHECK(noteHardReset());
     CHECK(serialNoteReset_fake.call_count == 1);
 
-    CHECK(NoteJSONTransaction(req, strlen(req), &resp, CARD_INTER_TRANSACTION_TIMEOUT_SEC) != NULL);
+    CHECK(noteJSONTransaction(req, strlen(req), &resp, CARD_INTER_TRANSACTION_TIMEOUT_SEC) != NULL);
     CHECK(serialNoteTransaction_fake.call_count == 1);
 
     RESET_FAKE(serialNoteReset);

--- a/test/src/NoteTransactionHooks_test.cpp
+++ b/test/src/NoteTransactionHooks_test.cpp
@@ -38,8 +38,8 @@ void MyTxnStop()
 SCENARIO("NoteTransactionHooks")
 {
     SECTION("Hooks not set") {
-        NoteTransactionStart(0);
-        NoteTransactionStop();
+        noteTransactionStart(0);
+        noteTransactionStop();
 
         CHECK(!txnStartCalled);
         CHECK(!txnStopCalled);
@@ -47,8 +47,8 @@ SCENARIO("NoteTransactionHooks")
 
     SECTION("Hooks set") {
         NoteSetFnTransaction(MyTxnStart, MyTxnStop);
-        NoteTransactionStart(0);
-        NoteTransactionStop();
+        noteTransactionStart(0);
+        noteTransactionStop();
 
         CHECK(txnStartCalled);
         CHECK(txnStopCalled);

--- a/test/src/NoteTransaction_test.cpp
+++ b/test/src/NoteTransaction_test.cpp
@@ -21,15 +21,15 @@
 
 DEFINE_FFF_GLOBALS
 FAKE_VALUE_FUNC(bool, NoteReset)
-FAKE_VALUE_FUNC(const char *, NoteJSONTransaction, const char *, size_t, char **, size_t)
-FAKE_VALUE_FUNC(bool, NoteTransactionStart, uint32_t)
+FAKE_VALUE_FUNC(const char *, noteJSONTransaction, const char *, size_t, char **, size_t)
+FAKE_VALUE_FUNC(bool, noteTransactionStart, uint32_t)
 FAKE_VALUE_FUNC(J *, NoteUserAgent)
 FAKE_VALUE_FUNC(bool, crcError, char *, uint16_t)
 
 namespace
 {
 
-const char *NoteJSONTransactionValid(const char *, size_t, char **resp, size_t)
+const char *noteJSONTransactionValid(const char *, size_t, char **resp, size_t)
 {
     static char respString[] = "{ \"total\": 1 }";
 
@@ -42,7 +42,7 @@ const char *NoteJSONTransactionValid(const char *, size_t, char **resp, size_t)
     return NULL;
 }
 
-const char *NoteJSONTransactionBadJSON(const char *, size_t, char **resp, size_t)
+const char *noteJSONTransactionBadJSON(const char *, size_t, char **resp, size_t)
 {
     static char respString[] = "Bad JSON";
 
@@ -55,7 +55,7 @@ const char *NoteJSONTransactionBadJSON(const char *, size_t, char **resp, size_t
     return NULL;
 }
 
-const char *NoteJSONTransactionIOError(const char *, size_t, char **resp, size_t)
+const char *noteJSONTransactionIOError(const char *, size_t, char **resp, size_t)
 {
     static char respString[] = "{\"err\": \"{io}\"}";
 
@@ -75,15 +75,15 @@ SCENARIO("NoteTransaction")
     // NoteReset's mock should succeed unless the test explicitly instructs
     // it to fail.
     NoteReset_fake.return_val = true;
-    NoteTransactionStart_fake.return_val = true;
+    noteTransactionStart_fake.return_val = true;
     crcError_fake.return_val = false;
 
     SECTION("Passing a NULL request returns NULL") {
         CHECK(NoteTransaction(NULL) == NULL);
     }
 
-    SECTION("NoteTransactionStart fails") {
-        NoteTransactionStart_fake.return_val = false;
+    SECTION("noteTransactionStart fails") {
+        noteTransactionStart_fake.return_val = false;
         J *req = NoteNewRequest("note.add");
         REQUIRE(req != NULL);
 
@@ -95,11 +95,11 @@ SCENARIO("NoteTransaction")
     SECTION("A response is expected and the response is valid") {
         J *req = NoteNewRequest("note.add");
         REQUIRE(req != NULL);
-        NoteJSONTransaction_fake.custom_fake = NoteJSONTransactionValid;
+        noteJSONTransaction_fake.custom_fake = noteJSONTransactionValid;
 
         J *resp = NoteTransaction(req);
 
-        CHECK(NoteJSONTransaction_fake.call_count == 1);
+        CHECK(noteJSONTransaction_fake.call_count == 1);
         CHECK(resp != NULL);
         // Ensure there's no error in the response.
         CHECK(!NoteResponseError(resp));
@@ -111,13 +111,13 @@ SCENARIO("NoteTransaction")
     SECTION("A response is expected and the response has an error") {
         J *req = NoteNewRequest("note.add");
         REQUIRE(req != NULL);
-        NoteJSONTransaction_fake.return_val = "This is an error.";
+        noteJSONTransaction_fake.return_val = "This is an error.";
 
         J *resp = NoteTransaction(req);
 
         // Ensure the mock is called at least once
         // Here the error causes multiple invocations by retries
-        CHECK(NoteJSONTransaction_fake.call_count >= 1);
+        CHECK(noteJSONTransaction_fake.call_count >= 1);
 
         // Ensure there's an error in the response.
         CHECK(resp != NULL);
@@ -130,7 +130,7 @@ SCENARIO("NoteTransaction")
     WHEN("The transaction is successful and the response has a {bad-bin} error") {
         J *req = NoteNewRequest("note.add");
         REQUIRE(req != NULL);
-        NoteJSONTransaction_fake.custom_fake = [](const char *, size_t, char **response, size_t) -> const char * {
+        noteJSONTransaction_fake.custom_fake = [](const char *, size_t, char **response, size_t) -> const char * {
             const char rsp_str[] = "{\"err\":\"{bad-bin}\"}";
             *response = (char *)malloc(sizeof(rsp_str));
             strncpy(*response, rsp_str, sizeof(rsp_str));
@@ -141,14 +141,14 @@ SCENARIO("NoteTransaction")
 
         // Ensure the mock is called at least once
         // Here the error causes multiple invocations by retries
-        REQUIRE(NoteJSONTransaction_fake.call_count >= 1);
+        REQUIRE(noteJSONTransaction_fake.call_count >= 1);
 
         THEN("An error is returned") {
             CHECK(resp != NULL);
         }
 
         THEN("The transaction is not retried") {
-            CHECK(NoteJSONTransaction_fake.call_count == 1);
+            CHECK(noteJSONTransaction_fake.call_count == 1);
         }
 
         JDelete(req);
@@ -158,7 +158,7 @@ SCENARIO("NoteTransaction")
     WHEN("The transaction is successful and the response contains invalid JSON") {
         J *req = NoteNewRequest("note.add");
         REQUIRE(req != NULL);
-        NoteJSONTransaction_fake.custom_fake = [](const char *, size_t, char **response, size_t) -> const char * {
+        noteJSONTransaction_fake.custom_fake = [](const char *, size_t, char **response, size_t) -> const char * {
             const char rsp_str[] = "{Looks like JSON, but won't parse}";
             *response = (char *)malloc(sizeof(rsp_str));
             strncpy(*response, rsp_str, sizeof(rsp_str));
@@ -169,14 +169,14 @@ SCENARIO("NoteTransaction")
 
         // Ensure the mock is called at least once
         // Here the error causes multiple invocations by retries
-        REQUIRE(NoteJSONTransaction_fake.call_count >= 1);
+        REQUIRE(noteJSONTransaction_fake.call_count >= 1);
 
         THEN("An error is returned") {
             CHECK(resp != NULL);
         }
 
         THEN("The transaction is retried") {
-            CHECK(NoteJSONTransaction_fake.call_count == (1 + CARD_REQUEST_RETRIES_ALLOWED));
+            CHECK(noteJSONTransaction_fake.call_count == (1 + CARD_REQUEST_RETRIES_ALLOWED));
         }
 
         JDelete(req);
@@ -186,7 +186,7 @@ SCENARIO("NoteTransaction")
     SECTION("Bad CRC") {
         J *req = NoteNewRequest("note.add");
         REQUIRE(req != NULL);
-        NoteJSONTransaction_fake.custom_fake = NoteJSONTransactionValid;
+        noteJSONTransaction_fake.custom_fake = noteJSONTransactionValid;
         crcError_fake.return_val = true;
 
         J *resp = NoteTransaction(req);
@@ -201,7 +201,7 @@ SCENARIO("NoteTransaction")
     SECTION("I/O error") {
         J *req = NoteNewRequest("note.add");
         REQUIRE(req != NULL);
-        NoteJSONTransaction_fake.custom_fake = NoteJSONTransactionIOError;
+        noteJSONTransaction_fake.custom_fake = noteJSONTransactionIOError;
 
         J *resp = NoteTransaction(req);
 
@@ -223,7 +223,7 @@ SCENARIO("NoteTransaction")
 
         CHECK(NoteReset_fake.call_count == 1);
         // The transaction shouldn't be attempted if reset failed.
-        CHECK(NoteJSONTransaction_fake.call_count == 0);
+        CHECK(noteJSONTransaction_fake.call_count == 0);
         // The response should be null if reset failed.
         CHECK(resp == NULL);
 
@@ -240,7 +240,7 @@ SCENARIO("NoteTransaction")
 
         // The transaction shouldn't be attempted if the request couldn't be
         // serialized.
-        CHECK(NoteJSONTransaction_fake.call_count == 0);
+        CHECK(noteJSONTransaction_fake.call_count == 0);
         // Ensure there's an error in the response.
         CHECK(resp != NULL);
         CHECK(NoteResponseError(resp));
@@ -252,11 +252,11 @@ SCENARIO("NoteTransaction")
     SECTION("No response is expected") {
         J *req = NoteNewCommand("note.add");
         REQUIRE(req != NULL);
-        NoteJSONTransaction_fake.custom_fake = NoteJSONTransactionValid;
+        noteJSONTransaction_fake.custom_fake = noteJSONTransactionValid;
 
         J *resp = NoteTransaction(req);
 
-        CHECK(NoteJSONTransaction_fake.call_count == 1);
+        CHECK(noteJSONTransaction_fake.call_count == 1);
         CHECK(resp != NULL);
         // Ensure there's no error in the response.
         CHECK(!NoteResponseError(resp));
@@ -272,11 +272,11 @@ SCENARIO("NoteTransaction")
     SECTION("Parsing the JSON response fails") {
         J *req = NoteNewRequest("note.add");
         REQUIRE(req != NULL);
-        NoteJSONTransaction_fake.custom_fake = NoteJSONTransactionBadJSON;
+        noteJSONTransaction_fake.custom_fake = noteJSONTransactionBadJSON;
 
         J *resp = NoteTransaction(req);
 
-        CHECK(NoteJSONTransaction_fake.call_count >= 1);
+        CHECK(noteJSONTransaction_fake.call_count >= 1);
         CHECK(resp != NULL);
         // Ensure there's an error in the response.
         CHECK(NoteResponseError(resp));
@@ -290,7 +290,7 @@ SCENARIO("NoteTransaction")
         J *req = NoteNewRequest("hub.set");
         REQUIRE(req != NULL);
         JAddStringToObject(req, "product", "a.b.c:d");
-        NoteJSONTransaction_fake.custom_fake = NoteJSONTransactionValid;
+        noteJSONTransaction_fake.custom_fake = noteJSONTransactionValid;
         NoteUserAgent_fake.return_val = JCreateObject();
 
         J *resp = NoteTransaction(req);
@@ -307,7 +307,7 @@ SCENARIO("NoteTransaction")
         REQUIRE(req != NULL);
 
         J *resp = NoteTransaction(req);
-        CHECK(NoteJSONTransaction_fake.arg3_val == (CARD_INTER_TRANSACTION_TIMEOUT_SEC * 1000));
+        CHECK(noteJSONTransaction_fake.arg3_val == (CARD_INTER_TRANSACTION_TIMEOUT_SEC * 1000));
 
         JDelete(req);
         JDelete(resp);
@@ -319,7 +319,7 @@ SCENARIO("NoteTransaction")
         JAddIntToObject(req, "milliseconds", 9171979);
 
         J *resp = NoteTransaction(req);
-        CHECK(NoteJSONTransaction_fake.arg3_val == 9171979);
+        CHECK(noteJSONTransaction_fake.arg3_val == 9171979);
 
         JDelete(req);
         JDelete(resp);
@@ -331,7 +331,7 @@ SCENARIO("NoteTransaction")
         JAddIntToObject(req, "seconds", 917);
 
         J *resp = NoteTransaction(req);
-        CHECK(NoteJSONTransaction_fake.arg3_val == (917 * 1000));
+        CHECK(noteJSONTransaction_fake.arg3_val == (917 * 1000));
 
         JDelete(req);
         JDelete(resp);
@@ -344,7 +344,7 @@ SCENARIO("NoteTransaction")
         JAddIntToObject(req, "milliseconds", 9171979);
 
         J *resp = NoteTransaction(req);
-        CHECK(NoteJSONTransaction_fake.arg3_val == 9171979);
+        CHECK(noteJSONTransaction_fake.arg3_val == 9171979);
 
         JDelete(req);
         JDelete(resp);
@@ -356,7 +356,7 @@ SCENARIO("NoteTransaction")
         JAddIntToObject(req, "milliseconds", 9171979);
 
         J *resp = NoteTransaction(req);
-        CHECK(NoteJSONTransaction_fake.arg3_val == 9171979);
+        CHECK(noteJSONTransaction_fake.arg3_val == 9171979);
 
         JDelete(req);
         JDelete(resp);
@@ -368,7 +368,7 @@ SCENARIO("NoteTransaction")
         JAddIntToObject(req, "seconds", 1979);
 
         J *resp = NoteTransaction(req);
-        CHECK(NoteJSONTransaction_fake.arg3_val == (1979 * 1000));
+        CHECK(noteJSONTransaction_fake.arg3_val == (1979 * 1000));
 
         JDelete(req);
         JDelete(resp);
@@ -381,7 +381,7 @@ SCENARIO("NoteTransaction")
         JAddIntToObject(req, "milliseconds", 9171979);
 
         J *resp = NoteTransaction(req);
-        CHECK(NoteJSONTransaction_fake.arg3_val == 9171979);
+        CHECK(noteJSONTransaction_fake.arg3_val == 9171979);
 
         JDelete(req);
         JDelete(resp);
@@ -392,15 +392,15 @@ SCENARIO("NoteTransaction")
         REQUIRE(req != NULL);
 
         J *resp = NoteTransaction(req);
-        CHECK(NoteJSONTransaction_fake.arg3_val == (90 * 1000));
+        CHECK(noteJSONTransaction_fake.arg3_val == (90 * 1000));
 
         JDelete(req);
         JDelete(resp);
     }
 
     RESET_FAKE(NoteReset);
-    RESET_FAKE(NoteJSONTransaction);
-    RESET_FAKE(NoteTransactionStart);
+    RESET_FAKE(noteJSONTransaction);
+    RESET_FAKE(noteTransactionStart);
     RESET_FAKE(crcError);
 }
 

--- a/test/src/i2cChunkedReceive_test.cpp
+++ b/test/src/i2cChunkedReceive_test.cpp
@@ -21,7 +21,7 @@
 #include "time_mocks.h"
 
 DEFINE_FFF_GLOBALS
-FAKE_VALUE_FUNC(const char *, NoteI2CReceive, uint16_t, uint8_t *, uint16_t,
+FAKE_VALUE_FUNC(const char *, noteI2CReceive, uint16_t, uint8_t *, uint16_t,
                 uint32_t *)
 FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
 FAKE_VOID_FUNC(NoteDelayMs, uint32_t)
@@ -29,7 +29,7 @@ FAKE_VOID_FUNC(NoteDelayMs, uint32_t)
 namespace
 {
 
-const char *NoteI2CReceiveInfinite(uint16_t, uint8_t *buf, uint16_t size,
+const char *noteI2CReceiveInfinite(uint16_t, uint8_t *buf, uint16_t size,
                                    uint32_t *available)
 {
     memset(buf, 'a', size);
@@ -49,9 +49,9 @@ SCENARIO("i2cChunkedReceive")
         uint8_t buf[] = {0xAB};
         uint32_t zeroSize = 0;
 
-        AND_GIVEN("NoteI2CReceive reports that here are bytes available from "
+        AND_GIVEN("noteI2CReceive reports that here are bytes available from "
                   "the Notecard") {
-            NoteI2CReceive_fake.custom_fake = NoteI2CReceiveInfinite;
+            noteI2CReceive_fake.custom_fake = noteI2CReceiveInfinite;
 
             WHEN("i2cChunkedReceive is called") {
                 uint32_t originalAvailable = available;
@@ -67,17 +67,17 @@ SCENARIO("i2cChunkedReceive")
                 }
 
                 THEN("available is exactly the number of bytes reported "
-                     "available by NoteI2CReceive") {
+                     "available by noteI2CReceive") {
                     CHECK(available == NOTE_I2C_MAX_DEFAULT);
                 }
             }
         }
     }
 
-    GIVEN("NoteI2CReceive returns an error") {
+    GIVEN("noteI2CReceive returns an error") {
         uint8_t buf[] = {0xAB};
         uint32_t size = sizeof(buf);
-        NoteI2CReceive_fake.return_val = "some error";
+        noteI2CReceive_fake.return_val = "some error";
 
         WHEN("i2cChunkedReceive is called") {
             const char *err = i2cChunkedReceive(buf, &size, true, timeoutMs,
@@ -92,7 +92,7 @@ SCENARIO("i2cChunkedReceive")
     GIVEN("The output buffer is too small") {
         uint8_t buf[NOTE_I2C_MAX_DEFAULT] = {0};
         uint32_t size = sizeof(buf);
-        NoteI2CReceive_fake.custom_fake = NoteI2CReceiveInfinite;
+        noteI2CReceive_fake.custom_fake = noteI2CReceiveInfinite;
 
         WHEN("i2cChunkedReceive is called") {
             const char *err = i2cChunkedReceive(buf, &size, true, timeoutMs,
@@ -103,17 +103,17 @@ SCENARIO("i2cChunkedReceive")
             }
 
             THEN("The output size is exactly the number of bytes returned by "
-                 "NoteI2CReceive") {
+                 "noteI2CReceive") {
                 CHECK(size == NOTE_I2C_MAX_DEFAULT);
             }
 
             THEN("available is exactly the number of bytes reported available "
-                 "by NoteI2CReceive") {
+                 "by noteI2CReceive") {
                 CHECK(available == NOTE_I2C_MAX_DEFAULT);
             }
 
             THEN("The output buffer contains exactly the bytes returned by "
-                 "NoteI2CReceive") {
+                 "noteI2CReceive") {
                 uint8_t expectedBuf[sizeof(buf)];
                 memset(expectedBuf, 'a', sizeof(expectedBuf));
 
@@ -126,9 +126,9 @@ SCENARIO("i2cChunkedReceive")
         uint8_t buf[NOTE_I2C_MAX_DEFAULT * 3] = {0};
         uint32_t size = sizeof(buf);
 
-        NoteI2CReceive_fake.custom_fake = [](uint16_t, uint8_t *buf,
+        noteI2CReceive_fake.custom_fake = [](uint16_t, uint8_t *buf,
         uint16_t size, uint32_t *available) -> const char* {
-            // If NoteI2CReceive is called with size 0, the caller is querying
+            // If noteI2CReceive is called with size 0, the caller is querying
             // the Notecard for how many bytes are available. Here, we report
             // back that there are NOTE_I2C_MAX_DEFAULT * 2 bytes available.
             if (size == 0)
@@ -170,7 +170,7 @@ SCENARIO("i2cChunkedReceive")
                 }
 
                 THEN("The output size is exactly the number of bytes returned"
-                     "by NoteI2CReceive") {
+                     "by noteI2CReceive") {
                     CHECK(size == numBytesExpected);
                 }
 
@@ -179,7 +179,7 @@ SCENARIO("i2cChunkedReceive")
                 }
 
                 THEN("The output buffer contains exactly the bytes returned by "
-                     "NoteI2CReceive") {
+                     "noteI2CReceive") {
                     uint8_t expectedBuf[10];
                     memset(expectedBuf, 'a', sizeof(expectedBuf) - 1);
                     expectedBuf[sizeof(expectedBuf) - 1] = '\n';
@@ -202,7 +202,7 @@ SCENARIO("i2cChunkedReceive")
                 }
 
                 THEN("The output size is exactly the number of bytes returned"
-                     "by NoteI2CReceive") {
+                     "by noteI2CReceive") {
                     CHECK(size == numBytesExpected);
                 }
 
@@ -211,7 +211,7 @@ SCENARIO("i2cChunkedReceive")
                 }
 
                 THEN("The output buffer contains exactly the bytes returned by "
-                     "NoteI2CReceive") {
+                     "noteI2CReceive") {
                     uint8_t expectedBuf[NOTE_I2C_MAX_DEFAULT * 2];
                     memset(expectedBuf, 'a', sizeof(expectedBuf) - 1);
                     expectedBuf[sizeof(expectedBuf) - 1] = '\n';
@@ -222,13 +222,13 @@ SCENARIO("i2cChunkedReceive")
         }
     }
 
-    GIVEN("End-of-packet (\\n) is received, but NoteI2CReceive indicates more "
+    GIVEN("End-of-packet (\\n) is received, but noteI2CReceive indicates more "
           "is still available to read") {
         uint8_t buf[NOTE_I2C_MAX_DEFAULT * 3] = {0};
         uint32_t size = sizeof(buf);
         size_t numBytesExpected = NOTE_I2C_MAX_DEFAULT * 2;
 
-        // On the first call, NoteI2CReceive reports back that
+        // On the first call, noteI2CReceive reports back that
         // NOTE_I2C_MAX_DEFAULT are available to read.
         auto bytesAvailable = [](uint16_t, uint8_t *buf, uint16_t size,
         uint32_t *available) -> const char* {
@@ -262,7 +262,7 @@ SCENARIO("i2cChunkedReceive")
             fullPacketButMoreAvailable,
             excessData
         };
-        SET_CUSTOM_FAKE_SEQ(NoteI2CReceive, recvFakeSequence, 3);
+        SET_CUSTOM_FAKE_SEQ(noteI2CReceive, recvFakeSequence, 3);
 
         WHEN("i2cChunkedReceive is called") {
             const char *err = i2cChunkedReceive(buf, &size, true, timeoutMs,
@@ -273,7 +273,7 @@ SCENARIO("i2cChunkedReceive")
             }
 
             THEN("The output size is exactly the number of bytes returned by "
-                 "NoteI2CReceive") {
+                 "noteI2CReceive") {
                 CHECK(size == numBytesExpected);
             }
 
@@ -282,7 +282,7 @@ SCENARIO("i2cChunkedReceive")
             }
 
             THEN("The output buffer contains exactly the bytes returned by "
-                 "NoteI2CReceive") {
+                 "noteI2CReceive") {
                 uint8_t expectedBuf[NOTE_I2C_MAX_DEFAULT * 2];
                 memset(expectedBuf, 'a', NOTE_I2C_MAX_DEFAULT - 1);
                 expectedBuf[NOTE_I2C_MAX_DEFAULT - 1] = '\n';
@@ -295,7 +295,7 @@ SCENARIO("i2cChunkedReceive")
     }
 
     GIVEN("There's nothing to read from the Notecard") {
-        NoteI2CReceive_fake.custom_fake = [](uint16_t, uint8_t *buf,
+        noteI2CReceive_fake.custom_fake = [](uint16_t, uint8_t *buf,
         uint16_t size, uint32_t *available) -> const char* {
             *available = 0;
 
@@ -348,7 +348,7 @@ SCENARIO("i2cChunkedReceive")
 
     GIVEN("There's initially data to read from the Notecard, but then there's "
           "nothing available and we never receive the \\n") {
-        // First, NoteI2CReceive will report that NOTE_I2C_MAX_DEFAULT bytes are
+        // First, noteI2CReceive will report that NOTE_I2C_MAX_DEFAULT bytes are
         // available to read.
         auto bytesAvailable = [](uint16_t, uint8_t *buf, uint16_t size,
         uint32_t *available) -> const char* {
@@ -381,7 +381,7 @@ SCENARIO("i2cChunkedReceive")
             partialPacket,
             nothingAvailable
         };
-        SET_CUSTOM_FAKE_SEQ(NoteI2CReceive, recvFakeSequence, 3);
+        SET_CUSTOM_FAKE_SEQ(noteI2CReceive, recvFakeSequence, 3);
 
         uint8_t buf[NOTE_I2C_MAX_DEFAULT] = {0};
         uint32_t size = sizeof(buf);
@@ -408,7 +408,7 @@ SCENARIO("i2cChunkedReceive")
         }
     }
 
-    RESET_FAKE(NoteI2CReceive);
+    RESET_FAKE(noteI2CReceive);
     RESET_FAKE(NoteGetMs);
     RESET_FAKE(NoteDelayMs);
 }

--- a/test/src/i2cChunkedTransmit_test.cpp
+++ b/test/src/i2cChunkedTransmit_test.cpp
@@ -20,8 +20,8 @@
 #include "test_static.h"
 
 DEFINE_FFF_GLOBALS
-FAKE_VALUE_FUNC(const char *, NoteI2CTransmit, uint16_t, uint8_t *, uint16_t)
-FAKE_VALUE_FUNC(bool, NoteI2CReset, uint16_t)
+FAKE_VALUE_FUNC(const char *, noteI2CTransmit, uint16_t, uint8_t *, uint16_t)
+FAKE_VALUE_FUNC(bool, noteI2CReset, uint16_t)
 FAKE_VOID_FUNC(NoteDelayMs, uint32_t)
 
 namespace
@@ -30,7 +30,7 @@ namespace
 uint8_t transmitBuf[CARD_REQUEST_I2C_SEGMENT_MAX_LEN * 2];
 size_t transmitBufIdx = 0;
 
-const char *NoteI2CTransmitCapture(uint16_t, uint8_t *buf, uint16_t size)
+const char *noteI2CTransmitCapture(uint16_t, uint8_t *buf, uint16_t size)
 {
     memcpy(transmitBuf + transmitBufIdx, buf, size);
 
@@ -50,7 +50,7 @@ SCENARIO("i2cChunkedTransmit")
             const char *err = i2cChunkedTransmit(buf, size, delay);
 
             THEN("Nothing is transmitted") {
-                CHECK(NoteI2CTransmit_fake.call_count == 0);
+                CHECK(noteI2CTransmit_fake.call_count == 0);
             }
 
             THEN("No error is returned") {
@@ -59,10 +59,10 @@ SCENARIO("i2cChunkedTransmit")
         }
     }
 
-    GIVEN("NoteI2CTransmit returns an error") {
+    GIVEN("noteI2CTransmit returns an error") {
         uint8_t buf[] = {0xAB};
         size_t size = sizeof(buf);
-        NoteI2CTransmit_fake.return_val = "some error";
+        noteI2CTransmit_fake.return_val = "some error";
 
         WHEN("i2cChunkedTransmit is called") {
             const char *err = i2cChunkedTransmit(buf, size, delay);
@@ -71,8 +71,8 @@ SCENARIO("i2cChunkedTransmit")
                 CHECK(err != NULL);
             }
 
-            THEN("NoteI2CReset is called") {
-                CHECK(NoteI2CReset_fake.call_count > 0);
+            THEN("noteI2CReset is called") {
+                CHECK(noteI2CReset_fake.call_count > 0);
             }
         }
     }
@@ -81,7 +81,7 @@ SCENARIO("i2cChunkedTransmit")
         uint8_t *buf = NULL;
         size_t size = 0;
         const char *err = NULL;
-        NoteI2CTransmit_fake.custom_fake = NoteI2CTransmitCapture;
+        noteI2CTransmit_fake.custom_fake = noteI2CTransmitCapture;
 
         AND_GIVEN("The input buffer can be sent in one chunk") {
             uint8_t oneChunkBuf[NOTE_I2C_MAX_DEFAULT];
@@ -92,8 +92,8 @@ SCENARIO("i2cChunkedTransmit")
             WHEN("i2cChunkedTransmit is called") {
                 err = i2cChunkedTransmit(buf, size, delay);
 
-                THEN("The data is sent in 1 call to NoteI2CTransmit") {
-                    CHECK(NoteI2CTransmit_fake.call_count == 1);
+                THEN("The data is sent in 1 call to noteI2CTransmit") {
+                    CHECK(noteI2CTransmit_fake.call_count == 1);
                 }
             }
         }
@@ -107,8 +107,8 @@ SCENARIO("i2cChunkedTransmit")
             WHEN("i2cChunkedTransmit is called") {
                 err = i2cChunkedTransmit(buf, size, delay);
 
-                THEN("The data is sent in > 1 call to NoteI2CTransmit") {
-                    CHECK(NoteI2CTransmit_fake.call_count > 1);
+                THEN("The data is sent in > 1 call to noteI2CTransmit") {
+                    CHECK(noteI2CTransmit_fake.call_count > 1);
                 }
             }
         }
@@ -129,14 +129,14 @@ SCENARIO("i2cChunkedTransmit")
             CHECK(err == NULL);
         }
 
-        THEN("The data passed to NoteI2CTransmit is exactly the same as "
+        THEN("The data passed to noteI2CTransmit is exactly the same as "
              "what was passed to i2cChunkedTransmit") {
             memcmp(buf, transmitBuf, sizeof(buf) == 0);
         }
     }
 
-    RESET_FAKE(NoteI2CTransmit);
-    RESET_FAKE(NoteI2CReset);
+    RESET_FAKE(noteI2CTransmit);
+    RESET_FAKE(noteI2CReset);
     RESET_FAKE(NoteDelayMs);
 }
 

--- a/test/src/i2cNoteQueryLength_test.cpp
+++ b/test/src/i2cNoteQueryLength_test.cpp
@@ -21,7 +21,7 @@
 #include "time_mocks.h"
 
 DEFINE_FFF_GLOBALS
-FAKE_VALUE_FUNC(const char *, NoteI2CReceive, uint16_t, uint8_t *, uint16_t,
+FAKE_VALUE_FUNC(const char *, noteI2CReceive, uint16_t, uint8_t *, uint16_t,
                 uint32_t *)
 FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
 
@@ -31,7 +31,7 @@ namespace
 // Something's immediately available.
 // Nothing available at the start, then something becomes available.
 
-const char * NoteI2CReceiveNotAvailable(uint16_t, uint8_t *, uint16_t,
+const char * noteI2CReceiveNotAvailable(uint16_t, uint8_t *, uint16_t,
                                         uint32_t *available)
 {
     *available = 0;
@@ -43,7 +43,7 @@ enum {
     NUM_BYTES_AVAILABLE = 3
 };
 
-const char * NoteI2CReceiveAvailable(uint16_t, uint8_t *, uint16_t,
+const char * noteI2CReceiveAvailable(uint16_t, uint8_t *, uint16_t,
                                      uint32_t *available)
 {
     *available = NUM_BYTES_AVAILABLE;
@@ -57,8 +57,8 @@ SCENARIO("i2cNoteQueryLength")
     uint32_t available = 0;
     size_t timeoutMs = 5000;
 
-    GIVEN("NoteI2CReceive returns an error") {
-        NoteI2CReceive_fake.return_val = "some error";
+    GIVEN("noteI2CReceive returns an error") {
+        noteI2CReceive_fake.return_val = "some error";
 
         WHEN("i2cNoteQueryLength is called") {
             const char *err = i2cNoteQueryLength(&available, timeoutMs);
@@ -70,7 +70,7 @@ SCENARIO("i2cNoteQueryLength")
     }
 
     GIVEN("Bytes are never available to read") {
-        NoteI2CReceive_fake.custom_fake = NoteI2CReceiveNotAvailable;
+        noteI2CReceive_fake.custom_fake = noteI2CReceiveNotAvailable;
 
         WHEN("i2cNoteQueryLength is called") {
             const char *err = i2cNoteQueryLength(&available, timeoutMs);
@@ -86,7 +86,7 @@ SCENARIO("i2cNoteQueryLength")
     }
 
     GIVEN("Bytes are immediately available to read") {
-        NoteI2CReceive_fake.custom_fake = NoteI2CReceiveAvailable;
+        noteI2CReceive_fake.custom_fake = noteI2CReceiveAvailable;
 
         WHEN("i2cNoteQueryLength is called") {
             const char *err = i2cNoteQueryLength(&available, timeoutMs);
@@ -96,14 +96,14 @@ SCENARIO("i2cNoteQueryLength")
             }
 
             THEN("The available out parameter reports the same number of "
-                 "available bytes as NoteI2CReceive reported") {
+                 "available bytes as noteI2CReceive reported") {
                 CHECK(available == NUM_BYTES_AVAILABLE);
             }
         }
     }
 
     GIVEN("Bytes are immediately available to read") {
-        NoteI2CReceive_fake.custom_fake = NoteI2CReceiveAvailable;
+        noteI2CReceive_fake.custom_fake = noteI2CReceiveAvailable;
 
         WHEN("i2cNoteQueryLength is called") {
             const char *err = i2cNoteQueryLength(&available, timeoutMs);
@@ -113,7 +113,7 @@ SCENARIO("i2cNoteQueryLength")
             }
 
             THEN("The available out parameter reports the same number of "
-                 "available bytes as NoteI2CReceive reported") {
+                 "available bytes as noteI2CReceive reported") {
                 CHECK(available == NUM_BYTES_AVAILABLE);
             }
         }
@@ -123,11 +123,11 @@ SCENARIO("i2cNoteQueryLength")
           "available") {
         const char * (*customI2CReciveFakes[])
         (uint16_t, uint8_t *, uint16_t, uint32_t *available) = {
-            NoteI2CReceiveNotAvailable,
-            NoteI2CReceiveNotAvailable,
-            NoteI2CReceiveAvailable
+            noteI2CReceiveNotAvailable,
+            noteI2CReceiveNotAvailable,
+            noteI2CReceiveAvailable
         };
-        SET_CUSTOM_FAKE_SEQ(NoteI2CReceive, customI2CReciveFakes, 3);
+        SET_CUSTOM_FAKE_SEQ(noteI2CReceive, customI2CReciveFakes, 3);
 
         WHEN("i2cNoteQueryLength is called") {
             const char *err = i2cNoteQueryLength(&available, timeoutMs);
@@ -137,13 +137,13 @@ SCENARIO("i2cNoteQueryLength")
             }
 
             THEN("The available out parameter reports the same number of "
-                 "available bytes as NoteI2CReceive reported") {
+                 "available bytes as noteI2CReceive reported") {
                 CHECK(available == NUM_BYTES_AVAILABLE);
             }
         }
     }
 
-    RESET_FAKE(NoteI2CReceive);
+    RESET_FAKE(noteI2CReceive);
     RESET_FAKE(NoteGetMs);
 }
 

--- a/test/src/i2cNoteReset_test.cpp
+++ b/test/src/i2cNoteReset_test.cpp
@@ -23,9 +23,9 @@ DEFINE_FFF_GLOBALS
 FAKE_VOID_FUNC(delayIO)
 FAKE_VOID_FUNC(NoteDelayMs, uint32_t)
 FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
-FAKE_VALUE_FUNC(bool, NoteI2CReset, uint16_t)
-FAKE_VALUE_FUNC(const char *, NoteI2CTransmit, uint16_t, uint8_t *, uint16_t)
-FAKE_VALUE_FUNC(const char *, NoteI2CReceive, uint16_t, uint8_t *, uint16_t,
+FAKE_VALUE_FUNC(bool, noteI2CReset, uint16_t)
+FAKE_VALUE_FUNC(const char *, noteI2CTransmit, uint16_t, uint8_t *, uint16_t)
+FAKE_VALUE_FUNC(const char *, noteI2CReceive, uint16_t, uint8_t *, uint16_t,
                 uint32_t *)
 FAKE_VOID_FUNC(NoteLockI2C)
 FAKE_VOID_FUNC(NoteUnlockI2C)
@@ -45,7 +45,7 @@ long unsigned int NoteGetMs_mock(void)
     return rtc_ms++;
 }
 
-const char * NoteI2CReceive_CleanResetSeq0(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
+const char * noteI2CReceive_CleanResetSeq0(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
 {
     if (available) {
         *available = 2;
@@ -53,7 +53,7 @@ const char * NoteI2CReceive_CleanResetSeq0(uint16_t, uint8_t *buffer, uint16_t, 
     return nullptr;
 }
 
-const char * NoteI2CReceive_CleanResetSeq1(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
+const char * noteI2CReceive_CleanResetSeq1(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
 {
     if (available) {
         *available = 0;
@@ -65,7 +65,7 @@ const char * NoteI2CReceive_CleanResetSeq1(uint16_t, uint8_t *buffer, uint16_t, 
     return nullptr;
 }
 
-const char * NoteI2CReceive_AvailGTBufferMessageSeq0(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
+const char * noteI2CReceive_AvailGTBufferMessageSeq0(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
 {
     if (available) {
         *available = (ALLOC_CHUNK + 1);
@@ -73,7 +73,7 @@ const char * NoteI2CReceive_AvailGTBufferMessageSeq0(uint16_t, uint8_t *buffer, 
     return nullptr;
 }
 
-const char * NoteI2CReceive_AvailGTBufferMessageSeq1(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
+const char * noteI2CReceive_AvailGTBufferMessageSeq1(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
 {
     if (available) {
         *available = 0;
@@ -81,7 +81,7 @@ const char * NoteI2CReceive_AvailGTBufferMessageSeq1(uint16_t, uint8_t *buffer, 
     return nullptr;
 }
 
-const char * NoteI2CReceive_AvailGTFFFFMessageSeq0(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
+const char * noteI2CReceive_AvailGTFFFFMessageSeq0(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
 {
     if (available) {
         *available = 19790917;
@@ -89,7 +89,7 @@ const char * NoteI2CReceive_AvailGTFFFFMessageSeq0(uint16_t, uint8_t *buffer, ui
     return nullptr;
 }
 
-const char * NoteI2CReceive_AvailGTFFFFMessageSeq1(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
+const char * noteI2CReceive_AvailGTFFFFMessageSeq1(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
 {
     if (available) {
         *available = 0;
@@ -97,7 +97,7 @@ const char * NoteI2CReceive_AvailGTFFFFMessageSeq1(uint16_t, uint8_t *buffer, ui
     return nullptr;
 }
 
-const char * NoteI2CReceive_AvailGTMaxMessageSeq0(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
+const char * noteI2CReceive_AvailGTMaxMessageSeq0(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
 {
     if (available) {
         *available = NoteI2CMax();
@@ -105,7 +105,7 @@ const char * NoteI2CReceive_AvailGTMaxMessageSeq0(uint16_t, uint8_t *buffer, uin
     return nullptr;
 }
 
-const char * NoteI2CReceive_AvailGTMaxMessageSeq1(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
+const char * noteI2CReceive_AvailGTMaxMessageSeq1(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
 {
     if (available) {
         *available = 0;
@@ -113,7 +113,7 @@ const char * NoteI2CReceive_AvailGTMaxMessageSeq1(uint16_t, uint8_t *buffer, uin
     return nullptr;
 }
 
-const char * NoteI2CReceive_ClearMessageSeq0(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
+const char * noteI2CReceive_ClearMessageSeq0(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
 {
     if (available) {
         *available = 4;
@@ -121,7 +121,7 @@ const char * NoteI2CReceive_ClearMessageSeq0(uint16_t, uint8_t *buffer, uint16_t
     return nullptr;
 }
 
-const char * NoteI2CReceive_ClearMessageSeq1(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
+const char * noteI2CReceive_ClearMessageSeq1(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
 {
     if (available) {
         *available = 0;
@@ -135,7 +135,7 @@ const char * NoteI2CReceive_ClearMessageSeq1(uint16_t, uint8_t *buffer, uint16_t
     return nullptr;
 }
 
-const char * NoteI2CReceive_ClearMessageSeq2(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
+const char * noteI2CReceive_ClearMessageSeq2(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
 {
     if (available) {
         *available = 2;
@@ -143,7 +143,7 @@ const char * NoteI2CReceive_ClearMessageSeq2(uint16_t, uint8_t *buffer, uint16_t
     return nullptr;
 }
 
-const char * NoteI2CReceive_ClearMessageSeq3(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
+const char * noteI2CReceive_ClearMessageSeq3(uint16_t, uint8_t *buffer, uint16_t, uint32_t *available)
 {
     if (available) {
         *available = 0;
@@ -172,20 +172,20 @@ SCENARIO("i2cNoteReset")
             CHECK(NoteLockI2C_fake.call_count > 0);
         }
 
-        THEN("`NoteI2CReset()` is called") {
-            CHECK(NoteI2CReset_fake.call_count > 0);
+        THEN("`noteI2CReset()` is called") {
+            CHECK(noteI2CReset_fake.call_count > 0);
         }
         AND_THEN("The first parameter is the Notecard address") {
-            CHECK(NoteI2CReset_fake.arg0_history[0] == NoteI2CAddress());
+            CHECK(noteI2CReset_fake.arg0_history[0] == NoteI2CAddress());
         }
     }
 
-    GIVEN("`NoteI2CReset()` is called") {
+    GIVEN("`noteI2CReset()` is called") {
         NoteDelayMs_fake.custom_fake = NoteDelayMs_mock;
         NoteGetMs_fake.custom_fake = NoteGetMs_mock;
 
-        WHEN("`NoteI2CReset()` fails") {
-            NoteI2CReset_fake.return_val = false;
+        WHEN("`noteI2CReset()` fails") {
+            noteI2CReset_fake.return_val = false;
             const bool success = i2cNoteReset();
 
             THEN("The I2C mutex will be released") {
@@ -196,12 +196,12 @@ SCENARIO("i2cNoteReset")
             }
 
             THEN("Exit immediately without retrying") {
-                CHECK(NoteI2CReset_fake.call_count == 1);
+                CHECK(noteI2CReset_fake.call_count == 1);
             }
         }
 
-        WHEN("`NoteI2CReset()` succeeds") {
-            NoteI2CReset_fake.return_val = true;
+        WHEN("`noteI2CReset()` succeeds") {
+            noteI2CReset_fake.return_val = true;
             i2cNoteReset();
 
             THEN("Then the I/O delay is respected") {
@@ -210,33 +210,33 @@ SCENARIO("i2cNoteReset")
         }
     }
 
-    GIVEN("`NoteI2CReset()` succeeds") {
+    GIVEN("`noteI2CReset()` succeeds") {
         NoteDelayMs_fake.custom_fake = NoteDelayMs_mock;
         NoteGetMs_fake.custom_fake = NoteGetMs_mock;
-        NoteI2CReset_fake.return_val = true;
+        noteI2CReset_fake.return_val = true;
         const bool success = i2cNoteReset();
 
-        THEN("`NoteI2CTransmit()` is called") {
-            CHECK(NoteI2CTransmit_fake.call_count > 0);
+        THEN("`noteI2CTransmit()` is called") {
+            CHECK(noteI2CTransmit_fake.call_count > 0);
         }
         THEN("The first parameter is the Notecard address") {
-            CHECK(NoteI2CTransmit_fake.arg0_history[0] == NoteI2CAddress());
+            CHECK(noteI2CTransmit_fake.arg0_history[0] == NoteI2CAddress());
         }
         THEN("The second parameter is a string containing a single newline") {
-            CHECK(NoteI2CTransmit_fake.arg1_history[0][0] == '\n');
+            CHECK(noteI2CTransmit_fake.arg1_history[0][0] == '\n');
         }
         THEN("The third parameter is the string length of 1") {
-            CHECK(NoteI2CTransmit_fake.arg2_history[0] == sizeof(char));
+            CHECK(noteI2CTransmit_fake.arg2_history[0] == sizeof(char));
         }
     }
 
-    GIVEN("`NoteI2CTransmit()` is called") {
+    GIVEN("`noteI2CTransmit()` is called") {
         NoteDelayMs_fake.custom_fake = NoteDelayMs_mock;
         NoteGetMs_fake.custom_fake = NoteGetMs_mock;
-        NoteI2CReset_fake.return_val = true;
+        noteI2CReset_fake.return_val = true;
 
-        WHEN("`NoteI2CTransmit()` fails") {
-            NoteI2CTransmit_fake.return_val = "most likely a NACK has occurred";
+        WHEN("`noteI2CTransmit()` fails") {
+            noteI2CTransmit_fake.return_val = "most likely a NACK has occurred";
             const bool success = i2cNoteReset();
 
             THEN("Delay for `CARD_REQUEST_I2C_NACK_WAIT_MS` milliseconds") {
@@ -244,12 +244,12 @@ SCENARIO("i2cNoteReset")
                 CHECK(NoteDelayMs_fake.arg0_history[1] == CARD_REQUEST_I2C_NACK_WAIT_MS);
             }
 
-            THEN("`NoteI2CReceive()` is not called") {
-                CHECK(NoteI2CReceive_fake.call_count == 0);
+            THEN("`noteI2CReceive()` is not called") {
+                CHECK(noteI2CReceive_fake.call_count == 0);
             }
 
-            THEN("`NoteI2CTransmit()` will retry `CARD_RESET_SYNC_RETRIES` times") {
-                CHECK(NoteI2CTransmit_fake.call_count == CARD_RESET_SYNC_RETRIES);
+            THEN("`noteI2CTransmit()` will retry `CARD_RESET_SYNC_RETRIES` times") {
+                CHECK(noteI2CTransmit_fake.call_count == CARD_RESET_SYNC_RETRIES);
             }
 
             THEN("The I2C mutex will be released") {
@@ -260,8 +260,8 @@ SCENARIO("i2cNoteReset")
             }
         }
 
-        WHEN("`NoteI2CTransmit()` succeeds") {
-            NoteI2CTransmit_fake.return_val = nullptr;
+        WHEN("`noteI2CTransmit()` succeeds") {
+            noteI2CTransmit_fake.return_val = nullptr;
             const bool success = i2cNoteReset();
 
             THEN("Delay for `CARD_REQUEST_I2C_SEGMENT_DELAY_MS`") {
@@ -269,40 +269,40 @@ SCENARIO("i2cNoteReset")
                 CHECK(NoteDelayMs_fake.arg0_history[1] == CARD_REQUEST_I2C_SEGMENT_DELAY_MS);
             }
 
-            THEN("`NoteI2CReceive()` is called to query the response") {
-                CHECK(NoteI2CReceive_fake.call_count > 0);
+            THEN("`noteI2CReceive()` is called to query the response") {
+                CHECK(noteI2CReceive_fake.call_count > 0);
             }
             AND_THEN("The first parameter is the Notecard address") {
-                CHECK(NoteI2CReceive_fake.arg0_history[0] == NoteI2CAddress());
+                CHECK(noteI2CReceive_fake.arg0_history[0] == NoteI2CAddress());
             }
             AND_THEN("The second parameter is a non-NULL static buffer used to drain bytes") {
-                CHECK(NoteI2CReceive_fake.arg1_history[0] != nullptr);
+                CHECK(noteI2CReceive_fake.arg1_history[0] != nullptr);
             }
             AND_THEN("The third parameter is zero to indicate a query request") {
-                CHECK(NoteI2CReceive_fake.arg2_history[0] == 0);
+                CHECK(noteI2CReceive_fake.arg2_history[0] == 0);
             }
             AND_THEN("The fourth parameter is a non-NULL unsigned integer pointer used for the query response") {
-                CHECK(NoteI2CReceive_fake.arg3_history[0] != nullptr);
+                CHECK(noteI2CReceive_fake.arg3_history[0] != nullptr);
             }
         }
     }
 
-    GIVEN("`NoteI2CReceive()` is called") {
+    GIVEN("`noteI2CReceive()` is called") {
         NoteDelayMs_fake.custom_fake = NoteDelayMs_mock;
         NoteGetMs_fake.custom_fake = NoteGetMs_mock;
-        NoteI2CReset_fake.return_val = true;
-        NoteI2CTransmit_fake.return_val = nullptr;
+        noteI2CReset_fake.return_val = true;
+        noteI2CTransmit_fake.return_val = nullptr;
 
-        WHEN("`NoteI2CReceive()` fails") {
-            NoteI2CReceive_fake.return_val = "the Notecard ESP commonly generates protocol errors";
+        WHEN("`noteI2CReceive()` fails") {
+            noteI2CReceive_fake.return_val = "the Notecard ESP commonly generates protocol errors";
             const bool success = i2cNoteReset();
 
             THEN("Delay for `CARD_REQUEST_I2C_SEGMENT_DELAY_MS`") {
                 CHECK(NoteDelayMs_fake.call_count > 2);
                 CHECK(NoteDelayMs_fake.arg0_history[2] == CARD_REQUEST_I2C_SEGMENT_DELAY_MS);
             }
-            AND_THEN("Will retry `NoteI2CReceive()`") {
-                CHECK(NoteI2CReceive_fake.call_count > CARD_RESET_SYNC_RETRIES);
+            AND_THEN("Will retry `noteI2CReceive()`") {
+                CHECK(noteI2CReceive_fake.call_count > CARD_RESET_SYNC_RETRIES);
             }
 
             THEN("The I2C mutex will be released") {
@@ -312,14 +312,14 @@ SCENARIO("i2cNoteReset")
                 CHECK(success == false);
             }
         }
-        WHEN("`NoteI2CReceive()` succeeds") {
+        WHEN("`noteI2CReceive()` succeeds") {
             const char * (*ClearMessageSeq[])(uint16_t, uint8_t *, uint16_t, uint32_t *) = {
-                NoteI2CReceive_ClearMessageSeq0,
-                NoteI2CReceive_ClearMessageSeq1,
-                NoteI2CReceive_ClearMessageSeq2,
-                NoteI2CReceive_ClearMessageSeq3,
+                noteI2CReceive_ClearMessageSeq0,
+                noteI2CReceive_ClearMessageSeq1,
+                noteI2CReceive_ClearMessageSeq2,
+                noteI2CReceive_ClearMessageSeq3,
             };
-            SET_CUSTOM_FAKE_SEQ(NoteI2CReceive, ClearMessageSeq, 4);
+            SET_CUSTOM_FAKE_SEQ(noteI2CReceive, ClearMessageSeq, 4);
             const bool success = i2cNoteReset();
 
             THEN("Delay for `CARD_REQUEST_I2C_CHUNK_DELAY_MS`") {
@@ -327,103 +327,103 @@ SCENARIO("i2cNoteReset")
                 CHECK(NoteDelayMs_fake.arg0_history[2] == CARD_REQUEST_I2C_CHUNK_DELAY_MS);
             }
 
-            THEN("`NoteI2CReceive()` is called to receive the response") {
-                CHECK(NoteI2CReceive_fake.call_count > 1);
+            THEN("`noteI2CReceive()` is called to receive the response") {
+                CHECK(noteI2CReceive_fake.call_count > 1);
             }
             AND_THEN("The first parameter is the Notecard address") {
-                CHECK(NoteI2CReceive_fake.arg0_val == NoteI2CAddress());
+                CHECK(noteI2CReceive_fake.arg0_val == NoteI2CAddress());
             }
             AND_THEN("The second parameter is a non-NULL static buffer used to drain bytes") {
-                CHECK(NoteI2CReceive_fake.arg1_val != nullptr);
+                CHECK(noteI2CReceive_fake.arg1_val != nullptr);
             }
             AND_THEN("The third parameter is populated with the available value from the previous query") {
-                REQUIRE(NoteI2CReceive_fake.call_count >= 4);
-                CHECK(NoteI2CReceive_fake.arg2_history[0] == 0);
-                CHECK(NoteI2CReceive_fake.arg2_history[1] == 4);
-                CHECK(NoteI2CReceive_fake.arg2_history[2] == 0);
-                CHECK(NoteI2CReceive_fake.arg2_history[3] == 2);
+                REQUIRE(noteI2CReceive_fake.call_count >= 4);
+                CHECK(noteI2CReceive_fake.arg2_history[0] == 0);
+                CHECK(noteI2CReceive_fake.arg2_history[1] == 4);
+                CHECK(noteI2CReceive_fake.arg2_history[2] == 0);
+                CHECK(noteI2CReceive_fake.arg2_history[3] == 2);
             }
             AND_THEN("The fourth parameter is a non-NULL unsigned integer pointer used for the query response") {
-                CHECK(NoteI2CReceive_fake.arg3_val != nullptr);
+                CHECK(noteI2CReceive_fake.arg3_val != nullptr);
             }
         }
     }
 
-    GIVEN("`NoteI2CReceive()` succeeds") {
+    GIVEN("`noteI2CReceive()` succeeds") {
         NoteDelayMs_fake.custom_fake = NoteDelayMs_mock;
         NoteGetMs_fake.custom_fake = NoteGetMs_mock;
-        NoteI2CReset_fake.return_val = true;
-        NoteI2CTransmit_fake.return_val = nullptr;
+        noteI2CReset_fake.return_val = true;
+        noteI2CTransmit_fake.return_val = nullptr;
 
-        WHEN("`NoteI2CReceive()` available returns a value greater than that which can be contained by uint16_t") {
+        WHEN("`noteI2CReceive()` available returns a value greater than that which can be contained by uint16_t") {
             const char * (*AvailGTFFFFMessageSeq[])(uint16_t, uint8_t *, uint16_t, uint32_t *) = {
-                NoteI2CReceive_AvailGTFFFFMessageSeq0,
-                NoteI2CReceive_AvailGTFFFFMessageSeq1,
+                noteI2CReceive_AvailGTFFFFMessageSeq0,
+                noteI2CReceive_AvailGTFFFFMessageSeq1,
             };
-            SET_CUSTOM_FAKE_SEQ(NoteI2CReceive, AvailGTFFFFMessageSeq, 2);
+            SET_CUSTOM_FAKE_SEQ(noteI2CReceive, AvailGTFFFFMessageSeq, 2);
             const bool success = i2cNoteReset();
 
             THEN("The third parameter is populated with the available value from the previous query") {
-                REQUIRE(NoteI2CReceive_fake.call_count >= 2);
-                CHECK(NoteI2CReceive_fake.arg2_history[0] == 0);
-                CHECK(NoteI2CReceive_fake.arg2_history[1] == NoteI2CMax());
+                REQUIRE(noteI2CReceive_fake.call_count >= 2);
+                CHECK(noteI2CReceive_fake.arg2_history[0] == 0);
+                CHECK(noteI2CReceive_fake.arg2_history[1] == NoteI2CMax());
             }
         }
 
-        WHEN("`NoteI2CReceive()` available returns a value greater than the buffer size") {
+        WHEN("`noteI2CReceive()` available returns a value greater than the buffer size") {
             const char * (*AvailGTBufferMessageSeq[])(uint16_t, uint8_t *, uint16_t, uint32_t *) = {
-                NoteI2CReceive_AvailGTBufferMessageSeq0,
-                NoteI2CReceive_AvailGTBufferMessageSeq1,
+                noteI2CReceive_AvailGTBufferMessageSeq0,
+                noteI2CReceive_AvailGTBufferMessageSeq1,
             };
-            SET_CUSTOM_FAKE_SEQ(NoteI2CReceive, AvailGTBufferMessageSeq, 2);
+            SET_CUSTOM_FAKE_SEQ(noteI2CReceive, AvailGTBufferMessageSeq, 2);
             const bool success = i2cNoteReset();
 
             THEN("The third parameter is populated with a value capped at the buffer size") {
-                REQUIRE(NoteI2CReceive_fake.call_count >= 2);
-                CHECK(NoteI2CReceive_fake.arg2_val <= ALLOC_CHUNK);
+                REQUIRE(noteI2CReceive_fake.call_count >= 2);
+                CHECK(noteI2CReceive_fake.arg2_val <= ALLOC_CHUNK);
             }
         }
 
-        WHEN("`NoteI2CReceive()` available returns a value greater than the maximum size allowed by the Serial-over-I2C protocol") {
+        WHEN("`noteI2CReceive()` available returns a value greater than the maximum size allowed by the Serial-over-I2C protocol") {
             const char * (*AvailGTMaxMessageSeq[])(uint16_t, uint8_t *, uint16_t, uint32_t *) = {
-                NoteI2CReceive_AvailGTMaxMessageSeq0,
-                NoteI2CReceive_AvailGTMaxMessageSeq1,
+                noteI2CReceive_AvailGTMaxMessageSeq0,
+                noteI2CReceive_AvailGTMaxMessageSeq1,
             };
-            SET_CUSTOM_FAKE_SEQ(NoteI2CReceive, AvailGTMaxMessageSeq, 2);
+            SET_CUSTOM_FAKE_SEQ(noteI2CReceive, AvailGTMaxMessageSeq, 2);
             const bool success = i2cNoteReset();
 
             THEN("The third parameter is populated with a value capped at NoteI2CMax()") {
-                REQUIRE(NoteI2CReceive_fake.call_count >= 2);
-                CHECK(NoteI2CReceive_fake.arg2_val <= NoteI2CMax());
+                REQUIRE(noteI2CReceive_fake.call_count >= 2);
+                CHECK(noteI2CReceive_fake.arg2_val <= NoteI2CMax());
             }
         }
     }
 
-    GIVEN("`NoteI2CReceive()` will drain the Notecard I2C interface for `CARD_RESET_DRAIN_MS`") {
+    GIVEN("`noteI2CReceive()` will drain the Notecard I2C interface for `CARD_RESET_DRAIN_MS`") {
         NoteDelayMs_fake.custom_fake = NoteDelayMs_mock;
         NoteGetMs_fake.custom_fake = NoteGetMs_mock;
-        NoteI2CReset_fake.return_val = true;
-        NoteI2CTransmit_fake.return_val = nullptr;
+        noteI2CReset_fake.return_val = true;
+        noteI2CTransmit_fake.return_val = nullptr;
 
-        WHEN("`NoteI2CReceive()` does not fail") {
+        WHEN("`noteI2CReceive()` does not fail") {
             rtc_ms = 0;
-            NoteI2CReceive_fake.return_val = nullptr;
+            noteI2CReceive_fake.return_val = nullptr;
             const bool success = i2cNoteReset();
 
-            THEN("`NoteI2CReceive()` will be called for `CARD_RESET_DRAIN_MS`") {
+            THEN("`noteI2CReceive()` will be called for `CARD_RESET_DRAIN_MS`") {
                 // Must account for both the priming delay and the post transmit delay
                 CHECK(rtc_ms >= CARD_RESET_DRAIN_MS + (CARD_REQUEST_I2C_SEGMENT_DELAY_MS * 2));
             }
         }
 
-        WHEN("`NoteI2CReceive()` receives any char that is neither \\r nor \\n") {
+        WHEN("`noteI2CReceive()` receives any char that is neither \\r nor \\n") {
             const char * (*ClearMessageSeq[])(uint16_t, uint8_t *, uint16_t, uint32_t *) = {
-                NoteI2CReceive_ClearMessageSeq0,
-                NoteI2CReceive_ClearMessageSeq1,
-                NoteI2CReceive_ClearMessageSeq2,
-                NoteI2CReceive_ClearMessageSeq3,
+                noteI2CReceive_ClearMessageSeq0,
+                noteI2CReceive_ClearMessageSeq1,
+                noteI2CReceive_ClearMessageSeq2,
+                noteI2CReceive_ClearMessageSeq3,
             };
-            SET_CUSTOM_FAKE_SEQ(NoteI2CReceive, ClearMessageSeq, 4);
+            SET_CUSTOM_FAKE_SEQ(noteI2CReceive, ClearMessageSeq, 4);
             const bool success = i2cNoteReset();
 
             THEN("`i2cNoteReset` fails") {
@@ -431,54 +431,54 @@ SCENARIO("i2cNoteReset")
             }
         }
 
-        WHEN("`NoteI2CReceive()` receives nothing") {
-            NoteI2CReceive_fake.return_val = nullptr;
+        WHEN("`noteI2CReceive()` receives nothing") {
+            noteI2CReceive_fake.return_val = nullptr;
             const bool success = i2cNoteReset();
 
             THEN("`i2cNoteReset` fails") {
                 CHECK(success == false);
             }
-            THEN("`NoteI2CReset()` is called") {
-                CHECK(NoteI2CReset_fake.call_count > 1);
+            THEN("`noteI2CReset()` is called") {
+                CHECK(noteI2CReset_fake.call_count > 1);
             }
         }
 
-        AND_GIVEN("`NoteI2CReceive()` receives nothing") {
-            NoteI2CReceive_fake.return_val = nullptr;
+        AND_GIVEN("`noteI2CReceive()` receives nothing") {
+            noteI2CReceive_fake.return_val = nullptr;
 
-            WHEN("`NoteI2CReset()` fails") {
+            WHEN("`noteI2CReset()` fails") {
                 bool retSeq[] = { true, false };
-                SET_RETURN_SEQ(NoteI2CReset, retSeq, 2);
+                SET_RETURN_SEQ(noteI2CReset, retSeq, 2);
                 const bool success = i2cNoteReset();
                 THEN("The I2C mutex will be released") {
                     CHECK(NoteUnlockI2C_fake.call_count == NoteLockI2C_fake.call_count);
                 }
                 THEN("Exit immediately without retrying") {
-                    CHECK(NoteI2CReset_fake.call_count == 2);
+                    CHECK(noteI2CReset_fake.call_count == 2);
                 }
             }
 
-            WHEN("`NoteI2CReset()` succeeds") {
+            WHEN("`noteI2CReset()` succeeds") {
                 i2cNoteReset();
 
                 THEN("Then the I/O delay is respected") {
                     // 1 + pre loop
-                    // 10 retries (simple NoteI2CReceive_fake returns zero --> nothing was found 10x)
+                    // 10 retries (simple noteI2CReceive_fake returns zero --> nothing was found 10x)
                     CHECK(delayIO_fake.call_count > 10);
                 }
             }
         }
 
-        WHEN("`NoteI2CReceive()` receives only `\\r` and/or `\\n`") {
+        WHEN("`noteI2CReceive()` receives only `\\r` and/or `\\n`") {
             const char * (*CleanResetSeq[])(uint16_t, uint8_t *, uint16_t, uint32_t *) = {
-                NoteI2CReceive_CleanResetSeq0,
-                NoteI2CReceive_CleanResetSeq1,
+                noteI2CReceive_CleanResetSeq0,
+                noteI2CReceive_CleanResetSeq1,
             };
-            SET_CUSTOM_FAKE_SEQ(NoteI2CReceive, CleanResetSeq, 2);
+            SET_CUSTOM_FAKE_SEQ(noteI2CReceive, CleanResetSeq, 2);
             const bool success = i2cNoteReset();
 
             THEN("Exit retry loop immediately") {
-                CHECK(NoteI2CTransmit_fake.call_count == 1);
+                CHECK(noteI2CTransmit_fake.call_count == 1);
             }
 
             THEN("`i2cNoteReset` succeeds") {
@@ -497,9 +497,9 @@ SCENARIO("i2cNoteReset")
     RESET_FAKE(delayIO);
     RESET_FAKE(NoteDelayMs);
     RESET_FAKE(NoteGetMs);
-    RESET_FAKE(NoteI2CReset);
-    RESET_FAKE(NoteI2CTransmit);
-    RESET_FAKE(NoteI2CReceive);
+    RESET_FAKE(noteI2CReset);
+    RESET_FAKE(noteI2CTransmit);
+    RESET_FAKE(noteI2CReceive);
     RESET_FAKE(NoteLockI2C);
     RESET_FAKE(NoteUnlockI2C);
 }

--- a/test/src/serialChunkedReceive_test.cpp
+++ b/test/src/serialChunkedReceive_test.cpp
@@ -20,8 +20,8 @@
 #include "n_lib.h"
 
 DEFINE_FFF_GLOBALS
-FAKE_VALUE_FUNC(bool, NoteSerialAvailable)
-FAKE_VALUE_FUNC(char, NoteSerialReceive)
+FAKE_VALUE_FUNC(bool, noteSerialAvailable)
+FAKE_VALUE_FUNC(char, noteSerialReceive)
 FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
 FAKE_VOID_FUNC(NoteDelayMs, uint32_t)
 
@@ -34,7 +34,7 @@ char *populateRecvBuf(size_t size)
     char *buf = (char *)malloc(size);
     memset(buf, 'a', size - 1);
     buf[size - 1] = '\n';
-    SET_RETURN_SEQ(NoteSerialReceive, buf, size);
+    SET_RETURN_SEQ(noteSerialReceive, buf, size);
 
     return buf;
 }
@@ -61,8 +61,8 @@ SCENARIO("serialChunkedReceive")
     // appropriate.
     uint32_t available = 37;
 
-    GIVEN("NoteSerialAvailable indicates nothing is available to read") {
-        NoteSerialAvailable_fake.return_val = false;
+    GIVEN("noteSerialAvailable indicates nothing is available to read") {
+        noteSerialAvailable_fake.return_val = false;
 
         WHEN("serialChunkedReceive is called") {
             const char *err = serialChunkedReceive(buf, &size, delay, timeoutMs,
@@ -83,7 +83,7 @@ SCENARIO("serialChunkedReceive")
     }
 
     GIVEN("The Notecard has 1 fewer bytes than the size of the output buffer") {
-        NoteSerialAvailable_fake.return_val = true;
+        noteSerialAvailable_fake.return_val = true;
         char *recvBuf = populateRecvBuf(sizeof(buf) - 1);
 
         WHEN("serialChunkedReceive is called") {
@@ -95,12 +95,12 @@ SCENARIO("serialChunkedReceive")
             }
 
             THEN("The returned size is exactly the number of bytes received "
-                 "with NoteSerialReceive") {
+                 "with noteSerialReceive") {
                 CHECK(size == sizeof(buf) - 1);
             }
 
             THEN("The output buffer has exactly the bytes returned by "
-                 "NoteSerialReceive") {
+                 "noteSerialReceive") {
                 CHECK(memcmp(buf, recvBuf, size) == 0);
             }
 
@@ -114,7 +114,7 @@ SCENARIO("serialChunkedReceive")
 
     GIVEN("The Notecard has exactly the same number of bytes as the output "
           "buffer") {
-        NoteSerialAvailable_fake.return_val = true;
+        noteSerialAvailable_fake.return_val = true;
         char *recvBuf = populateRecvBuf(sizeof(buf));
 
         WHEN("serialChunkedReceive is called") {
@@ -126,12 +126,12 @@ SCENARIO("serialChunkedReceive")
             }
 
             THEN("The returned size is exactly the number of bytes received "
-                 "with NoteSerialReceive") {
+                 "with noteSerialReceive") {
                 CHECK(size == sizeof(buf));
             }
 
             THEN("The output buffer has exactly the bytes returned by "
-                 "NoteSerialReceive") {
+                 "noteSerialReceive") {
                 CHECK(memcmp(buf, recvBuf, size) == 0);
             }
 
@@ -144,7 +144,7 @@ SCENARIO("serialChunkedReceive")
     }
 
     GIVEN("The Notecard has 3 more bytes than the size of the output buffer") {
-        NoteSerialAvailable_fake.return_val = true;
+        noteSerialAvailable_fake.return_val = true;
         char *recvBuf = populateRecvBuf(sizeof(buf) + 3);
 
         WHEN("serialChunkedReceive is called") {
@@ -156,12 +156,12 @@ SCENARIO("serialChunkedReceive")
             }
 
             THEN("The returned size is exactly the number of bytes received "
-                 "with NoteSerialReceive") {
+                 "with noteSerialReceive") {
                 CHECK(size == sizeof(buf));
             }
 
             THEN("The output buffer has exactly the bytes returned by "
-                 "NoteSerialReceive") {
+                 "noteSerialReceive") {
                 CHECK(memcmp(buf, recvBuf, size) == 0);
             }
 
@@ -200,7 +200,7 @@ SCENARIO("serialChunkedReceive")
         memset(serialAvailableReturnVals, true, numAvailableBytes);
         size_t numAvailRetVals = sizeof(serialAvailableReturnVals) /
                                  sizeof(*serialAvailableReturnVals);
-        SET_RETURN_SEQ(NoteSerialAvailable, serialAvailableReturnVals,
+        SET_RETURN_SEQ(noteSerialAvailable, serialAvailableReturnVals,
                        numAvailRetVals);
         char *recvBuf = populateRecvBuf(sizeof(buf));
 
@@ -235,7 +235,7 @@ SCENARIO("serialChunkedReceive")
         size_t numAvailRetVals = sizeof(serialAvailableReturnVals) /
                                  sizeof(*serialAvailableReturnVals);
         size_t numAvailableBytes = 4;
-        SET_RETURN_SEQ(NoteSerialAvailable, serialAvailableReturnVals,
+        SET_RETURN_SEQ(noteSerialAvailable, serialAvailableReturnVals,
                        numAvailRetVals);
         char *recvBuf = populateRecvBuf(numAvailableBytes);
 
@@ -248,12 +248,12 @@ SCENARIO("serialChunkedReceive")
             }
 
             THEN("The returned size is exactly the number of bytes received "
-                 "with NoteSerialReceive") {
+                 "with noteSerialReceive") {
                 CHECK(size == numAvailableBytes);
             }
 
             THEN("The output buffer has exactly the bytes returned by "
-                 "NoteSerialReceive") {
+                 "noteSerialReceive") {
                 CHECK(memcmp(buf, recvBuf, size) == 0);
             }
 
@@ -266,7 +266,7 @@ SCENARIO("serialChunkedReceive")
     }
 
     GIVEN("The delay parameter is false") {
-        NoteSerialAvailable_fake.return_val = false;
+        noteSerialAvailable_fake.return_val = false;
 
         WHEN("serialChunkedReceive is called") {
             serialChunkedReceive(buf, &size, false, timeoutMs, &available);
@@ -279,7 +279,7 @@ SCENARIO("serialChunkedReceive")
     }
 
     GIVEN("The delay parameter is true") {
-        NoteSerialAvailable_fake.return_val = false;
+        noteSerialAvailable_fake.return_val = false;
 
         WHEN("serialChunkedReceive is called") {
             serialChunkedReceive(buf, &size, true, timeoutMs, &available);
@@ -291,8 +291,8 @@ SCENARIO("serialChunkedReceive")
         }
     }
 
-    RESET_FAKE(NoteSerialAvailable);
-    RESET_FAKE(NoteSerialReceive);
+    RESET_FAKE(noteSerialAvailable);
+    RESET_FAKE(noteSerialReceive);
     RESET_FAKE(NoteGetMs);
     RESET_FAKE(NoteDelayMs);
 }

--- a/test/src/serialChunkedTransmit_test.cpp
+++ b/test/src/serialChunkedTransmit_test.cpp
@@ -20,19 +20,19 @@
 #include "n_lib.h"
 
 DEFINE_FFF_GLOBALS
-FAKE_VOID_FUNC(NoteSerialTransmit, uint8_t *, size_t, bool)
+FAKE_VOID_FUNC(noteSerialTransmit, uint8_t *, size_t, bool)
 FAKE_VOID_FUNC(NoteDelayMs, uint32_t)
 
 namespace
 {
 
-// This buffer will hold the bytes passed to NoteSerialTransmit. We can then
+// This buffer will hold the bytes passed to noteSerialTransmit. We can then
 // check that the bytes passed to serialChunkedTransmit are passed to
-// NoteSerialTransmit without alteration.
+// noteSerialTransmit without alteration.
 uint8_t accumulatedBuf[CARD_REQUEST_SERIAL_SEGMENT_MAX_LEN * 2];
 size_t accumulatedIdx = 0;
 
-void NoteSerialTransmitAccumulate(uint8_t *buf, size_t size, bool)
+void noteSerialTransmitAccumulate(uint8_t *buf, size_t size, bool)
 {
     memcpy(accumulatedBuf + accumulatedIdx, buf, size);
     accumulatedIdx += size;
@@ -55,7 +55,7 @@ SCENARIO("serialChunkedTransmit")
     }
 
     GIVEN("A buffer with size less than the maximum serial segment length") {
-        NoteSerialTransmit_fake.custom_fake = NoteSerialTransmitAccumulate;
+        noteSerialTransmit_fake.custom_fake = noteSerialTransmitAccumulate;
         uint8_t buf[CARD_REQUEST_SERIAL_SEGMENT_MAX_LEN - 1];
         size_t size = sizeof(buf);
         memset(buf, 1, size);
@@ -67,20 +67,20 @@ SCENARIO("serialChunkedTransmit")
                 CHECK(err == NULL);
             }
 
-            THEN("The buffer is passed verbatim to NoteSerialTransmit") {
+            THEN("The buffer is passed verbatim to noteSerialTransmit") {
                 CHECK(memcmp(buf, accumulatedBuf, size) == 0);
             }
 
-            THEN("NoteSerialTransmit is only called once, since the buffer fits"
+            THEN("noteSerialTransmit is only called once, since the buffer fits"
                  " in a single segment") {
-                CHECK(NoteSerialTransmit_fake.call_count == 1);
+                CHECK(noteSerialTransmit_fake.call_count == 1);
             }
         }
     }
 
     // TODO: Come up with a way to reduce duplication here.
     GIVEN("A buffer with size equal to the maximum serial segment length") {
-        NoteSerialTransmit_fake.custom_fake = NoteSerialTransmitAccumulate;
+        noteSerialTransmit_fake.custom_fake = noteSerialTransmitAccumulate;
         uint8_t buf[CARD_REQUEST_SERIAL_SEGMENT_MAX_LEN];
         size_t size = sizeof(buf);
         memset(buf, 1, size);
@@ -92,19 +92,19 @@ SCENARIO("serialChunkedTransmit")
                 CHECK(err == NULL);
             }
 
-            THEN("The buffer is passed verbatim to NoteSerialTransmit") {
+            THEN("The buffer is passed verbatim to noteSerialTransmit") {
                 CHECK(memcmp(buf, accumulatedBuf, size) == 0);
             }
 
-            THEN("NoteSerialTransmit is only called once, since the buffer fits"
+            THEN("noteSerialTransmit is only called once, since the buffer fits"
                  " in a single segment") {
-                CHECK(NoteSerialTransmit_fake.call_count == 1);
+                CHECK(noteSerialTransmit_fake.call_count == 1);
             }
         }
     }
 
     GIVEN("A buffer with size greater than the maximum serial segment length") {
-        NoteSerialTransmit_fake.custom_fake = NoteSerialTransmitAccumulate;
+        noteSerialTransmit_fake.custom_fake = noteSerialTransmitAccumulate;
         uint8_t buf[CARD_REQUEST_SERIAL_SEGMENT_MAX_LEN + 10];
         size_t size = sizeof(buf);
         memset(buf, 1, size);
@@ -116,13 +116,13 @@ SCENARIO("serialChunkedTransmit")
                 CHECK(err == NULL);
             }
 
-            THEN("The buffer is passed verbatim to NoteSerialTransmit") {
+            THEN("The buffer is passed verbatim to noteSerialTransmit") {
                 CHECK(memcmp(buf, accumulatedBuf, size) == 0);
             }
 
-            THEN("NoteSerialTransmit is called more than once, since the buffer"
+            THEN("noteSerialTransmit is called more than once, since the buffer"
                  " doesn't fit in a single segment") {
-                CHECK(NoteSerialTransmit_fake.call_count > 1);
+                CHECK(noteSerialTransmit_fake.call_count > 1);
             }
         }
 
@@ -147,7 +147,7 @@ SCENARIO("serialChunkedTransmit")
         }
     }
 
-    RESET_FAKE(NoteSerialTransmit);
+    RESET_FAKE(noteSerialTransmit);
     RESET_FAKE(NoteDelayMs);
 }
 

--- a/test/src/serialNoteReset_test.cpp
+++ b/test/src/serialNoteReset_test.cpp
@@ -19,10 +19,10 @@
 #include "n_lib.h"
 
 DEFINE_FFF_GLOBALS
-FAKE_VALUE_FUNC(bool, NoteSerialReset)
-FAKE_VOID_FUNC(NoteSerialTransmit, uint8_t *, size_t, bool)
-FAKE_VALUE_FUNC(bool, NoteSerialAvailable)
-FAKE_VALUE_FUNC(char, NoteSerialReceive)
+FAKE_VALUE_FUNC(bool, noteSerialReset)
+FAKE_VOID_FUNC(noteSerialTransmit, uint8_t *, size_t, bool)
+FAKE_VALUE_FUNC(bool, noteSerialAvailable)
+FAKE_VALUE_FUNC(char, noteSerialReceive)
 FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
 
 namespace
@@ -51,68 +51,68 @@ long unsigned int NoteGetMsMock()
 
 SCENARIO("serialNoteReset")
 {
-    SECTION("NoteSerialReset fails") {
-        NoteSerialReset_fake.return_val = false;
+    SECTION("noteSerialReset fails") {
+        noteSerialReset_fake.return_val = false;
 
         CHECK(!serialNoteReset());
-        CHECK(NoteSerialReset_fake.call_count == 1);
-        CHECK(NoteSerialTransmit_fake.call_count == 0);
+        CHECK(noteSerialReset_fake.call_count == 1);
+        CHECK(noteSerialTransmit_fake.call_count == 0);
     }
 
     SECTION("Serial never available") {
-        NoteSerialReset_fake.return_val = true;
-        NoteSerialAvailable_fake.return_val = false;
+        noteSerialReset_fake.return_val = true;
+        noteSerialAvailable_fake.return_val = false;
         NoteGetMs_fake.custom_fake = NoteGetMsMock;
 
         CHECK(!serialNoteReset());
         // serialNoteReset has retry logic, so we expect retries.
-        CHECK(NoteSerialTransmit_fake.call_count > 1);
-        CHECK(NoteSerialReceive_fake.call_count == 0);
+        CHECK(noteSerialTransmit_fake.call_count > 1);
+        CHECK(noteSerialReceive_fake.call_count == 0);
     }
 
     SECTION("Character received") {
         NoteGetMs_fake.custom_fake = NoteGetMsMock;
         bool serialAvailRetVals[] = {true, false};
-        SET_RETURN_SEQ(NoteSerialAvailable, serialAvailRetVals, 2);
+        SET_RETURN_SEQ(noteSerialAvailable, serialAvailRetVals, 2);
 
         SECTION("Non-control character received") {
-            NoteSerialReceive_fake.return_val = 'a';
+            noteSerialReceive_fake.return_val = 'a';
 
             SECTION("Retry") {
-                NoteSerialReset_fake.return_val = true;
+                noteSerialReset_fake.return_val = true;
 
                 CHECK(!serialNoteReset());
                 // Expect retries.
-                CHECK(NoteSerialTransmit_fake.call_count > 1);
+                CHECK(noteSerialTransmit_fake.call_count > 1);
             }
 
-            SECTION("NoteSerialReset fails before retry possible") {
+            SECTION("noteSerialReset fails before retry possible") {
                 bool noteSerialResetRetVals[] = {true, false};
-                SET_RETURN_SEQ(NoteSerialReset, noteSerialResetRetVals, 2);
+                SET_RETURN_SEQ(noteSerialReset, noteSerialResetRetVals, 2);
 
                 CHECK(!serialNoteReset());
                 // No retries.
-                CHECK(NoteSerialTransmit_fake.call_count == 1);
+                CHECK(noteSerialTransmit_fake.call_count == 1);
             }
         }
 
         SECTION("Only control character received") {
-            NoteSerialReset_fake.return_val = true;
-            NoteSerialReceive_fake.return_val = '\n';
+            noteSerialReset_fake.return_val = true;
+            noteSerialReceive_fake.return_val = '\n';
 
             CHECK(serialNoteReset());
             // There should be no retrying.
-            CHECK(NoteSerialTransmit_fake.call_count == 1);
+            CHECK(noteSerialTransmit_fake.call_count == 1);
         }
 
-        CHECK(NoteSerialReceive_fake.call_count > 0);
+        CHECK(noteSerialReceive_fake.call_count > 0);
     }
 
     SECTION("NoteGetMs overflow") {
-        NoteSerialReset_fake.return_val = true;
-        NoteSerialReceive_fake.return_val = '\n';
+        noteSerialReset_fake.return_val = true;
+        noteSerialReceive_fake.return_val = '\n';
         bool serialAvailRetVals[] = {true, false};
-        SET_RETURN_SEQ(NoteSerialAvailable, serialAvailRetVals, 2);
+        SET_RETURN_SEQ(noteSerialAvailable, serialAvailRetVals, 2);
         long unsigned int getMsReturnVals[] = {
             UINT32_MAX - 500,
             UINT32_MAX - 400,
@@ -123,10 +123,10 @@ SCENARIO("serialNoteReset")
         CHECK(serialNoteReset());
     }
 
-    RESET_FAKE(NoteSerialReset);
-    RESET_FAKE(NoteSerialTransmit);
-    RESET_FAKE(NoteSerialAvailable);
-    RESET_FAKE(NoteSerialReceive);
+    RESET_FAKE(noteSerialReset);
+    RESET_FAKE(noteSerialTransmit);
+    RESET_FAKE(noteSerialAvailable);
+    RESET_FAKE(noteSerialReceive);
     RESET_FAKE(NoteGetMs);
 }
 

--- a/test/src/serialNoteTransaction_test.cpp
+++ b/test/src/serialNoteTransaction_test.cpp
@@ -20,10 +20,10 @@
 
 DEFINE_FFF_GLOBALS
 FAKE_VALUE_FUNC(void *, NoteMalloc, size_t)
-FAKE_VALUE_FUNC(bool, NoteSerialAvailable)
-FAKE_VALUE_FUNC(char, NoteSerialReceive)
+FAKE_VALUE_FUNC(bool, noteSerialAvailable)
+FAKE_VALUE_FUNC(char, noteSerialReceive)
 FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
-FAKE_VOID_FUNC(NoteSerialTransmit, uint8_t *, size_t, bool)
+FAKE_VOID_FUNC(noteSerialTransmit, uint8_t *, size_t, bool)
 FAKE_VALUE_FUNC(const char *, serialChunkedTransmit, uint8_t *, uint32_t, bool);
 FAKE_VALUE_FUNC(const char *, serialChunkedReceive, uint8_t *, uint32_t *, bool, size_t, uint32_t *)
 
@@ -34,7 +34,7 @@ char transmitBuf[CARD_REQUEST_SERIAL_SEGMENT_MAX_LEN * 2];
 size_t transmitBufLen = 0;
 bool resetTransmitBufLen = false;
 
-void NoteSerialTransmitAppend(uint8_t *buf, size_t len, bool)
+void noteSerialTransmitAppend(uint8_t *buf, size_t len, bool)
 {
     if (resetTransmitBufLen) {
         transmitBufLen = 0;
@@ -55,7 +55,7 @@ void NoteSerialTransmitAppend(uint8_t *buf, size_t len, bool)
 
 const char *serialChunkedTransmitAppend(uint8_t *buf, uint32_t len, bool)
 {
-    NoteSerialTransmitAppend(buf, len, true);
+    noteSerialTransmitAppend(buf, len, true);
 
     return NULL;
 }
@@ -106,7 +106,7 @@ SCENARIO("serialNoteTransaction")
     const size_t timeoutMs = CARD_INTER_TRANSACTION_TIMEOUT_SEC;
 
     GIVEN("A valid JSON request C-string and a NULL response pointer") {
-        NoteSerialTransmit_fake.custom_fake = NoteSerialTransmitAppend;
+        noteSerialTransmit_fake.custom_fake = noteSerialTransmitAppend;
         serialChunkedTransmit_fake.custom_fake = serialChunkedTransmitAppend;
 
         WHEN("serialNoteTransaction is called") {
@@ -123,8 +123,8 @@ SCENARIO("serialNoteTransaction")
                 CHECK(!memcmp(transmitBuf + rawReqLen, c_newline, c_newline_len));
             }
 
-            THEN("NoteSerialReceive is not called") {
-                CHECK(NoteSerialReceive_fake.call_count == 0);
+            THEN("noteSerialReceive is not called") {
+                CHECK(noteSerialReceive_fake.call_count == 0);
             }
         }
 
@@ -147,7 +147,7 @@ SCENARIO("serialNoteTransaction")
 
         AND_GIVEN("Allocating a buffer to hold the response fails") {
             NoteMalloc_fake.return_val = NULL;
-            NoteSerialAvailable_fake.return_val = true;
+            noteSerialAvailable_fake.return_val = true;
 
             WHEN("serialNoteTransaction is called") {
                 const char *err = serialNoteTransaction(req, strlen(req), &rsp, timeoutMs);
@@ -160,9 +160,9 @@ SCENARIO("serialNoteTransaction")
                     CHECK(err != NULL);
                 }
 
-                THEN("NoteSerialReceive is not called (no bytes received from "
+                THEN("noteSerialReceive is not called (no bytes received from "
                      "the Notecard)") {
-                    CHECK(NoteSerialReceive_fake.call_count == 0);
+                    CHECK(noteSerialReceive_fake.call_count == 0);
                 }
 
                 THEN("The response pointer is unchanged") {
@@ -171,9 +171,9 @@ SCENARIO("serialNoteTransaction")
             }
         }
 
-        AND_GIVEN("NoteSerialAvailable never indicates bytes are available from"
+        AND_GIVEN("noteSerialAvailable never indicates bytes are available from"
                   " the Notecard") {
-            NoteSerialAvailable_fake.return_val = false;
+            noteSerialAvailable_fake.return_val = false;
             NoteMalloc_fake.custom_fake = malloc;
             long unsigned int getMsReturnVals[3];
 
@@ -193,9 +193,9 @@ SCENARIO("serialNoteTransaction")
                 WHEN("serialNoteTransaction is called") {
                     const char* err = serialNoteTransaction(req, strlen(req), &rsp, timeoutMs);
 
-                    THEN("NoteSerialReceive is not called (no bytes received "
+                    THEN("noteSerialReceive is not called (no bytes received "
                          "from the Notecard)") {
-                        CHECK(NoteSerialReceive_fake.call_count == 0);
+                        CHECK(noteSerialReceive_fake.call_count == 0);
                     }
 
                     THEN("serialNoteTransaction returns an error") {
@@ -214,7 +214,7 @@ SCENARIO("serialNoteTransaction")
         }
 
         AND_GIVEN("serialChunkedReceive returns an error") {
-            NoteSerialAvailable_fake.return_val = true;
+            noteSerialAvailable_fake.return_val = true;
             NoteMalloc_fake.custom_fake = malloc;
             serialChunkedReceive_fake.return_val = "some error";
 
@@ -232,7 +232,7 @@ SCENARIO("serialNoteTransaction")
         }
 
         AND_GIVEN("serialChunkedReceive indicates there's nothing to receive") {
-            NoteSerialAvailable_fake.return_val = true;
+            noteSerialAvailable_fake.return_val = true;
             NoteMalloc_fake.custom_fake = malloc;
             serialChunkedReceive_fake.custom_fake = serialChunkedReceiveNothing;
 
@@ -257,7 +257,7 @@ SCENARIO("serialNoteTransaction")
 
         AND_GIVEN("The response is small enough for one call to "
                   "serialChunkedReceive") {
-            NoteSerialAvailable_fake.return_val = true;
+            noteSerialAvailable_fake.return_val = true;
             NoteMalloc_fake.custom_fake = malloc;
             serialChunkedReceive_fake.custom_fake =
                 serialChunkedReceiveOneAndDone;
@@ -288,7 +288,7 @@ SCENARIO("serialNoteTransaction")
 
         AND_GIVEN("The response is too big for one call to "
                   "serialChunkedReceive") {
-            NoteSerialAvailable_fake.return_val = true;
+            noteSerialAvailable_fake.return_val = true;
             NoteMalloc_fake.custom_fake = malloc;
             serialChunkedReceive_fake.custom_fake =
                 serialChunkedReceiveMultiple;
@@ -343,9 +343,9 @@ SCENARIO("serialNoteTransaction")
     }
 
     RESET_FAKE(NoteMalloc);
-    RESET_FAKE(NoteSerialAvailable);
-    RESET_FAKE(NoteSerialTransmit);
-    RESET_FAKE(NoteSerialReceive);
+    RESET_FAKE(noteSerialAvailable);
+    RESET_FAKE(noteSerialTransmit);
+    RESET_FAKE(noteSerialReceive);
     RESET_FAKE(NoteGetMs);
     RESET_FAKE(serialChunkedTransmit);
     RESET_FAKE(serialChunkedReceive);


### PR DESCRIPTION
All internal/private functions in note-c should begin with a lowercase letter.

See https://github.com/blues/note-c/pull/99#discussion_r1324923027.