### PR TITLE
Enable some previously disabled card.binary HIL tests.

### DIFF
--- a/.github/workflows/notecard-binary-tests.yml
+++ b/.github/workflows/notecard-binary-tests.yml
@@ -152,6 +152,9 @@ jobs:
             echo Stop Tunnelmole
             [ -n "$TMOLE_PID" ] || (echo "TMOLE_PID not set" && exit 1)
             [ -z "$TMOLE_PID" ] || kill $TMOLE_PID
+            # Remove the tmole_ready file, which may be leftover from a prior
+            # run.
+            rm -f $GITHUB_WORKSPACE/tmole_ready
 
       - name: Start tunnelmole
         uses: JarvusInnovations/background-action@v1
@@ -159,9 +162,9 @@ jobs:
         with:
           run: |
             bash ./scripts/run_tunnelmole.sh
+          log-output-if: true
           wait-on:
-            # just a dummy wait-on since this is required.
-            file:${{github.workspace}}/tmole.log
+            file:${{github.workspace}}/tmole_ready
 
       - name: Check server is available
         run: |

--- a/scripts/run_tunnelmole.sh
+++ b/scripts/run_tunnelmole.sh
@@ -18,5 +18,8 @@ MD5SRV_URL=`echo "$output" | grep https | cut -d " " -f1`
 echo "MD5SRV_URL=$MD5SRV_URL"
 [ -n "$MD5SRV_URL" ] || (echo "Could not fetch tunnelmole URL" && exit 1)
 echo "MD5SRV_URL=$MD5SRV_URL" >> $GITHUB_ENV
+# Only create tmole_ready once MD5SRV_URL has been set, as the next step in the
+# GitHub workflow depends on it.
+touch tmole_ready
 sleep 2
 echo "Tunnel mole started. Writing logs to `realpath tmole.log`"

--- a/test/hitl/card.binary/test/test_card_binary.cpp
+++ b/test/hitl/card.binary/test/test_card_binary.cpp
@@ -352,10 +352,10 @@ void base_test_max_length(NotecardInterface nif, const BinaryTestArgs& testArgs)
     binaryTransferTest("maxlength", image, nif, 0, testArgs);
 }
 
-// TEST(test_max_length_serial)
-// {
-//     base_test_max_length(NOTECARD_IF_SERIAL, validate);
-// }
+TEST(test_max_length_serial)
+{
+    base_test_max_length(NOTECARD_IF_SERIAL, validate);
+}
 
 TEST(test_max_length_i2c)
 {
@@ -421,14 +421,12 @@ void testsuite_card_binary()
     RUN_SMOKE_TESTS(NOTECARD_IF_I2C, i2c);
     set_aux_serial_baudrate();
     RUN_SMOKE_TESTS(NOTECARD_IF_AUX_SERIAL, auxserial);
-    // RUN_SMOKE_TESTS(NOTECARD_IF_SERIAL, serial);
+    RUN_SMOKE_TESTS(NOTECARD_IF_SERIAL, serial);
 
 //    RUN_AUX_SERIAL_ALL_BAUDRATES(all_sevens, AllSevens, TINY_SIZE, TINY_SIZE_NAME);
 //    RUN_AUX_SERIAL_ALL_BAUDRATES(all_sevens, AllSevens, 4*1024, 4k);
 
     //RUN_SIZE(all_ones, BuildAllSameValue, NOTECARD_IF_SERIAL, serial, 6*1024, 6k, 1);
-
-
 
 #if 0
     RUN_ALL_SIZES_ALL_IFACES(all_sevens, AllSevens);
@@ -440,5 +438,5 @@ void testsuite_card_binary()
 
     RUN_FILTER(test_max_length_i2c);
     RUN_FILTER(test_max_length_aux_serial);
-    // RUN_FILTER(test_max_length_serial);
+    RUN_FILTER(test_max_length_serial);
 }


### PR DESCRIPTION
These were disabled because there was a Notecard firmware bug that would drop a pair of bytes every ~1600 bytes of a binary transmit to the Notecard. Fixed with https://github.com/blues/notecard/commit/cb348dd496ae6f38990d8fdfa6d68478d49a4d1b.