### PR TITLE
Reduce the cJSON object nesting limit from 1000 to 100 and document the macro.

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -144,8 +144,14 @@ Functions
 
 .. doxygenfunction:: JAddArrayToObject
 
+.. doxygenfunction:: JParse
 
 Types
 -----
 
 .. doxygenstruct:: J
+
+Macros
+------
+
+.. doxygendefine:: N_CJSON_NESTING_LIMIT

--- a/n_cjson.c
+++ b/n_cjson.c
@@ -957,7 +957,14 @@ fail:
     return NULL;
 }
 
-/* Default options for JParse */
+/*!
+ @brief Parse the passed in C-string as JSON and return a `J` object
+        representing it.
+
+ @param value The JSON object as a C-string.
+
+ @returns A `J` object or NULL on error (e.g. the string was invalid JSON).
+ */
 N_CJSON_PUBLIC(J *) JParse(const char *value)
 {
     return JParseWithOpts(value, 0, 0);

--- a/n_cjson.h
+++ b/n_cjson.h
@@ -145,10 +145,35 @@ then using the N_CJSON_API_VISIBILITY flag to "export" the same symbols the way 
 #endif
 #endif
 
-/* Limits how deeply nested arrays/objects can be before J rejects to parse them.
- * This is to prevent stack overflows. */
+/*!
+  @brief The maximum nesting level for JSON objects before a parsing error.
+
+  Default value: `100`
+
+  For example, if you have a JSON object that contains multiple, nested
+  objects like this
+
+      {
+          "x":
+          {
+              "x:"
+              {
+                  .
+                  .
+                  .
+              }
+          }
+      }
+
+  And the nesting level exceeds `N_CJSON_NESTING_LIMIT`, then calling `JParse` on
+  a `J *` representing this object will return an error (NULL).
+
+  This exists to prevent the cJSON parser from causing a stack overflow. The
+  user may override this macro at build time (e.g.
+  -DN_CJSON_NESTING_LIMIT=200) to increase or reduce the limit.
+ */
 #ifndef N_CJSON_NESTING_LIMIT
-#define N_CJSON_NESTING_LIMIT 1000
+#define N_CJSON_NESTING_LIMIT 100
 #endif
 
 /* returns the version of J as a string */


### PR DESCRIPTION
This limit is controlled with the macro `N_CJSON_NESTING_LIMIT`, which the user can override. This commit adds Doxygen documentation for it and includes it in the note-c docs site. The documentation references `JParse`, so I added documentation for that, too.