### PR TITLE
Fix timeout data type bugs.

### DIFF
--- a/n_hooks.c
+++ b/n_hooks.c
@@ -174,8 +174,8 @@ i2cReceiveFn hookI2CReceive = NULL;
 
 // Internal hooks
 typedef bool (*nNoteResetFn) (void);
-typedef const char * (*nTransactionFn) (const char *, size_t, char **, size_t);
-typedef const char * (*nReceiveFn) (uint8_t *, uint32_t *, bool, size_t, uint32_t *);
+typedef const char * (*nTransactionFn) (const char *, size_t, char **, uint32_t);
+typedef const char * (*nReceiveFn) (uint8_t *, uint32_t *, bool, uint32_t, uint32_t *);
 typedef const char * (*nTransmitFn) (uint8_t *, uint32_t, bool);
 static nNoteResetFn notecardReset = NULL;
 static nTransactionFn notecardTransaction = NULL;
@@ -470,7 +470,7 @@ void NoteDebugWithLevelLn(uint8_t level, const char *msg)
   @returns  The current milliseconds value.
 */
 /**************************************************************************/
-long unsigned int NoteGetMs(void)
+uint32_t NoteGetMs(void)
 {
     if (hookGetMs == NULL) {
         return 0;
@@ -857,7 +857,7 @@ bool noteHardReset(void)
   or the hook has not been set.
 */
 /**************************************************************************/
-const char *noteJSONTransaction(const char *request, size_t reqLen, char **response, size_t timeoutMs)
+const char *noteJSONTransaction(const char *request, size_t reqLen, char **response, uint32_t timeoutMs)
 {
     if (notecardTransaction == NULL || hookActiveInterface == interfaceNone) {
         return "i2c or serial interface must be selected";
@@ -884,7 +884,7 @@ const char *noteJSONTransaction(const char *request, size_t reqLen, char **respo
 */
 /**************************************************************************/
 const char *noteChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay,
-                               size_t timeoutMs, uint32_t *available)
+                               uint32_t timeoutMs, uint32_t *available)
 {
     if (notecardChunkedReceive == NULL || hookActiveInterface == interfaceNone) {
         return "i2c or serial interface must be selected";

--- a/n_i2c.c
+++ b/n_i2c.c
@@ -23,7 +23,7 @@
 
 // Forwards
 NOTE_C_STATIC void delayIO(void);
-NOTE_C_STATIC const char * i2cNoteQueryLength(uint32_t * available, size_t timeoutMs);
+NOTE_C_STATIC const char * i2cNoteQueryLength(uint32_t * available, uint32_t timeoutMs);
 
 /**************************************************************************/
 /*!
@@ -50,11 +50,11 @@ NOTE_C_STATIC void delayIO(void)
 */
 /**************************************************************************/
 NOTE_C_STATIC const char * i2cNoteQueryLength(uint32_t * available,
-        size_t timeoutMs)
+        uint32_t timeoutMs)
 {
     uint8_t dummy_buffer = 0;
 
-    for (const size_t startMs = _GetMs() ; !(*available) ; _DelayMs(50)) {
+    for (const uint32_t startMs = _GetMs() ; !(*available) ; _DelayMs(50)) {
         // Send a dummy I2C transaction to prime the Notecard
         const char *err = _I2CReceive(_I2CAddress(), &dummy_buffer, 0, available);
         if (err) {
@@ -92,7 +92,7 @@ NOTE_C_STATIC const char * i2cNoteQueryLength(uint32_t * available,
   @returns a c-string with an error, or `NULL` if no error occurred.
 */
 /**************************************************************************/
-const char *i2cNoteTransaction(const char *request, size_t reqLen, char **response, size_t timeoutMs)
+const char *i2cNoteTransaction(const char *request, size_t reqLen, char **response, uint32_t timeoutMs)
 {
     const char *err = NULL;
 
@@ -256,7 +256,7 @@ bool i2cNoteReset(void)
         bool nonControlCharFound = false;
 
         // Read I2C data for at least `CARD_RESET_DRAIN_MS` continuously
-        for (size_t startMs = _GetMs() ; (_GetMs() - startMs) < CARD_RESET_DRAIN_MS ;) {
+        for (uint32_t startMs = _GetMs() ; (_GetMs() - startMs) < CARD_RESET_DRAIN_MS ;) {
 
             // Read the next chunk of available data
             uint32_t available = 0;
@@ -350,13 +350,13 @@ bool i2cNoteReset(void)
   @returns  A c-string with an error, or `NULL` if no error ocurred.
 */
 /**************************************************************************/
-const char *i2cChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay, size_t timeoutMs, uint32_t *available)
+const char *i2cChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay, uint32_t timeoutMs, uint32_t *available)
 {
     // Load buffer with chunked I2C values
     size_t received = 0;
     uint16_t requested = 0;
     bool overflow = false;
-    size_t startMs = _GetMs();
+    uint32_t startMs = _GetMs();
 
     // Request all available bytes, up to the maximum request size
     requested = (*available > 0xFFFF) ? 0xFFFF : *available;

--- a/n_lib.h
+++ b/n_lib.h
@@ -106,13 +106,13 @@ extern "C" {
 
 // Transactions
 J *noteTransactionShouldLock(J *req, bool lockNotecard);
-const char *i2cNoteTransaction(const char *request, size_t reqLen, char **response, size_t timeoutMs);
+const char *i2cNoteTransaction(const char *request, size_t reqLen, char **response, uint32_t timeoutMs);
 bool i2cNoteReset(void);
-const char *serialNoteTransaction(const char *request, size_t reqLen, char **response, size_t timeoutMs);
+const char *serialNoteTransaction(const char *request, size_t reqLen, char **response, uint32_t timeoutMs);
 bool serialNoteReset(void);
-const char *i2cChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay, size_t timeoutMs, uint32_t *available);
+const char *i2cChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay, uint32_t timeoutMs, uint32_t *available);
 const char *i2cChunkedTransmit(uint8_t *buffer, uint32_t size, bool delay);
-const char *serialChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay, size_t timeoutMs, uint32_t *available);
+const char *serialChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay, uint32_t timeoutMs, uint32_t *available);
 const char *serialChunkedTransmit(uint8_t *buffer, uint32_t size, bool delay);
 
 // Hooks
@@ -129,8 +129,8 @@ bool noteI2CReset(uint16_t DevAddress);
 const char *noteI2CTransmit(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size);
 const char *noteI2CReceive(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size, uint32_t *avail);
 bool noteHardReset(void);
-const char *noteJSONTransaction(const char *request, size_t reqLen, char **response, size_t timeoutMs);
-const char *noteChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay, size_t timeoutMs, uint32_t *available);
+const char *noteJSONTransaction(const char *request, size_t reqLen, char **response, uint32_t timeoutMs);
+const char *noteChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay, uint32_t timeoutMs, uint32_t *available);
 const char *noteChunkedTransmit(uint8_t *buffer, uint32_t size, bool delay);
 bool noteIsDebugOutputActive(void);
 

--- a/n_request.c
+++ b/n_request.c
@@ -303,7 +303,7 @@ J *NoteRequestResponseWithRetry(J *req, uint32_t timeoutSeconds)
 */
 char * NoteRequestResponseJSON(const char *reqJSON)
 {
-    size_t transactionTimeoutMs = (CARD_INTER_TRANSACTION_TIMEOUT_SEC * 1000);
+    uint32_t transactionTimeoutMs = (CARD_INTER_TRANSACTION_TIMEOUT_SEC * 1000);
     char *rspJSON = NULL;
 
     if (reqJSON == NULL) {
@@ -476,7 +476,7 @@ J *noteTransactionShouldLock(J *req, bool lockNotecard)
     //   - If the request is a `web.*`, follow the same logic, but instead
     //     of using the standard timeout, use the Notecard timeout of 90
     //     seconds for all `web.*` transactions.
-    size_t transactionTimeoutMs = (CARD_INTER_TRANSACTION_TIMEOUT_SEC * 1000);
+    uint32_t transactionTimeoutMs = (CARD_INTER_TRANSACTION_TIMEOUT_SEC * 1000);
 
     // Interrogate the request
     if (JContainsString(req, (reqType ? "req" : "cmd"), "note.add")) {

--- a/n_serial.c
+++ b/n_serial.c
@@ -31,7 +31,7 @@
   @returns a c-string with an error, or `NULL` if no error occurred.
 */
 /**************************************************************************/
-const char *serialNoteTransaction(const char *request, size_t reqLen, char **response, size_t timeoutMs)
+const char *serialNoteTransaction(const char *request, size_t reqLen, char **response, uint32_t timeoutMs)
 {
     // Strip off the newline and optional carriage return characters. This
     // allows for standardized output to be reapplied.
@@ -167,7 +167,7 @@ bool serialNoteReset(void)
         bool nonControlCharFound = false;
 
         // Read Serial data for at least CARD_RESET_DRAIN_MS continously
-        for (size_t startMs = _GetMs() ; (_GetMs() - startMs) < CARD_RESET_DRAIN_MS ;) {
+        for (uint32_t startMs = _GetMs() ; (_GetMs() - startMs) < CARD_RESET_DRAIN_MS ;) {
             // Determine if Serial data is available
             while (_SerialAvailable()) {
                 somethingFound = true;
@@ -225,11 +225,11 @@ bool serialNoteReset(void)
   @returns  A c-string with an error, or `NULL` if no error ocurred.
 */
 /**************************************************************************/
-const char *serialChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay, size_t timeoutMs, uint32_t *available)
+const char *serialChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay, uint32_t timeoutMs, uint32_t *available)
 {
     size_t received = 0;
     bool overflow = (received >= *size);
-    size_t startMs = _GetMs();
+    uint32_t startMs = _GetMs();
     for (bool eop = false ; !overflow && !eop ;) {
         while (!_SerialAvailable()) {
             if (timeoutMs && (_GetMs() - startMs >= timeoutMs)) {

--- a/note.h
+++ b/note.h
@@ -355,7 +355,7 @@ void NoteDebugWithLevelLn(uint8_t level, const char *msg);
 
 void *NoteMalloc(size_t size);
 void NoteFree(void *);
-long unsigned int NoteGetMs(void);
+uint32_t NoteGetMs(void);
 void NoteDelayMs(uint32_t ms);
 void NoteLockI2C(void);
 void NoteUnlockI2C(void);

--- a/test/include/test_static.h
+++ b/test/include/test_static.h
@@ -15,7 +15,7 @@ extern "C" {
 char *crcAdd(char *json, uint16_t seqno);
 bool crcError(char *json, uint16_t shouldBeSeqno);
 void delayIO(void);
-const char * i2cNoteQueryLength(uint32_t * available, size_t timeoutMs);
+const char * i2cNoteQueryLength(uint32_t * available, uint32_t timeoutMs);
 void setTime(JTIME seconds);
 bool timerExpiredSecs(uint32_t *timer, uint32_t periodSecs);
 char Jtolower(char c);

--- a/test/include/time_mocks.h
+++ b/test/include/time_mocks.h
@@ -13,7 +13,7 @@
 
 #pragma once
 
-long unsigned int NoteGetMsIncrement(void)
+uint32_t NoteGetMsIncrement(void)
 {
     static long unsigned int count = 0;
 

--- a/test/src/NoteBinaryStoreReceive_test.cpp
+++ b/test/src/NoteBinaryStoreReceive_test.cpp
@@ -25,7 +25,7 @@ FAKE_VALUE_FUNC(uint32_t, NoteBinaryCodecDecode, const uint8_t *, uint32_t, uint
 FAKE_VALUE_FUNC(const char *, NoteBinaryStoreEncodedLength, uint32_t *)
 FAKE_VALUE_FUNC(J *, noteTransactionShouldLock, J *, bool)
 FAKE_VALUE_FUNC(const char *, noteChunkedReceive, uint8_t *, uint32_t *, bool,
-                size_t, uint32_t *)
+                uint32_t, uint32_t *)
 FAKE_VOID_FUNC(noteLockNote)
 FAKE_VOID_FUNC(noteUnlockNote)
 
@@ -143,7 +143,7 @@ SCENARIO("NoteBinaryStoreReceive")
     GIVEN("noteChunkedReceive indicates there's unexpectedly more data "
           "available") {
         noteChunkedReceive_fake.custom_fake = [](uint8_t *, uint32_t *, bool,
-        size_t, uint32_t *available) -> const char* {
+        uint32_t, uint32_t *available) -> const char* {
             *available = 1;
 
             return NULL;
@@ -164,7 +164,7 @@ SCENARIO("NoteBinaryStoreReceive")
             return cobsDecode((uint8_t *)encData, encDataLen, '\n', decBuf);
         };
         noteChunkedReceive_fake.custom_fake = [](uint8_t *buffer, uint32_t *size,
-        bool, size_t, uint32_t *available) -> const char* {
+        bool, uint32_t, uint32_t *available) -> const char* {
             uint32_t outLen = NoteBinaryCodecEncode((uint8_t *)rawMsg, rawMsgLen, buffer, *size);
 
             buffer[outLen] = '\n';

--- a/test/src/NoteDebugSyncStatus_test.cpp
+++ b/test/src/NoteDebugSyncStatus_test.cpp
@@ -20,7 +20,7 @@
 #include "time_mocks.h"
 
 DEFINE_FFF_GLOBALS
-FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
+FAKE_VALUE_FUNC(uint32_t, NoteGetMs)
 FAKE_VALUE_FUNC(J *, NoteNewRequest, const char *)
 FAKE_VALUE_FUNC(J *, NoteRequestResponse, J *)
 FAKE_VOID_FUNC(NoteDebug, const char *)
@@ -85,7 +85,7 @@ SCENARIO("NoteDebugSyncStatus")
 
         SECTION("Millisecond rollover") {
             NoteGetMs_fake.custom_fake = NULL;
-            long unsigned int getMsReturnVals[3] = {8000, 9000, 500};
+            uint32_t getMsReturnVals[3] = {8000, 9000, 500};
             SET_RETURN_SEQ(NoteGetMs, getMsReturnVals, 3);
 
             CHECK(!NoteDebugSyncStatus(pollFrequencyMs, maxLevel));

--- a/test/src/NoteRequestResponseJSON_test.cpp
+++ b/test/src/NoteRequestResponseJSON_test.cpp
@@ -23,7 +23,7 @@ FAKE_VALUE_FUNC(bool, noteTransactionStart, uint32_t)
 FAKE_VOID_FUNC(noteTransactionStop)
 FAKE_VOID_FUNC(noteLockNote)
 FAKE_VOID_FUNC(noteUnlockNote)
-FAKE_VALUE_FUNC(const char *, noteJSONTransaction, const char *, size_t, char **, size_t)
+FAKE_VALUE_FUNC(const char *, noteJSONTransaction, const char *, size_t, char **, uint32_t)
 
 namespace
 {

--- a/test/src/NoteRequestWithRetry_test.cpp
+++ b/test/src/NoteRequestWithRetry_test.cpp
@@ -20,7 +20,7 @@
 
 DEFINE_FFF_GLOBALS
 FAKE_VALUE_FUNC(J *, NoteTransaction, J *)
-FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
+FAKE_VALUE_FUNC(uint32_t, NoteGetMs)
 
 namespace
 {
@@ -55,7 +55,7 @@ SCENARIO("NoteRequestWithRetry")
         // With this timeout configuration, NoteTransaction will be retried at
         // most one time.
         const uint32_t timeoutSec = 5;
-        long unsigned int getMsReturnVals[3];
+        uint32_t getMsReturnVals[3];
 
         J *req = NoteNewRequest("note.add");
         REQUIRE(req != nullptr);

--- a/test/src/NoteSetFnI2C_test.cpp
+++ b/test/src/NoteSetFnI2C_test.cpp
@@ -20,7 +20,7 @@
 
 DEFINE_FFF_GLOBALS
 FAKE_VALUE_FUNC(bool, i2cNoteReset)
-FAKE_VALUE_FUNC(const char *, i2cNoteTransaction, const char *, size_t, char **, size_t)
+FAKE_VALUE_FUNC(const char *, i2cNoteTransaction, const char *, size_t, char **, uint32_t)
 
 namespace
 {

--- a/test/src/NoteSetFnSerial_test.cpp
+++ b/test/src/NoteSetFnSerial_test.cpp
@@ -20,7 +20,7 @@
 
 DEFINE_FFF_GLOBALS
 FAKE_VALUE_FUNC(bool, serialNoteReset)
-FAKE_VALUE_FUNC(const char *, serialNoteTransaction, const char *, size_t, char **, size_t)
+FAKE_VALUE_FUNC(const char *, serialNoteTransaction, const char *, size_t, char **, uint32_t)
 
 namespace
 {

--- a/test/src/NoteTimeSet_test.cpp
+++ b/test/src/NoteTimeSet_test.cpp
@@ -20,21 +20,11 @@
 #include "time_mocks.h"
 
 DEFINE_FFF_GLOBALS
-FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
+FAKE_VALUE_FUNC(uint32_t, NoteGetMs)
 FAKE_VALUE_FUNC(J *, NoteNewRequest, const char *)
 
 namespace
 {
-
-long unsigned int NoteGetMsIncrement(void)
-{
-    static long unsigned int count = 0;
-
-    // increment by 1 second
-    count += 1000;
-    // return count pre-increment
-    return count - 1000;
-}
 
 SCENARIO("NoteTimeSet")
 {

--- a/test/src/NoteTime_test.cpp
+++ b/test/src/NoteTime_test.cpp
@@ -22,7 +22,7 @@
 DEFINE_FFF_GLOBALS
 FAKE_VALUE_FUNC(J *, NoteNewRequest, const char *)
 FAKE_VALUE_FUNC(J *, NoteRequestResponse, J *)
-FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
+FAKE_VALUE_FUNC(uint32_t, NoteGetMs)
 
 namespace
 {
@@ -81,9 +81,9 @@ SCENARIO("NoteTime")
 
     SECTION("Millisecond rollover") {
         JTIME baseTime = 1679335667;
-        long unsigned int baseTimeSetAtMs = 1000;
-        long unsigned int rolloverMs = 500;
-        long unsigned int getMsRetVals[] = {baseTimeSetAtMs, rolloverMs};
+        uint32_t baseTimeSetAtMs = 1000;
+        uint32_t rolloverMs = 500;
+        uint32_t getMsRetVals[] = {baseTimeSetAtMs, rolloverMs};
         SET_RETURN_SEQ(NoteGetMs, getMsRetVals, 2);
 
         // Set the time manually so that the base time is non-zero.

--- a/test/src/NoteTransaction_test.cpp
+++ b/test/src/NoteTransaction_test.cpp
@@ -21,7 +21,7 @@
 
 DEFINE_FFF_GLOBALS
 FAKE_VALUE_FUNC(bool, NoteReset)
-FAKE_VALUE_FUNC(const char *, noteJSONTransaction, const char *, size_t, char **, size_t)
+FAKE_VALUE_FUNC(const char *, noteJSONTransaction, const char *, size_t, char **, uint32_t)
 FAKE_VALUE_FUNC(bool, noteTransactionStart, uint32_t)
 FAKE_VALUE_FUNC(J *, NoteUserAgent)
 FAKE_VALUE_FUNC(bool, crcError, char *, uint16_t)
@@ -29,7 +29,7 @@ FAKE_VALUE_FUNC(bool, crcError, char *, uint16_t)
 namespace
 {
 
-const char *noteJSONTransactionValid(const char *, size_t, char **resp, size_t)
+const char *noteJSONTransactionValid(const char *, size_t, char **resp, uint32_t)
 {
     static char respString[] = "{ \"total\": 1 }";
 
@@ -42,7 +42,7 @@ const char *noteJSONTransactionValid(const char *, size_t, char **resp, size_t)
     return NULL;
 }
 
-const char *noteJSONTransactionBadJSON(const char *, size_t, char **resp, size_t)
+const char *noteJSONTransactionBadJSON(const char *, size_t, char **resp, uint32_t)
 {
     static char respString[] = "Bad JSON";
 
@@ -55,7 +55,7 @@ const char *noteJSONTransactionBadJSON(const char *, size_t, char **resp, size_t
     return NULL;
 }
 
-const char *noteJSONTransactionIOError(const char *, size_t, char **resp, size_t)
+const char *noteJSONTransactionIOError(const char *, size_t, char **resp, uint32_t)
 {
     static char respString[] = "{\"err\": \"{io}\"}";
 
@@ -130,7 +130,7 @@ SCENARIO("NoteTransaction")
     WHEN("The transaction is successful and the response has a {bad-bin} error") {
         J *req = NoteNewRequest("note.add");
         REQUIRE(req != NULL);
-        noteJSONTransaction_fake.custom_fake = [](const char *, size_t, char **response, size_t) -> const char * {
+        noteJSONTransaction_fake.custom_fake = [](const char *, size_t, char **response, uint32_t) -> const char * {
             const char rsp_str[] = "{\"err\":\"{bad-bin}\"}";
             *response = (char *)malloc(sizeof(rsp_str));
             strncpy(*response, rsp_str, sizeof(rsp_str));
@@ -158,7 +158,7 @@ SCENARIO("NoteTransaction")
     WHEN("The transaction is successful and the response contains invalid JSON") {
         J *req = NoteNewRequest("note.add");
         REQUIRE(req != NULL);
-        noteJSONTransaction_fake.custom_fake = [](const char *, size_t, char **response, size_t) -> const char * {
+        noteJSONTransaction_fake.custom_fake = [](const char *, size_t, char **response, uint32_t) -> const char * {
             const char rsp_str[] = "{Looks like JSON, but won't parse}";
             *response = (char *)malloc(sizeof(rsp_str));
             strncpy(*response, rsp_str, sizeof(rsp_str));

--- a/test/src/i2cChunkedReceive_test.cpp
+++ b/test/src/i2cChunkedReceive_test.cpp
@@ -23,7 +23,7 @@
 DEFINE_FFF_GLOBALS
 FAKE_VALUE_FUNC(const char *, noteI2CReceive, uint16_t, uint8_t *, uint16_t,
                 uint32_t *)
-FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
+FAKE_VALUE_FUNC(uint32_t, NoteGetMs)
 FAKE_VOID_FUNC(NoteDelayMs, uint32_t)
 
 namespace
@@ -43,7 +43,7 @@ SCENARIO("i2cChunkedReceive")
     NoteGetMs_fake.custom_fake = NoteGetMsIncrement;
 
     uint32_t available = 0;
-    size_t timeoutMs = 5000;
+    uint32_t timeoutMs = 5000;
 
     GIVEN("0 is specified for the output buffer length") {
         uint8_t buf[] = {0xAB};

--- a/test/src/i2cNoteQueryLength_test.cpp
+++ b/test/src/i2cNoteQueryLength_test.cpp
@@ -23,7 +23,7 @@
 DEFINE_FFF_GLOBALS
 FAKE_VALUE_FUNC(const char *, noteI2CReceive, uint16_t, uint8_t *, uint16_t,
                 uint32_t *)
-FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
+FAKE_VALUE_FUNC(uint32_t, NoteGetMs)
 
 namespace
 {
@@ -55,7 +55,7 @@ SCENARIO("i2cNoteQueryLength")
 {
     NoteGetMs_fake.custom_fake = NoteGetMsIncrement;
     uint32_t available = 0;
-    size_t timeoutMs = 5000;
+    uint32_t timeoutMs = 5000;
 
     GIVEN("noteI2CReceive returns an error") {
         noteI2CReceive_fake.return_val = "some error";

--- a/test/src/i2cNoteReset_test.cpp
+++ b/test/src/i2cNoteReset_test.cpp
@@ -22,7 +22,7 @@
 DEFINE_FFF_GLOBALS
 FAKE_VOID_FUNC(delayIO)
 FAKE_VOID_FUNC(NoteDelayMs, uint32_t)
-FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
+FAKE_VALUE_FUNC(uint32_t, NoteGetMs)
 FAKE_VALUE_FUNC(bool, noteI2CReset, uint16_t)
 FAKE_VALUE_FUNC(const char *, noteI2CTransmit, uint16_t, uint8_t *, uint16_t)
 FAKE_VALUE_FUNC(const char *, noteI2CReceive, uint16_t, uint8_t *, uint16_t,
@@ -33,14 +33,14 @@ FAKE_VOID_FUNC(NoteUnlockI2C)
 namespace
 {
 
-static size_t rtc_ms = 0;
+static uint32_t rtc_ms = 0;
 
 void NoteDelayMs_mock(uint32_t delayMs)
 {
     rtc_ms += delayMs;
 }
 
-long unsigned int NoteGetMs_mock(void)
+uint32_t NoteGetMs_mock(void)
 {
     return rtc_ms++;
 }

--- a/test/src/serialChunkedReceive_test.cpp
+++ b/test/src/serialChunkedReceive_test.cpp
@@ -22,7 +22,7 @@
 DEFINE_FFF_GLOBALS
 FAKE_VALUE_FUNC(bool, noteSerialAvailable)
 FAKE_VALUE_FUNC(char, noteSerialReceive)
-FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
+FAKE_VALUE_FUNC(uint32_t, NoteGetMs)
 FAKE_VOID_FUNC(NoteDelayMs, uint32_t)
 
 namespace
@@ -43,8 +43,8 @@ SCENARIO("serialChunkedReceive")
 {
     NoteSetFnDefault(malloc, free, NULL, NULL);
 
-    NoteGetMs_fake.custom_fake = []() -> long unsigned int {
-        static long unsigned int count = 0;
+    NoteGetMs_fake.custom_fake = []() -> uint32_t {
+        static uint32_t count = 0;
 
         // increment by 1 second
         count += 750;
@@ -54,7 +54,7 @@ SCENARIO("serialChunkedReceive")
     uint8_t buf[] = {0xDE, 0xAD, 0xBE, 0xEF, 0x00};
     uint32_t size = sizeof(buf);
     bool delay = false;
-    const size_t timeoutMs = 3000;
+    const uint32_t timeoutMs = 3000;
     // 37 is not significant. serialChunkedReceive will return either a 1 or 0
     // in the "available" parameter. 37 is simply "not 1 or 0" -- that means we
     // can validate that available is changed to the correct value where

--- a/test/src/serialNoteReset_test.cpp
+++ b/test/src/serialNoteReset_test.cpp
@@ -23,14 +23,14 @@ FAKE_VALUE_FUNC(bool, noteSerialReset)
 FAKE_VOID_FUNC(noteSerialTransmit, uint8_t *, size_t, bool)
 FAKE_VALUE_FUNC(bool, noteSerialAvailable)
 FAKE_VALUE_FUNC(char, noteSerialReceive)
-FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
+FAKE_VALUE_FUNC(uint32_t, NoteGetMs)
 
 namespace
 {
 
-long unsigned int NoteGetMsMock()
+uint32_t NoteGetMsMock()
 {
-    static long unsigned int ret = 500;
+    static uint32_t ret = 500;
 
     // Cycle through returning 0, 1, and 500. 500 ms is the timeout of the
     // receive loop in serialNoteReset.
@@ -113,7 +113,7 @@ SCENARIO("serialNoteReset")
         noteSerialReceive_fake.return_val = '\n';
         bool serialAvailRetVals[] = {true, false};
         SET_RETURN_SEQ(noteSerialAvailable, serialAvailRetVals, 2);
-        long unsigned int getMsReturnVals[] = {
+        uint32_t getMsReturnVals[] = {
             UINT32_MAX - 500,
             UINT32_MAX - 400,
             0

--- a/test/src/serialNoteTransaction_test.cpp
+++ b/test/src/serialNoteTransaction_test.cpp
@@ -22,10 +22,10 @@ DEFINE_FFF_GLOBALS
 FAKE_VALUE_FUNC(void *, NoteMalloc, size_t)
 FAKE_VALUE_FUNC(bool, noteSerialAvailable)
 FAKE_VALUE_FUNC(char, noteSerialReceive)
-FAKE_VALUE_FUNC(long unsigned int, NoteGetMs)
+FAKE_VALUE_FUNC(uint32_t, NoteGetMs)
 FAKE_VOID_FUNC(noteSerialTransmit, uint8_t *, size_t, bool)
 FAKE_VALUE_FUNC(const char *, serialChunkedTransmit, uint8_t *, uint32_t, bool);
-FAKE_VALUE_FUNC(const char *, serialChunkedReceive, uint8_t *, uint32_t *, bool, size_t, uint32_t *)
+FAKE_VALUE_FUNC(const char *, serialChunkedReceive, uint8_t *, uint32_t *, bool, uint32_t, uint32_t *)
 
 namespace
 {
@@ -60,8 +60,8 @@ const char *serialChunkedTransmitAppend(uint8_t *buf, uint32_t len, bool)
     return NULL;
 }
 
-const char *serialChunkedReceiveNothing(uint8_t *, uint32_t *size, bool, size_t,
-                                        uint32_t *available)
+const char *serialChunkedReceiveNothing(uint8_t *, uint32_t *size, bool,
+                                        uint32_t, uint32_t *available)
 {
     *size = 0;
     *available = 0;
@@ -70,7 +70,7 @@ const char *serialChunkedReceiveNothing(uint8_t *, uint32_t *size, bool, size_t,
 }
 
 const char *serialChunkedReceiveOneAndDone(uint8_t *buf, uint32_t *size, bool,
-        size_t, uint32_t *available)
+        uint32_t, uint32_t *available)
 {
     *buf = '\n';
     *size = 1;
@@ -84,7 +84,7 @@ const char *serialChunkedReceiveOneAndDone(uint8_t *buf, uint32_t *size, bool,
 size_t serialChunkedReceiveMultipleLeft = SERIAL_CHUNKED_RECEIVE_MULTIPLE_SIZE;
 
 const char *serialChunkedReceiveMultiple(uint8_t *buf, uint32_t *size, bool,
-        size_t, uint32_t *available)
+        uint32_t, uint32_t *available)
 {
     memset(buf, 1, *size);
     serialChunkedReceiveMultipleLeft -= *size;
@@ -103,7 +103,7 @@ SCENARIO("serialNoteTransaction")
     NoteSetFnDefault(NULL, free, NULL, NULL);
 
     char req[] = "{\"req\": \"note.add\"}\n";
-    const size_t timeoutMs = CARD_INTER_TRANSACTION_TIMEOUT_SEC;
+    const uint32_t timeoutMs = CARD_INTER_TRANSACTION_TIMEOUT_SEC;
 
     GIVEN("A valid JSON request C-string and a NULL response pointer") {
         noteSerialTransmit_fake.custom_fake = noteSerialTransmitAppend;
@@ -175,7 +175,7 @@ SCENARIO("serialNoteTransaction")
                   " the Notecard") {
             noteSerialAvailable_fake.return_val = false;
             NoteMalloc_fake.custom_fake = malloc;
-            long unsigned int getMsReturnVals[3];
+            uint32_t getMsReturnVals[3];
 
             AND_GIVEN("There's a timeout after waiting for "
                       "CARD_INTER_TRANSACTION_TIMEOUT_SEC seconds") {


### PR DESCRIPTION
This commit resolves a couple problems.

First, it changes the return type of NoteGetMs. NoteGetMs is simply a wrapper around the user-supplied millisecond timer hook. The prototype for this hook specifies that it should return a uint32_t yet NoteGetMs's return type is long unsigned int. This commit changes the return type of NoteGetMs to uint32_t.

Second, there are many places in the code where we are comparing and assigning millisecond timer values (i.e. gotten via NoteGetMs) to size_t variables. This is a bug. On some platforms (e.g. the Arduino Uno), size_t is 16 bits, so assigning one of these 32-bit millisecond timer values to a 16-bit variable can lead to undefined behavior when the timer value is larger than what can fit into 16 bits. This commit fixes all these bugs by using uint32_t instead of size_t.