### PR TITLE
Fix NOTE_LOWMEM.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,23 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./build/test/coverage/lcov.info
 
+  run_low_mem_unit_tests:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [build_ci_docker_image]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Load CI Docker image
+        if: ${{ needs.build_ci_docker_image.result == 'success' }}
+        uses: ./.github/actions/load-ci-image
+
+      - name: Run tests with NOTE_LOWMEM defined
+        run: |
+          docker run --rm --volume $(pwd):/note-c/ --workdir /note-c/ --entrypoint ./scripts/run_unit_tests.sh ghcr.io/blues/note_c_ci:latest --mem-check --low-mem
+
   run_astyle:
     runs-on: ubuntu-latest
     if: ${{ always() }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(NOTE_C_COVERAGE "Compile for test NOTE_C_COVERAGE reporting." OFF)
 option(NOTE_C_MEM_CHECK "Run tests with Valgrind." OFF)
 option(NOTE_C_BUILD_DOCS "Build docs." OFF)
 option(NOTE_C_NO_LIBC "Build the library without linking against libc, generating errors for any undefined symbols." OFF)
+option(NOTE_C_LOW_MEM "Build the library tailored for low memory usage." OFF)
 
 set(NOTE_C_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(note_c SHARED)
@@ -40,7 +41,6 @@ target_sources(
         ${NOTE_C_SRC_DIR}/n_request.c
         ${NOTE_C_SRC_DIR}/n_serial.c
         ${NOTE_C_SRC_DIR}/n_str.c
-        ${NOTE_C_SRC_DIR}/n_ua.c
 )
 target_compile_options(
     note_c
@@ -56,6 +56,23 @@ target_include_directories(
     note_c
     PUBLIC ${NOTE_C_SRC_DIR}
 )
+
+if(NOTE_C_LOW_MEM)
+    target_compile_definitions(
+        note_c
+        PUBLIC
+            NOTE_LOWMEM
+    )
+else()
+    # This file is empty if NOTE_LOWMEM is defined, which leads to a warning
+    # about an empty translation unit, so we only add it to the build if
+    # NOTE_C_LOW_MEM is false.
+    target_sources(
+        note_c
+        PRIVATE
+            ${NOTE_C_SRC_DIR}/n_ua.c
+    )
+endif()
 
 if(NOTE_C_NO_LIBC)
     target_link_options(
@@ -82,11 +99,13 @@ if(NOTE_C_BUILD_TESTS)
 
     target_compile_definitions(
         note_c
-        PUBLIC NOTE_C_TEST
+        PUBLIC
+            NOTE_C_TEST
     )
     target_include_directories(
         note_c
-        PRIVATE ${CMAKE_CURRENT_LIST_DIR}/test/include
+        PRIVATE
+            ${CMAKE_CURRENT_LIST_DIR}/test/include
     )
 
     add_subdirectory(test)

--- a/n_lib.h
+++ b/n_lib.h
@@ -100,6 +100,10 @@ extern "C" {
 #define ALLOC_CHUNK 128
 #endif
 
+#ifdef NOTE_LOWMEM
+#define NOTE_DISABLE_USER_AGENT
+#endif
+
 // Transactions
 J *noteTransactionShouldLock(J *req, bool lockNotecard);
 const char *i2cNoteTransaction(const char *request, size_t reqLen, char **response, size_t timeoutMs);

--- a/n_request.c
+++ b/n_request.c
@@ -450,8 +450,8 @@ J *noteTransactionShouldLock(J *req, bool lockNotecard)
     // where we can find out that the cmd failed.  Note that a Seqno is included
     // as part of the CRC data so that two identical requests occurring within the
     // modulus of seqno never are mistaken as being the same request being retried.
-#ifndef NOTE_LOWMEM
     uint8_t lastRequestRetries = 0;
+#ifndef NOTE_LOWMEM
     bool lastRequestCrcAdded = false;
     if (!noResponseExpected) {
         char *newJson = crcAdd(json, lastRequestSeqno);
@@ -509,7 +509,6 @@ J *noteTransactionShouldLock(J *req, bool lockNotecard)
     char *responseJSON = NULL;
     J *rsp = NULL;
     while (true) {
-#ifndef NOTE_LOWMEM
         // If no retry possibility, break out
         if (lastRequestRetries > CARD_REQUEST_RETRIES_ALLOWED) {
             break;
@@ -517,7 +516,6 @@ J *noteTransactionShouldLock(J *req, bool lockNotecard)
             // free on retry
             JDelete(rsp);
         }
-#endif // !NOTE_LOWMEM
 
         // reset variables
         rsp = NULL;
@@ -542,7 +540,6 @@ J *noteTransactionShouldLock(J *req, bool lockNotecard)
         // Swap newline-terminator for NULL-terminator
         json[jsonLen] = '\0';
 
-#ifndef NOTE_LOWMEM
         // If there's an I/O error on the transaction, retry
         if (errStr != NULL) {
             JFree(responseJSON);
@@ -553,6 +550,7 @@ J *noteTransactionShouldLock(J *req, bool lockNotecard)
             continue;
         }
 
+#ifndef NOTE_LOWMEM
         // If we sent a CRC in the request, examine the response JSON to see if
         // it has a CRC error.  Note that the CRC is stripped from the
         // responseJSON as a side-effect of this method.
@@ -564,6 +562,7 @@ J *noteTransactionShouldLock(J *req, bool lockNotecard)
             _DelayMs(500);
             continue;
         }
+#endif // !NOTE_LOWMEM
 
         // See if the response JSON can't be unmarshaled, or if it contains an {io} error
         rsp = JParse(responseJSON);
@@ -603,7 +602,6 @@ J *noteTransactionShouldLock(J *req, bool lockNotecard)
                 continue;
             }
         }
-#endif // !NOTE_LOWMEM
 
         // Transaction completed
         break;

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -2,11 +2,13 @@
 
 COVERAGE=0
 MEM_CHECK=0
+LOW_MEM=0
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --coverage) COVERAGE=1 ;;
         --mem-check) MEM_CHECK=1 ;;
+        --low-mem) LOW_MEM=1 ;;
         *) echo "Unknown parameter: $1"; exit 1 ;;
     esac
     shift
@@ -36,6 +38,9 @@ if [[ $MEM_CHECK -eq 1 ]]; then
     # This fixes a problem when running valgrind in a Docker container when the
     # host machine is running Fedora. See https://stackoverflow.com/a/75293014.
     ulimit -n 1024
+fi
+if [[ $NOTE_C_LOW_MEM -eq 1 ]]; then
+    CMAKE_OPTIONS="${CMAKE_OPTIONS} -DNOTE_C_LOW_MEM=1"
 fi
 
 cmake -B build/ $CMAKE_OPTIONS

--- a/test/src/NoteTransaction_test.cpp
+++ b/test/src/NoteTransaction_test.cpp
@@ -183,6 +183,7 @@ SCENARIO("NoteTransaction")
         JDelete(resp);
     }
 
+#ifndef NOTE_LOWMEM
     SECTION("Bad CRC") {
         J *req = NoteNewRequest("note.add");
         REQUIRE(req != NULL);
@@ -197,6 +198,7 @@ SCENARIO("NoteTransaction")
         JDelete(req);
         JDelete(resp);
     }
+#endif // !NOTE_LOWMEM
 
     SECTION("I/O error") {
         J *req = NoteNewRequest("note.add");

--- a/test/src/NoteUserAgent_test.cpp
+++ b/test/src/NoteUserAgent_test.cpp
@@ -13,10 +13,13 @@
 
 #ifdef NOTE_C_TEST
 
+#include "n_lib.h"
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
 
-#include "n_lib.h"
+// This has to come after n_lib.h, which will define NOTE_DISABLE_USER_AGENT if
+// NOTE_LOWMEM is defined.
+#ifndef NOTE_DISABLE_USER_AGENT
 
 DEFINE_FFF_GLOBALS
 FAKE_VALUE_FUNC(J *, JCreateObject)
@@ -94,4 +97,5 @@ SCENARIO("NoteUserAgent")
 
 }
 
+#endif // !NOTE_DISABLE_USER_AGENT
 #endif // NOTE_C_TEST

--- a/test/src/crcAdd_test.cpp
+++ b/test/src/crcAdd_test.cpp
@@ -12,6 +12,7 @@
  */
 
 #ifdef NOTE_C_TEST
+#ifndef NOTE_LOWMEM
 
 #include <catch2/catch_test_macros.hpp>
 #include "fff.h"
@@ -68,4 +69,5 @@ SCENARIO("crcAdd")
 
 }
 
+#endif // !NOTE_LOWMEM
 #endif // NOTE_C_TEST

--- a/test/src/crcError_test.cpp
+++ b/test/src/crcError_test.cpp
@@ -12,6 +12,7 @@
  */
 
 #ifdef NOTE_C_TEST
+#ifndef NOTE_LOWMEM
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -85,4 +86,5 @@ SCENARIO("crcError")
 
 }
 
+#endif // !NOTE_LOWMEM
 #endif // NOTE_C_TEST


### PR DESCRIPTION
Prior to this commit, NOTE_LOWMEM was fundamentally broken because it would cause our core transaction logic to never return a response from the Notecard. This commit fixes that and the relevant unit tests. There were some other unit tests that were broken for different reasons. For example, the CRC tests should never run with NOTE_LOWMEM defined because all the CRC logic is cut out.

Additionally, the n_ua.c is empty if NOTE_LOWMEM is defined. This implies that NOTE_DISABLE_USER_AGENT should be defined if NOTE_LOWMEM is defined, so I added that logic to n_lib.h.

This commit also adds a CI build that runs the unit tests with NOTE_LOWMEM defined.