### PR TITLE
Remove ifdef guards around unit and HIL tests.

### DIFF
--- a/test/hitl/card.binary/lib/notecard_binary/NotecardBinary.cpp
+++ b/test/hitl/card.binary/lib/notecard_binary/NotecardBinary.cpp
@@ -1,5 +1,3 @@
-#ifdef PLATFORMIO
-
 #include "NotecardBinary.h"
 
 Notecard notecard;
@@ -14,4 +12,4 @@ BufferBinaryGenerator small_image(small_binary);
 // ensure the virtual destructor is defined.
 BinaryGenerator::~BinaryGenerator() {}
 
-#endif // PLATFORMIO
+

--- a/test/hitl/card.binary/lib/notecard_binary/NotecardBinary.h
+++ b/test/hitl/card.binary/lib/notecard_binary/NotecardBinary.h
@@ -1,4 +1,3 @@
-#ifdef PLATFORMIO
 
 #pragma once
 
@@ -1185,4 +1184,4 @@ public:
 extern BinaryImage small_binary;
 extern BufferBinaryGenerator small_image;
 
-#endif // PLATFORMIO
+

--- a/test/hitl/card.binary/lib/notecard_binary/NotecardComms.cpp
+++ b/test/hitl/card.binary/lib/notecard_binary/NotecardComms.cpp
@@ -1,4 +1,3 @@
-#ifdef PLATFORMIO
 
 #include "NotecardComms.h"
 #include <Arduino.h>
@@ -144,4 +143,4 @@ size_t readDataUntilTimeout(Stream& serial, size_t timeout, uint8_t* buf, size_t
 HardwareSerial Serial2(A0,A3);
 HardwareSerial Serial3(A5,A4); // A5 is RX, A4 is TX
 
-#endif // PLATFORMIO
+

--- a/test/hitl/card.binary/lib/notecard_binary/NotecardComms.h
+++ b/test/hitl/card.binary/lib/notecard_binary/NotecardComms.h
@@ -1,4 +1,3 @@
-#ifdef PLATFORMIO
 
 #pragma once
 
@@ -48,4 +47,4 @@ bool set_aux_serial_baudrate(size_t baudrate=NOTECARD_IF_AUX_SERIAL_BAUDRATE, No
 
 extern Notecard notecard;
 
-#endif // PLATFORMIO
+

--- a/test/hitl/card.binary/lib/notecard_binary/small_img.cpp
+++ b/test/hitl/card.binary/lib/notecard_binary/small_img.cpp
@@ -1,4 +1,3 @@
-#ifdef PLATFORMIO
 
 #include "small_img.h"
 
@@ -4919,4 +4918,4 @@ const uint8_t small_img_map[] = {
 };
 size_t small_img_len = 73687;
 
-#endif // PLATFORMIO
+

--- a/test/hitl/card.binary/lib/notecard_binary/small_img.h
+++ b/test/hitl/card.binary/lib/notecard_binary/small_img.h
@@ -1,4 +1,3 @@
-#ifdef PLATFORMIO
 
 #pragma once
 
@@ -8,4 +7,4 @@
 extern const uint8_t small_img_map[];
 extern size_t small_img_len;
 
-#endif // PLATFORMIO
+

--- a/test/hitl/card.binary/src/main.cpp
+++ b/test/hitl/card.binary/src/main.cpp
@@ -1,4 +1,3 @@
-#ifdef PLATFORMIO
 
 #include "NotecardBinary.h"
 
@@ -17,4 +16,4 @@ void loop()
 
 }
 
-#endif // PLATFORMIO
+

--- a/test/hitl/card.binary/test/test_binary_generators.cpp
+++ b/test/hitl/card.binary/test/test_binary_generators.cpp
@@ -1,4 +1,3 @@
-#ifdef PLATFORMIO
 
 #include "NotecardBinary.h"
 #include <Arduino.h>
@@ -89,4 +88,4 @@ void testsuite_binary_generators()
     RUN_TEST(test_random_generator);
 }
 
-#endif // PLATFORMIO
+

--- a/test/hitl/card.binary/test/test_binary_generators.h
+++ b/test/hitl/card.binary/test/test_binary_generators.h
@@ -1,4 +1,3 @@
-#ifdef PLATFORMIO
 
 #pragma once
 #include "NotecardBinary.h"
@@ -60,4 +59,4 @@ struct BuildRandom {
     }
 };
 
-#endif // PLATFORMIO
+

--- a/test/hitl/card.binary/test/test_card_binary.cpp
+++ b/test/hitl/card.binary/test/test_card_binary.cpp
@@ -1,4 +1,3 @@
-#ifdef PLATFORMIO
 
 #include "NotecardBinary.h"
 #include "NotecardComms.h"
@@ -473,4 +472,4 @@ void testsuite_card_binary()
     RUN_FILTER(test_max_length_serial);
 }
 
-#endif // PLATFORMIO
+

--- a/test/hitl/card.binary/test/test_card_binary.h
+++ b/test/hitl/card.binary/test/test_card_binary.h
@@ -1,5 +1,4 @@
-#ifdef PLATFORMIO
 
 void testsuite_card_binary();
 
-#endif // PLATFORMIO
+

--- a/test/hitl/card.binary/test/test_main.cpp
+++ b/test/hitl/card.binary/test/test_main.cpp
@@ -1,4 +1,3 @@
-#ifdef PLATFORMIO
 
 #include "test_card_binary.h"
 #include "test_binary_generators.h"
@@ -37,4 +36,4 @@ void loop()
 //  #error serial buffer is too small
 // #endif
 
-#endif // PLATFORMIO
+

--- a/test/hitl/card.binary/test/test_unity_util.cpp
+++ b/test/hitl/card.binary/test/test_unity_util.cpp
@@ -1,4 +1,3 @@
-#ifdef PLATFORMIO
 
 #include "test_unity_util.h"
 #include <string.h>
@@ -35,4 +34,4 @@ bool filterTest(const char* name)
     return true;
 }
 
-#endif // PLATFORMIO
+

--- a/test/hitl/card.binary/test/test_unity_util.h
+++ b/test/hitl/card.binary/test/test_unity_util.h
@@ -1,4 +1,3 @@
-#ifdef PLATFORMIO
 
 // This also needs to be added to build_flags in platformio.ini
 #ifndef UNITY_INCLUDE_PRINT_FORMATTED
@@ -32,4 +31,4 @@ extern bool filterTest(const char* name);
         RUN_TEST(func); \
     }
 
-#endif // PLATFORMIO
+

--- a/test/src/JAddBinaryToObject_test.cpp
+++ b/test/src/JAddBinaryToObject_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -83,4 +83,4 @@ SCENARIO("JAddBinaryToObject")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JAllocString_test.cpp
+++ b/test/src/JAllocString_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -59,4 +59,4 @@ SCENARIO("JAllocString")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JAtoI_test.cpp
+++ b/test/src/JAtoI_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -58,4 +58,4 @@ SCENARIO("JAtoI")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JBoolValue_test.cpp
+++ b/test/src/JBoolValue_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -50,4 +50,4 @@ SCENARIO("JBoolValue")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JContainsString_test.cpp
+++ b/test/src/JContainsString_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -68,4 +68,4 @@ SCENARIO("JContainsString")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JGetArray_test.cpp
+++ b/test/src/JGetArray_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -53,4 +53,4 @@ SCENARIO("JGetArray")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JGetBinaryFromObject_test.cpp
+++ b/test/src/JGetBinaryFromObject_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -80,4 +80,4 @@ SCENARIO("JGetBinaryFromObject")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JGetBool_test.cpp
+++ b/test/src/JGetBool_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -53,4 +53,4 @@ SCENARIO("JGetBool")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JGetInt_test.cpp
+++ b/test/src/JGetInt_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -53,4 +53,4 @@ SCENARIO("JGetInt")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JGetItemName_test.cpp
+++ b/test/src/JGetItemName_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -47,4 +47,4 @@ SCENARIO("JGetItemName")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JGetNumber_test.cpp
+++ b/test/src/JGetNumber_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -53,4 +53,4 @@ SCENARIO("JGetNumber")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JGetObject_test.cpp
+++ b/test/src/JGetObject_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -53,4 +53,4 @@ SCENARIO("JGetObject")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JGetString_test.cpp
+++ b/test/src/JGetString_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -66,4 +66,4 @@ SCENARIO("JGetString")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JGetType_test.cpp
+++ b/test/src/JGetType_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -158,4 +158,4 @@ SCENARIO("JGetType")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JIntValue_test.cpp
+++ b/test/src/JIntValue_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -46,4 +46,4 @@ SCENARIO("JIntValue")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JIsExactString_test.cpp
+++ b/test/src/JIsExactString_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -71,4 +71,4 @@ SCENARIO("JIsExactString")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JIsNullString_test.cpp
+++ b/test/src/JIsNullString_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -61,4 +61,4 @@ SCENARIO("JIsNullString")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JIsPresent_test.cpp
+++ b/test/src/JIsPresent_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -50,4 +50,4 @@ SCENARIO("JIsPresent")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JItoA_test.cpp
+++ b/test/src/JItoA_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -45,4 +45,4 @@ SCENARIO("JItoA")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JNumberValue_test.cpp
+++ b/test/src/JNumberValue_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -46,4 +46,4 @@ SCENARIO("JNumberValue")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JPrintUnformatted_test.cpp
+++ b/test/src/JPrintUnformatted_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -63,4 +63,4 @@ SCENARIO("JPrintUnformatted")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JStringValue_test.cpp
+++ b/test/src/JStringValue_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -46,4 +46,4 @@ SCENARIO("JStringValue")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/JType_test.cpp
+++ b/test/src/JType_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -64,4 +64,4 @@ SCENARIO("JType")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/Jtolower_test.cpp
+++ b/test/src/Jtolower_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -70,4 +70,4 @@ SCENARIO("Jtolower")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteAdd_test.cpp
+++ b/test/src/NoteAdd_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -72,4 +72,4 @@ SCENARIO("NoteAdd")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteBinaryCodecDecode_test.cpp
+++ b/test/src/NoteBinaryCodecDecode_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -88,4 +88,4 @@ SCENARIO("NoteBinaryCodecDecode")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteBinaryCodecEncode_test.cpp
+++ b/test/src/NoteBinaryCodecEncode_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <string.h>
 
@@ -89,4 +89,4 @@ SCENARIO("NoteBinaryCodecEncode")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteBinaryCodecMaxDecodedLength_test.cpp
+++ b/test/src/NoteBinaryCodecMaxDecodedLength_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -53,4 +53,4 @@ SCENARIO("NoteBinaryCodecMaxDecodedLength")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteBinaryCodecMaxEncodedLength_test.cpp
+++ b/test/src/NoteBinaryCodecMaxEncodedLength_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -53,4 +53,4 @@ SCENARIO("NoteBinaryCodecMaxEncodedLength")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteBinaryStoreDecodedLength_test.cpp
+++ b/test/src/NoteBinaryStoreDecodedLength_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -132,4 +132,4 @@ SCENARIO("NoteBinaryStoreDecodedLength")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteBinaryStoreEncodedLength_test.cpp
+++ b/test/src/NoteBinaryStoreEncodedLength_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -130,4 +130,4 @@ SCENARIO("NoteBinaryStoreEncodedLength")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteBinaryStoreReceive_test.cpp
+++ b/test/src/NoteBinaryStoreReceive_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -242,4 +242,4 @@ SCENARIO("NoteBinaryStoreReceive")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteBinaryStoreReset_test.cpp
+++ b/test/src/NoteBinaryStoreReset_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -84,4 +84,4 @@ SCENARIO("NoteBinaryStoreReset")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteBinaryStoreTransmit_test.cpp
+++ b/test/src/NoteBinaryStoreTransmit_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -404,4 +404,4 @@ SCENARIO("NoteBinaryStoreTransmit")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteClearLocation_test.cpp
+++ b/test/src/NoteClearLocation_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -62,4 +62,4 @@ SCENARIO("NoteClearLocation")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteDebugSyncStatus_test.cpp
+++ b/test/src/NoteDebugSyncStatus_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -167,4 +167,4 @@ SCENARIO("NoteDebugSyncStatus")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteDebug_test.cpp
+++ b/test/src/NoteDebug_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -124,4 +124,4 @@ SCENARIO("NoteDebug")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteDebugf_test.cpp
+++ b/test/src/NoteDebugf_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -46,4 +46,4 @@ SCENARIO("NoteDebugf")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteErrorClean_test.cpp
+++ b/test/src/NoteErrorClean_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -47,4 +47,4 @@ SCENARIO("NoteErrorClean")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteFactoryReset_test.cpp
+++ b/test/src/NoteFactoryReset_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -82,4 +82,4 @@ SCENARIO("NoteFactoryReset")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteGetContact_test.cpp
+++ b/test/src/NoteGetContact_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -107,4 +107,4 @@ SCENARIO("NoteGetContact")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteGetEnvNumber_test.cpp
+++ b/test/src/NoteGetEnvNumber_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -67,4 +67,4 @@ SCENARIO("NoteGetEnvNumber, NoteGetEnvInt")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteGetEnv_test.cpp
+++ b/test/src/NoteGetEnv_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -99,4 +99,4 @@ SCENARIO("NoteGetEnv")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteGetLocationMode_test.cpp
+++ b/test/src/NoteGetLocationMode_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -64,4 +64,4 @@ SCENARIO("NoteGetLocationMode")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteGetLocation_test.cpp
+++ b/test/src/NoteGetLocation_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -69,4 +69,4 @@ SCENARIO("NoteGetLocation")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteGetNetStatus_test.cpp
+++ b/test/src/NoteGetNetStatus_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -64,4 +64,4 @@ SCENARIO("NoteGetNetStatus")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteGetServiceConfig_test.cpp
+++ b/test/src/NoteGetServiceConfig_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -96,4 +96,4 @@ SCENARIO("NoteGetServiceConfig")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteGetStatus_test.cpp
+++ b/test/src/NoteGetStatus_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -95,4 +95,4 @@ SCENARIO("NoteGetStatus")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteGetTemperature_test.cpp
+++ b/test/src/NoteGetTemperature_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -78,4 +78,4 @@ SCENARIO("NoteGetTemperature")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteGetVersion_test.cpp
+++ b/test/src/NoteGetVersion_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -64,4 +64,4 @@ SCENARIO("NoteGetVersion")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteGetVoltage_test.cpp
+++ b/test/src/NoteGetVoltage_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -78,4 +78,4 @@ SCENARIO("NoteGetVoltage")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteIsConnected_test.cpp
+++ b/test/src/NoteIsConnected_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -66,4 +66,4 @@ SCENARIO("NoteIsConnected")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteLocalTimeST_test.cpp
+++ b/test/src/NoteLocalTimeST_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -97,4 +97,4 @@ SCENARIO("NoteLocalTimeST")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteLocationValid_test.cpp
+++ b/test/src/NoteLocationValid_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -76,4 +76,4 @@ SCENARIO("NoteLocationValid")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteNewCommand_test.cpp
+++ b/test/src/NoteNewCommand_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -53,4 +53,4 @@ SCENARIO("NoteNewCommand")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteNewRequest_test.cpp
+++ b/test/src/NoteNewRequest_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -53,4 +53,4 @@ SCENARIO("NoteNewRequest")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NotePayloadRetrieveAfterSleep_test.cpp
+++ b/test/src/NotePayloadRetrieveAfterSleep_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -140,4 +140,4 @@ SCENARIO("NotePayloadRetrieveAfterSleep")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NotePayloadSaveAndSleep_test.cpp
+++ b/test/src/NotePayloadSaveAndSleep_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -73,4 +73,4 @@ SCENARIO("NotePayloadSaveAndSleep")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NotePayload_test.cpp
+++ b/test/src/NotePayload_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -142,4 +142,4 @@ SCENARIO("NotePayload")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NotePrint_test.cpp
+++ b/test/src/NotePrint_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -83,4 +83,4 @@ SCENARIO("NotePrint")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NotePrintf_test.cpp
+++ b/test/src/NotePrintf_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -50,4 +50,4 @@ SCENARIO("NotePrintf")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NotePrintln_test.cpp
+++ b/test/src/NotePrintln_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -55,4 +55,4 @@ SCENARIO("NotePrintln")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteRegion_test.cpp
+++ b/test/src/NoteRegion_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -98,4 +98,4 @@ SCENARIO("NoteRegion")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteRequestResponseJSON_test.cpp
+++ b/test/src/NoteRequestResponseJSON_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -177,4 +177,4 @@ SCENARIO("NoteRequestResponseJSON")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteRequestResponse_test.cpp
+++ b/test/src/NoteRequestResponse_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -64,4 +64,4 @@ SCENARIO("NoteRequestResponse")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteRequestWithRetry_test.cpp
+++ b/test/src/NoteRequestWithRetry_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -120,5 +120,3 @@ SCENARIO("NoteRequestWithRetry")
 }
 
 }
-
-#endif

--- a/test/src/NoteRequest_test.cpp
+++ b/test/src/NoteRequest_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -67,4 +67,4 @@ SCENARIO("NoteRequest")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteReset_test.cpp
+++ b/test/src/NoteReset_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -55,4 +55,4 @@ SCENARIO("NoteReset")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSendToRoute_test.cpp
+++ b/test/src/NoteSendToRoute_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -103,4 +103,4 @@ SCENARIO("NoteSendToRoute")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSerialHooks_test.cpp
+++ b/test/src/NoteSerialHooks_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -60,4 +60,4 @@ SCENARIO("NoteSerialHooks")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSetContact_test.cpp
+++ b/test/src/NoteSetContact_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -72,4 +72,4 @@ SCENARIO("NoteSetContact")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSetEnvDefaultNumber_test.cpp
+++ b/test/src/NoteSetEnvDefaultNumber_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -55,4 +55,4 @@ SCENARIO("NoteSetEnvDefaultNumber, NoteSetEnvDefaultInt")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSetEnvDefault_test.cpp
+++ b/test/src/NoteSetEnvDefault_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -64,4 +64,4 @@ SCENARIO("NoteSetEnvDefault")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSetFnI2CMutex_test.cpp
+++ b/test/src/NoteSetFnI2CMutex_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -55,4 +55,4 @@ SCENARIO("NoteSetFnI2CMutex")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSetFnI2C_test.cpp
+++ b/test/src/NoteSetFnI2C_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -116,4 +116,4 @@ SCENARIO("NoteSetFnI2C")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSetFnMutex_test.cpp
+++ b/test/src/NoteSetFnMutex_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -79,4 +79,4 @@ SCENARIO("NoteSetFnMutex")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSetFnNoteMutex_test.cpp
+++ b/test/src/NoteSetFnNoteMutex_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -55,4 +55,4 @@ SCENARIO("NoteSetFnNoteMutex")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSetFnSerial_test.cpp
+++ b/test/src/NoteSetFnSerial_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -114,4 +114,4 @@ SCENARIO("NoteSetFnSerial")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSetFn_test.cpp
+++ b/test/src/NoteSetFn_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -90,4 +90,4 @@ SCENARIO("NoteSetFn")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSetLocationMode_test.cpp
+++ b/test/src/NoteSetLocationMode_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -75,4 +75,4 @@ SCENARIO("NoteSetLocationMode")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSetLocation_test.cpp
+++ b/test/src/NoteSetLocation_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -65,4 +65,4 @@ SCENARIO("NoteSetLocation")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSetProductID_test.cpp
+++ b/test/src/NoteSetProductID_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -72,4 +72,4 @@ SCENARIO("NoteSetProductID")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSetSerialNumber_test.cpp
+++ b/test/src/NoteSetSerialNumber_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -72,4 +72,4 @@ SCENARIO("NoteSetSerialNumber")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSetSyncMode_test.cpp
+++ b/test/src/NoteSetSyncMode_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -95,4 +95,4 @@ SCENARIO("NoteSetSyncMode")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSetUploadMode_test.cpp
+++ b/test/src/NoteSetUploadMode_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -77,4 +77,4 @@ SCENARIO("NoteSetUploadMode")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteSleep_test.cpp
+++ b/test/src/NoteSleep_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -77,4 +77,4 @@ SCENARIO("NoteSleep")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteTemplate_test.cpp
+++ b/test/src/NoteTemplate_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -65,4 +65,4 @@ SCENARIO("NoteTemplate")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteTimeSet_test.cpp
+++ b/test/src/NoteTimeSet_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -91,4 +91,4 @@ SCENARIO("NoteTimeSet")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteTime_test.cpp
+++ b/test/src/NoteTime_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -102,4 +102,4 @@ SCENARIO("NoteTime")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteTransactionHooks_test.cpp
+++ b/test/src/NoteTransactionHooks_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -60,4 +60,4 @@ SCENARIO("NoteTransactionHooks")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteTransaction_test.cpp
+++ b/test/src/NoteTransaction_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -408,4 +408,4 @@ SCENARIO("NoteTransaction")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/NoteUserAgent_test.cpp
+++ b/test/src/NoteUserAgent_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include "n_lib.h"
 #include <catch2/catch_test_macros.hpp>
@@ -98,4 +98,3 @@ SCENARIO("NoteUserAgent")
 }
 
 #endif // !NOTE_DISABLE_USER_AGENT
-#endif // NOTE_C_TEST

--- a/test/src/NoteWake_test.cpp
+++ b/test/src/NoteWake_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -76,4 +76,4 @@ SCENARIO("NoteWake")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/crcAdd_test.cpp
+++ b/test/src/crcAdd_test.cpp
@@ -11,7 +11,6 @@
  *
  */
 
-#ifdef NOTE_C_TEST
 #ifndef NOTE_LOWMEM
 
 #include <catch2/catch_test_macros.hpp>
@@ -70,4 +69,3 @@ SCENARIO("crcAdd")
 }
 
 #endif // !NOTE_LOWMEM
-#endif // NOTE_C_TEST

--- a/test/src/crcError_test.cpp
+++ b/test/src/crcError_test.cpp
@@ -11,7 +11,6 @@
  *
  */
 
-#ifdef NOTE_C_TEST
 #ifndef NOTE_LOWMEM
 
 #include <catch2/catch_test_macros.hpp>
@@ -87,4 +86,3 @@ SCENARIO("crcError")
 }
 
 #endif // !NOTE_LOWMEM
-#endif // NOTE_C_TEST

--- a/test/src/i2cChunkedReceive_test.cpp
+++ b/test/src/i2cChunkedReceive_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -415,4 +415,4 @@ SCENARIO("i2cChunkedReceive")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/i2cChunkedTransmit_test.cpp
+++ b/test/src/i2cChunkedTransmit_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -142,4 +142,4 @@ SCENARIO("i2cChunkedTransmit")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/i2cNoteQueryLength_test.cpp
+++ b/test/src/i2cNoteQueryLength_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -149,4 +149,4 @@ SCENARIO("i2cNoteQueryLength")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/i2cNoteReset_test.cpp
+++ b/test/src/i2cNoteReset_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -506,4 +506,4 @@ SCENARIO("i2cNoteReset")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/i2cNoteTransaction_test.cpp
+++ b/test/src/i2cNoteTransaction_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -260,4 +260,4 @@ SCENARIO("i2cNoteTransaction")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/serialChunkedReceive_test.cpp
+++ b/test/src/serialChunkedReceive_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -299,4 +299,4 @@ SCENARIO("serialChunkedReceive")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/serialChunkedTransmit_test.cpp
+++ b/test/src/serialChunkedTransmit_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -153,4 +153,4 @@ SCENARIO("serialChunkedTransmit")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/serialNoteReset_test.cpp
+++ b/test/src/serialNoteReset_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -132,4 +132,4 @@ SCENARIO("serialNoteReset")
 
 }
 
-#endif // NOTE_C_TEST
+

--- a/test/src/serialNoteTransaction_test.cpp
+++ b/test/src/serialNoteTransaction_test.cpp
@@ -11,7 +11,7 @@
  *
  */
 
-#ifdef NOTE_C_TEST
+
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -353,4 +353,4 @@ SCENARIO("serialNoteTransaction")
 
 }
 
-#endif // NOTE_C_TEST
+


### PR DESCRIPTION
These guards were our way of getting around the contents of these files being included in note-arduino builds. With this commit, we're getting rid of them. Instead, in note-arduino when we include note-c, we'll remove the test subdirectory all together. Then these files aren't even there to begin with, so they can't mess up the note-arduino build.