### PR TITLE
chore: Remove unused json_requests Doxygen group.

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -5,7 +5,7 @@ API Reference
 .. contents:: Table of Contents
    :depth: 2
 
-This pages covers the core functions and types that make up the note-c API.
+These pages cover the core functions and types that make up the note-c API.
 
 Dynamic Memory and Timing Hooks
 ===============================

--- a/n_request.c
+++ b/n_request.c
@@ -38,11 +38,6 @@ static bool notecardSupportsCrc = false;
 #endif
 
 /*!
- @defgroup json_requests Functions for creating and sending requests to a
-           Notecard.
- */
-
-/*!
  @internal
 
  @brief Create a JSON object containing an error message.


### PR DESCRIPTION
This is left over from experiments I was doing when working on the docs stuff. I just forgot to delete it.