### PR TITLE
Make some tweaks to HIL testing.

### DIFF
--- a/scripts/run_tunnelmole.sh
+++ b/scripts/run_tunnelmole.sh
@@ -15,7 +15,6 @@ exec 3< tmole.log
 read <&3 output
 read <&3 output
 MD5SRV_URL=`echo "$output" | grep https | cut -d " " -f1`
-echo "MD5SRV_URL=$MD5SRV_URL"
 [ -n "$MD5SRV_URL" ] || (echo "Could not fetch tunnelmole URL" && exit 1)
 echo "MD5SRV_URL=$MD5SRV_URL" >> $GITHUB_ENV
 # Only create tmole_ready once MD5SRV_URL has been set, as the next step in the


### PR DESCRIPTION
- Don't put the MD5 server URL in the log output. We want to keep that private.
- Dynamically computed binary store size based on the MCU being used by the
Notecard (i.e. r5 vs. u5).
- Change timeout in waitForNotecardConnected to 5 minutes instead of 300 ms,
which I believe was a mistake.