### PR TITLE
Improve cJSON number handling.

### DIFF
--- a/n_atof.c
+++ b/n_atof.c
@@ -257,7 +257,7 @@ char **endPtr;              /* If non-NULL, store terminating character's
         case 5:
             p10 = 1.0e32;
             break;
-#ifndef NOTE_FLOAT
+#ifndef NOTE_LOWMEM
         case 6:
             p10 = 1.0e64;
             break;

--- a/n_cjson.c
+++ b/n_cjson.c
@@ -63,9 +63,6 @@
 
 // For Note, disable dependencies
 #undef ENABLE_LOCALES
-#ifndef CJSON_NO_CLIB
-#define CJSON_NO_CLIB      1       // Use tiny but non-robust versions of conversions
-#endif
 
 #include "n_lib.h"
 
@@ -287,25 +284,19 @@ static Jbool parse_number(J * const item, parse_buffer * const input_buffer)
 loop_end:
     number_c_string[i] = '\0';
 
-    /* some platforms may not have locale support */
-#if !CJSON_NO_CLIB
-    number = strtod((const char*)number_c_string, (char**)&after_end);
-#else
     number = JAtoN((const char*)number_c_string, (char**)&after_end);
-#endif
     if (number_c_string == after_end) {
         return false; /* parse_error */
     }
-
     item->valuenumber = number;
 
-    /* use saturation in case of overflow */
-    if (number >= LONG_MAX) {
-        item->valueint = LONG_MAX;
-    } else if (number <= LONG_MIN) {
-        item->valueint = LONG_MIN;
+    // Saturate valueint in the case of overflow.
+    if (number >= JINTEGER_MAX) {
+        item->valueint = JINTEGER_MAX;
+    } else if (number <= JINTEGER_MIN) {
+        item->valueint = JINTEGER_MIN;
     } else {
-        item->valueint = (long int)number;
+        item->valueint = JAtoI((const char*)number_c_string);
     }
 
     item->type = JNumber;
@@ -320,12 +311,14 @@ N_CJSON_PUBLIC(JNUMBER) JSetNumberHelper(J *object, JNUMBER number)
     if (object == NULL) {
         return number;
     }
-    if (number >= LONG_MAX) {
-        object->valueint = LONG_MAX;
-    } else if (number <= LONG_MIN) {
-        object->valueint = LONG_MIN;
+
+    // Saturate valueint in the case of overflow.
+    if (number >= JINTEGER_MAX) {
+        object->valueint = JINTEGER_MAX;
+    } else if (number <= JINTEGER_MIN) {
+        object->valueint = JINTEGER_MIN;
     } else {
-        object->valueint = (long int)number;
+        object->valueint = (JINTEGER)number;
     }
 
     return object->valuenumber = number;
@@ -421,7 +414,8 @@ static Jbool print_number(const J * const item, printbuffer * const output_buffe
     }
 
     unsigned char *output_pointer = NULL;
-    JNUMBER d = item->valuenumber;
+    JNUMBER vnum = item->valuenumber;
+    JINTEGER vint = item->valueint;
     int length = 0;
     size_t i = 0;
     unsigned char number_buffer[JNTOA_MAX]; /* temporary buffer to print the number into */
@@ -432,34 +426,20 @@ static Jbool print_number(const J * const item, printbuffer * const output_buffe
     }
 
     /* This checks for NaN and Infinity */
-    if ((d * 0) != 0) {
+    if ((vnum * 0) != 0) {
         char *nbuf = (char *) number_buffer;
         strlcpy(nbuf, "null", JNTOA_MAX);
         length = strlen(nbuf);
     } else {
-#if !CJSON_NO_CLIB
-        JNUMBER test;
-        /* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */
-        length = sprintf((char*)number_buffer, "%1.15g", d);
-
-        /* Check whether the original double can be recovered */
-        if ((sscanf((char*)number_buffer, "%lg", &test) != 1) || ((JNUMBER)test != d)) {
-            /* If not, print with 17 decimal places of precision */
-            length = sprintf((char*)number_buffer, "%1.17g", d);
-        }
-        if (strchr((char*)number_buffer, '.') != NULL) {
-            while (length > 1 && number_buffer[length-1] == '0') {
-                number_buffer[--length] = '\0';
-            }
-            if (length > 1 && number_buffer[length-1] == '.') {
-                number_buffer[--length] = '\0';
-            }
-        }
-#else
         char *nbuf = (char *) number_buffer;
-        JNtoA(d, nbuf, -1);
+
+        if (vnum != (JNUMBER)vint) {
+            JNtoA(vnum, nbuf, -1);
+        } else {
+            JItoA(vint, nbuf);
+        }
+
         length = strlen(nbuf);
-#endif
     }
 
     /* conversion failed or buffer overrun occured */
@@ -1939,6 +1919,21 @@ N_CJSON_PUBLIC(J*) JAddNumberToObject(J * const object, const char * const name,
     return NULL;
 }
 
+N_CJSON_PUBLIC(J*) JAddIntToObject(J * const object, const char * const name, const JINTEGER integer)
+{
+    if (object == NULL) {
+        return NULL;
+    }
+
+    J *integer_item = JCreateInteger(integer);
+    if (add_item_to_object(object, name, integer_item, false)) {
+        return integer_item;
+    }
+
+    JDelete(integer_item);
+    return NULL;
+}
+
 /*!
  @brief Add a string field to a `J` object.
 
@@ -2257,14 +2252,26 @@ N_CJSON_PUBLIC(J *) JCreateNumber(JNUMBER num)
     if(item) {
         item->type = JNumber;
         item->valuenumber = num;
-        /* use saturation in case of overflow */
-        if (num >= LONG_MAX) {
-            item->valueint = LONG_MAX;
-        } else if (num <= LONG_MIN) {
-            item->valueint = LONG_MIN;
+
+        // Saturate valueint in the case of overflow.
+        if (num >= JINTEGER_MAX) {
+            item->valueint = JINTEGER_MAX;
+        } else if (num <= JINTEGER_MIN) {
+            item->valueint = JINTEGER_MIN;
         } else {
-            item->valueint = (long int)num;
+            item->valueint = (JINTEGER)num;
         }
+    }
+    return item;
+}
+
+N_CJSON_PUBLIC(J *) JCreateInteger(JINTEGER integer)
+{
+    J *item = JNew_Item();
+    if(item) {
+        item->type = JNumber;
+        item->valuenumber = (JNUMBER)integer;
+        item->valueint = integer;
     }
     return item;
 }

--- a/n_cjson.h
+++ b/n_cjson.h
@@ -88,7 +88,7 @@ typedef struct J {
     /* The item's string, if type==JString  and type == JRaw */
     char *valuestring;
     /* writing to valueint is DEPRECATED, use JSetNumberValue instead */
-    long int valueint;
+    JINTEGER valueint;
     /* The item's number, if type==JNumber */
     JNUMBER valuenumber;
     /* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
@@ -236,6 +236,7 @@ N_CJSON_PUBLIC(J *) JCreateTrue(void);
 N_CJSON_PUBLIC(J *) JCreateFalse(void);
 N_CJSON_PUBLIC(J *) JCreateBool(Jbool boolean);
 N_CJSON_PUBLIC(J *) JCreateNumber(JNUMBER num);
+N_CJSON_PUBLIC(J *) JCreateInteger(JINTEGER integer);
 N_CJSON_PUBLIC(J *) JCreateString(const char *string);
 /* raw json */
 N_CJSON_PUBLIC(J *) JCreateRaw(const char *raw);
@@ -302,7 +303,7 @@ N_CJSON_PUBLIC(J*) JAddTrueToObject(J * const object, const char * const name);
 N_CJSON_PUBLIC(J*) JAddFalseToObject(J * const object, const char * const name);
 N_CJSON_PUBLIC(J*) JAddBoolToObject(J * const object, const char * const name, const Jbool boolean);
 N_CJSON_PUBLIC(J*) JAddNumberToObject(J * const object, const char * const name, const JNUMBER number);
-#define JAddIntToObject(object, name, integer) JAddNumberToObject(object, name, (JNUMBER)(integer))
+N_CJSON_PUBLIC(J*) JAddIntToObject(J * const object, const char * const name, const JINTEGER integer);
 N_CJSON_PUBLIC(J*) JAddStringToObject(J * const object, const char * const name, const char * const string);
 N_CJSON_PUBLIC(J*) JAddRawToObject(J * const object, const char * const name, const char * const raw);
 N_CJSON_PUBLIC(J*) JAddObjectToObject(J * const object, const char * const name);

--- a/n_cjson_helpers.c
+++ b/n_cjson_helpers.c
@@ -179,7 +179,7 @@ JNUMBER JGetNumber(J *rsp, const char *field)
     @returns The number, or 0, if NULL.
 */
 /**************************************************************************/
-long int JIntValue(J *item)
+JINTEGER JIntValue(J *item)
 {
     if (item == NULL) {
         return 0;
@@ -195,7 +195,7 @@ long int JIntValue(J *item)
     @returns The int found, or 0, if not present.
 */
 /**************************************************************************/
-long int JGetInt(J *rsp, const char *field)
+JINTEGER JGetInt(J *rsp, const char *field)
 {
     if (rsp == NULL) {
         return 0;
@@ -431,15 +431,18 @@ const char *JGetItemName(const J * item)
 void JItoA(long int n, char *s)
 {
     char c;
-    long int i, j, sign;
-    if ((sign = n) < 0) {
-        n = -n;
+    // Conversion to unsigned is required to handle the case where n is
+    // LONG_MIN.
+    unsigned long int unsignedN = n;
+    long int i, j;
+    if (n < 0) {
+        unsignedN = -unsignedN;
     }
     i = 0;
     do {
-        s[i++] = n % 10 + '0';
-    } while ((n /= 10) > 0);
-    if (sign < 0) {
+        s[i++] = unsignedN % 10 + '0';
+    } while ((unsignedN /= 10) > 0);
+    if (n < 0) {
         s[i++] = '-';
     }
     s[i] = '\0';
@@ -585,11 +588,7 @@ int JGetItemType(J *item)
         }
         int vlen = strlen(v);
         char *endstr;
-#if !CJSON_NO_CLIB
-        JNUMBER value = strtod(v, &endstr);
-#else
         JNUMBER value = JAtoN(v, &endstr);
-#endif
         if (endstr[0] == 0) {
             if (value == 0) {
                 return JTYPE_STRING_ZERO;

--- a/note.h
+++ b/note.h
@@ -25,28 +25,43 @@
 #define NOTE_C_VERSION_MINOR 1
 #define NOTE_C_VERSION_PATCH 1
 
-// Determine our basic floating data type.  In most cases "double" is the right answer, however for
-// very small microcontrollers we must use single-precision.
+// If double and float are the same size, then we must be on a small MCU. Turn
+// on NOTE_LOWMEM to conserve memory.
 #if defined(FLT_MAX_EXP) && defined(DBL_MAX_EXP)
 #if (FLT_MAX_EXP == DBL_MAX_EXP)
-#define NOTE_FLOAT
+#define NOTE_LOWMEM
 #endif
 #elif defined(__FLT_MAX_EXP__) && defined(__DBL_MAX_EXP__)
 #if (__FLT_MAX_EXP__ == __DBL_MAX_EXP__)
-#define NOTE_FLOAT
+#define NOTE_LOWMEM
 #endif
 #else
 #error What are floating point exponent length symbols for this compiler?
 #endif
 
-// If using a short float, we must be on a VERY small MCU.  In this case, define additional
-// symbols that will save quite a bit of memory in the runtime image.
-#ifdef NOTE_FLOAT
+#ifndef JNUMBER
+#ifdef NOTE_LOWMEM
 #define JNUMBER float
-#define ERRSTR(x,y) (y)
-#define NOTE_LOWMEM
 #else
 #define JNUMBER double
+#endif
+#endif
+
+#ifndef JINTEGER
+#ifdef NOTE_LOWMEM
+#define JINTEGER int32_t
+#define JINTEGER_MIN INT32_MIN
+#define JINTEGER_MAX INT32_MAX
+#else
+#define JINTEGER int64_t
+#define JINTEGER_MIN INT64_MIN
+#define JINTEGER_MAX INT64_MAX
+#endif
+#endif
+
+#ifdef NOTE_LOWMEM
+#define ERRSTR(x,y) (y)
+#else
 #define ERRSTR(x,y) (x)
 #define ERRDBG
 #endif
@@ -378,12 +393,12 @@ char *JGetString(J *rsp, const char *field);
 JNUMBER JGetNumber(J *rsp, const char *field);
 J *JGetArray(J *rsp, const char *field);
 J *JGetObject(J *rsp, const char *field);
-long int JGetInt(J *rsp, const char *field);
+JINTEGER JGetInt(J *rsp, const char *field);
 bool JGetBool(J *rsp, const char *field);
 JNUMBER JNumberValue(J *item);
 char *JStringValue(J *item);
 bool JBoolValue(J *item);
-long int JIntValue(J *item);
+JINTEGER JIntValue(J *item);
 bool JIsNullString(J *rsp, const char *field);
 bool JIsExactString(J *rsp, const char *field, const char *teststr);
 bool JContainsString(J *rsp, const char *field, const char *substr);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -160,6 +160,7 @@ add_test(NoteBinaryStoreReset_test)
 add_test(NoteBinaryStoreTransmit_test)
 add_test(JPrintUnformatted_test)
 add_test(Jtolower_test)
+add_test(JSON_number_handling_test)
 
 if(NOTE_C_COVERAGE)
     find_program(LCOV lcov REQUIRED)

--- a/test/src/JItoA_test.cpp
+++ b/test/src/JItoA_test.cpp
@@ -11,8 +11,6 @@
  *
  */
 
-
-
 #include <catch2/catch_test_macros.hpp>
 
 #include "n_lib.h"
@@ -20,29 +18,101 @@
 namespace
 {
 
+#if LONG_MIN == -2147483648
+const char LONG_MIN_STR[] = "-2147483648";
+// The weird form of the RHS of this conditional resolves this warning:
+// "warning: integer constant is so large that it is unsigned". See:
+// https://stackoverflow.com/a/65008305
+#elif LONG_MIN == (-9223372036854775807 - 1)
+const char LONG_MIN_STR[] = "-9223372036854775808";
+#else
+#error "Couldn't determine value of LONG_MIN."
+#endif
+
+#if LONG_MAX == 2147483647
+const char LONG_MAX_STR[] = "2147483647";
+#elif LONG_MAX == 9223372036854775807
+const char LONG_MAX_STR[] = "9223372036854775807";
+#else
+#error "Couldn't determine value of LONG_MAX."
+#endif
+
 SCENARIO("JItoA")
 {
-    long int n = 0;
+    long int n;
     char text[16];
 
-    JItoA(n, text);
-    CHECK(strcmp(text, "0") == 0);
+    GIVEN("The number to convert to a string is 0") {
+        n = 0;
 
-    n = 1;
-    JItoA(n, text);
-    CHECK(strcmp(text, "1") == 0);
+        WHEN("JItoA is called on it") {
+            JItoA(n, text);
 
-    // Trailing 0s.
-    n = 1234500;
-    JItoA(n, text);
-    CHECK(strcmp(text, "1234500") == 0);
+            THEN("The correct string is produced") {
+                CHECK(strcmp(text, "0") == 0);
+            }
+        }
+    }
 
-    // Negative with trailing 0s.
-    n = -1234500;
-    JItoA(n, text);
-    CHECK(strcmp(text, "-1234500") == 0);
+    GIVEN("The number to convert to a string is non-zero") {
+        n = 1;
+
+        WHEN("JItoA is called on it") {
+            JItoA(n, text);
+
+            THEN("The correct string is produced") {
+                CHECK(strcmp(text, "1") == 0);
+            }
+        }
+    }
+
+    GIVEN("The number to convert to a string is positive with trailing zeros") {
+        n = 1234500;
+
+        WHEN("JItoA is called on it") {
+            JItoA(n, text);
+
+            THEN("The correct string is produced") {
+                CHECK(strcmp(text, "1234500") == 0);
+            }
+        }
+    }
+
+    GIVEN("The number to convert to a string is negative with trailing zeros") {
+        n = -1234500;
+
+        WHEN("JItoA is called on it") {
+            JItoA(n, text);
+
+            THEN("The correct string is produced") {
+                CHECK(strcmp(text, "-1234500") == 0);
+            }
+        }
+    }
+
+    GIVEN("The number to convert to a string is LONG_MIN") {
+        n = LONG_MIN;
+
+        WHEN("JItoA is called on it") {
+            JItoA(n, text);
+
+            THEN("The correct string is produced") {
+                CHECK(strcmp(text, LONG_MIN_STR) == 0);
+            }
+        }
+    }
+
+    GIVEN("The number to convert to a string is LONG_MAX") {
+        n = LONG_MAX;
+
+        WHEN("JItoA is called on it") {
+            JItoA(n, text);
+
+            THEN("The correct string is produced") {
+                CHECK(strcmp(text, LONG_MAX_STR) == 0);
+            }
+        }
+    }
 }
 
 }
-
-

--- a/test/src/JSON_number_handling_test.cpp
+++ b/test/src/JSON_number_handling_test.cpp
@@ -1,0 +1,507 @@
+/*!
+ * @file JSON_number_handling_test.cpp
+ *
+ * Written by the Blues Inc. team.
+ *
+ * Copyright (c) 2024 Blues Inc. MIT License. Use of this source code is
+ * governed by licenses granted by the copyright holder including that found in
+ * the
+ * <a href="https://github.com/blues/note-c/blob/master/LICENSE">LICENSE</a>
+ * file.
+ *
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "n_lib.h"
+
+namespace
+{
+
+#define FIELD "num"
+
+#if JINTEGER_MAX == 2147483647
+#define JINTEGER_MAX_STR "2147483647"
+
+#define JINTEGER_MAX_PLUS_ONE 2147483648
+#define JINTEGER_MAX_PLUS_ONE_STR "2147483648"
+// "Integers between 2^24=16777216 and 2^25=33554432 round to a multiple of
+// 2 (even number)" (https://en.wikipedia.org/wiki/Single-precision_floating-point_format)
+#define JINTEGER_MAX_PLUS_ONE_ROUNDED 2147483650
+#define JINTEGER_MAX_PLUS_ONE_ROUNDED_STR "2147483650"
+#define JINTEGER_MAX_PLUS_4096 2147487743
+#define JINTEGER_MAX_PLUS_4096_STR "2147487743"
+// The nearest multiple of 2048.
+#define JINTEGER_MAX_PLUS_4096_ROUNDED 2147487744
+#define JINTEGER_MAX_PLUS_4096_ROUNDED_STR "2147487744"
+#elif JINTEGER_MAX == 9223372036854775807
+#define JINTEGER_MAX_STR "9223372036854775807"
+
+#define JINTEGER_MAX_PLUS_ONE 9223372036854775808UL
+#define JINTEGER_MAX_PLUS_ONE_STR "9223372036854775808"
+// "Integers between 2^(n) and 2^(n+1) round to a multiple of 2^(n−52)."
+// (https://en.wikipedia.org/wiki/Double-precision_floating-point_format)
+// 9223372036854775808 == 2^63, so its JNUMBER representation should be rounded
+// up to the nearest multiple of 2^11 (2048).
+#define JINTEGER_MAX_PLUS_ONE_ROUNDED 9223372036854776000UL
+#define JINTEGER_MAX_PLUS_ONE_ROUNDED_STR "9223372036854776000"
+#define JINTEGER_MAX_PLUS_4096 9223372036854779903UL
+#define JINTEGER_MAX_PLUS_4096_STR "9223372036854779903"
+// The nearest multiple of 2048.
+#define JINTEGER_MAX_PLUS_4096_ROUNDED 9223372036854780000UL
+#define JINTEGER_MAX_PLUS_4096_ROUNDED_STR "9.22337203685478e+18"
+#else
+#error "Couldn't determine value of JINTEGER_MAX."
+#endif
+
+#if JINTEGER_MIN == -2147483648
+#define JINTEGER_MIN_STR "-2147483648"
+
+#define JINTEGER_MIN_MINUS_ONE -2147483649
+#define JINTEGER_MIN_MINUS_ONE_STR "-2147483649"
+#define JINTEGER_MIN_MINUS_ONE_ROUNDED -2147483650
+
+#define JINTEGER_MIN_MINUS_4096 -2147487745
+#define JINTEGER_MIN_MINUS_4096_STR "-2147487745"
+// The nearest multiple of 2048.
+#define JINTEGER_MIN_MINUS_4096_ROUNDED -2147487744
+#define JINTEGER_MIN_MINUS_4096_ROUNDED_STR "-2147487744"
+// The weird form of the RHS of this conditional resolves this warning:
+// "warning: integer constant is so large that it is unsigned". See:
+// https://stackoverflow.com/a/65008305
+#elif JINTEGER_MIN == (-9223372036854775807 - 1)
+#define JINTEGER_MIN_STR "-9223372036854775808"
+
+#define JINTEGER_MIN_MINUS_ONE -9223372036854775809
+#define JINTEGER_MIN_MINUS_ONE_STR "-9223372036854775809"
+// The nearest multiple of 2048 happens to be JINTEGER_MIN in this case.
+#define JINTEGER_MIN_MINUS_ONE_ROUNDED (-9223372036854775807 - 1)
+
+// #define JINTEGER_MIN_MINUS_4096 -9223372036854779904
+#define JINTEGER_MIN_MINUS_4096 -((JNUMBER)9223372036854779904UL)
+#define JINTEGER_MIN_MINUS_4096_STR "-9223372036854779904"
+// The nearest multiple of 2048.
+#define JINTEGER_MIN_MINUS_4096_ROUNDED -((JNUMBER)9223372036854780000UL)
+#define JINTEGER_MIN_MINUS_4096_ROUNDED_STR "-9.22337203685478e+18"
+#else
+#error "Couldn't determine value of JINTEGER_MIN."
+#endif
+
+#define SMALL_FLOAT 0.0009765625
+#define SMALL_FLOAT_STR "0.0009765625"
+
+#define UNIX_TIMESTAMP 1705699768
+#define UNIX_TIMESTAMP_STR "1705699768"
+
+// We treat most of the JSON code as "tested" in the sense that it comes from a
+// tested third party library. However, we have made some changes to the
+// underlying code. For example, we've tweaked the number parsing code (see
+// parse_number and print_number in n_cjson.c).
+
+SCENARIO("Unmarshalling")
+{
+    J *obj;
+    NoteSetFnDefault(malloc, free, NULL, NULL);
+
+    GIVEN("A JSON string with a numeric field with value 0") {
+        const char json[] = "{\"" FIELD "\":0}";
+
+        WHEN("JParse is called on that string") {
+            obj = JParse(json);
+
+            REQUIRE(obj != NULL);
+
+            THEN("JGetInt on the object returns 0") {
+                CHECK(JGetInt(obj, FIELD) == 0);
+            }
+
+            THEN("JGetNumber on the object returns 0") {
+                CHECK(JGetNumber(obj, FIELD) == 0);
+            }
+
+            JDelete(obj);
+        }
+    }
+
+    GIVEN("A JSON string with a numeric field with the max value of JINTEGER") {
+        const char json[] = "{\"" FIELD "\":" JINTEGER_MAX_STR "}";
+
+        WHEN("JParse is called on that string") {
+            obj = JParse(json);
+
+            REQUIRE(obj != NULL);
+
+            THEN("JGetInt on the object returns the max value of JINTEGER") {
+                CHECK(JGetInt(obj, FIELD) == JINTEGER_MAX);
+            }
+
+            THEN("JGetNumber on the object returns the max value of JINTEGER") {
+                CHECK(JGetNumber(obj, FIELD) == JINTEGER_MAX);
+            }
+
+            JDelete(obj);
+        }
+    }
+
+    GIVEN("A JSON string with a numeric field with the max value of JINTEGER "
+          "plus one") {
+        const char json[] = "{\"" FIELD "\":" JINTEGER_MAX_PLUS_ONE_STR "}";
+
+        WHEN("JParse is called on that string") {
+            obj = JParse(json);
+
+            REQUIRE(obj != NULL);
+
+            THEN("JGetInt on the object returns the max value of JINTEGER "
+                 "(saturation)") {
+                CHECK(JGetInt(obj, FIELD) == JINTEGER_MAX);
+            }
+
+            THEN("JGetNumber on the object returns the max value of JINTEGER "
+                 "rounded to the expected power of 2") {
+                CHECK(JGetNumber(obj, FIELD) == JINTEGER_MAX_PLUS_ONE_ROUNDED);
+            }
+
+            JDelete(obj);
+        }
+    }
+
+    GIVEN("A JSON string with a numeric field with the max value of JINTEGER "
+          "plus 4096") {
+        const char json[] = "{\"" FIELD "\":" JINTEGER_MAX_PLUS_4096_STR "}";
+
+        WHEN("JParse is called on that string") {
+            obj = JParse(json);
+
+            REQUIRE(obj != NULL);
+
+            THEN("JGetInt on the object returns the max value of JINTEGER "
+                 "(saturation)") {
+                CHECK(JGetInt(obj, FIELD) == JINTEGER_MAX);
+            }
+
+            THEN("JGetNumber on the object returns the max value of JINTEGER "
+                 "plus 4096 rounded to the expected power of 2") {
+                CHECK(JGetNumber(obj, FIELD) == JINTEGER_MAX_PLUS_4096_ROUNDED);
+            }
+
+            JDelete(obj);
+        }
+    }
+
+    GIVEN("A JSON string with a numeric field with the min value of JINTEGER") {
+        const char json[] = "{\"" FIELD "\":" JINTEGER_MIN_STR "}";
+
+        WHEN("JParse is called on that string") {
+            obj = JParse(json);
+
+            REQUIRE(obj != NULL);
+
+            THEN("JGetInt on the object returns the min value of JINTEGER") {
+                CHECK(JGetInt(obj, FIELD) == JINTEGER_MIN);
+            }
+
+            THEN("JGetNumber on the object returns the min value of JINTEGER") {
+                CHECK(JGetNumber(obj, FIELD) == JINTEGER_MIN);
+            }
+
+            JDelete(obj);
+        }
+    }
+
+    GIVEN("A JSON string with a numeric field with the min value of JINTEGER "
+          "minus one") {
+        const char json[] = "{\"" FIELD "\":" JINTEGER_MIN_MINUS_ONE_STR "}";
+
+        WHEN("JParse is called on that string") {
+            obj = JParse(json);
+
+            REQUIRE(obj != NULL);
+
+            THEN("JGetInt on the object returns the min value of JINTEGER "
+                 "(saturation)") {
+                CHECK(JGetInt(obj, FIELD) == JINTEGER_MIN);
+            }
+
+            THEN("JGetNumber on the object returns the min value of JINTEGER "
+                 "rounded to the expected power of 2") {
+                CHECK(JGetNumber(obj, FIELD) == JINTEGER_MIN_MINUS_ONE_ROUNDED);
+            }
+
+            JDelete(obj);
+        }
+    }
+
+    GIVEN("A JSON string with a numeric field with the min value of JINTEGER "
+          "minus 4096") {
+        const char json[] = "{\"" FIELD "\":" JINTEGER_MIN_MINUS_4096_STR "}";
+
+        WHEN("JParse is called on that string") {
+            obj = JParse(json);
+
+            REQUIRE(obj != NULL);
+
+            THEN("JGetInt on the object returns the min value of JINTEGER "
+                 "(saturation)") {
+                CHECK(JGetInt(obj, FIELD) == JINTEGER_MIN);
+            }
+
+            THEN("JGetNumber on the object returns the min value of JINTEGER "
+                 "rounded to the expected power of 2") {
+                CHECK(JGetNumber(obj, FIELD) ==
+                      JINTEGER_MIN_MINUS_4096_ROUNDED);
+            }
+
+            JDelete(obj);
+        }
+    }
+
+    GIVEN("A JSON string with a numeric field with a small floating point "
+          "value") {
+        const char json[] = "{\"" FIELD "\":" SMALL_FLOAT_STR "}";
+
+        WHEN("JParse is called on that string") {
+            obj = JParse(json);
+
+            REQUIRE(obj != NULL);
+
+            THEN("JGetNumber on the object returns the small floating point "
+                 "value") {
+                CHECK(JGetNumber(obj, FIELD) == SMALL_FLOAT);
+            }
+
+            JDelete(obj);
+        }
+    }
+
+    GIVEN("A JSON string with a numeric field with a number that's accurately "
+          "represented by a 32-bit int but not a single precision float (e.g. a"
+          " Unix timestamp") {
+        const char json[] = "{\"" FIELD "\":" UNIX_TIMESTAMP_STR "}";
+
+        WHEN("JParse is called on that string") {
+            obj = JParse(json);
+
+            REQUIRE(obj != NULL);
+
+            THEN("JGetNumber on the object returns the small floating point "
+                 "value") {
+                CHECK(JGetNumber(obj, FIELD) == UNIX_TIMESTAMP);
+            }
+
+            JDelete(obj);
+        }
+    }
+}
+
+SCENARIO("Marshalling")
+{
+    J *obj;
+    NoteSetFnDefault(malloc, free, NULL, NULL);
+
+    GIVEN("A JSON object with a numeric field with value 0") {
+        const char expected[] = "{\"" FIELD "\":0}";
+        obj = JCreateObject();
+        REQUIRE(obj != NULL);
+        REQUIRE(JAddNumberToObject(obj, FIELD, 0) != NULL);
+
+        WHEN("JPrintUnformatted is called on that object") {
+            char *out = JPrintUnformatted(obj);
+            REQUIRE(out != NULL);
+
+            THEN("0 is printed accurately") {
+                CHECK(strcmp(expected, out) == 0);
+            }
+
+            JFree(out);
+        }
+
+        JDelete(obj);
+    }
+
+    GIVEN("A JSON object with a numeric field with the max value of JINTEGER") {
+        const char expected[] = "{\"" FIELD "\":" JINTEGER_MAX_STR "}";
+        obj = JCreateObject();
+        REQUIRE(obj != NULL);
+        REQUIRE(JAddIntToObject(obj, FIELD, JINTEGER_MAX) != NULL);
+
+        WHEN("JPrintUnformatted is called on that object") {
+            char *out = JPrintUnformatted(obj);
+            REQUIRE(out != NULL);
+
+            THEN("The value is printed accurately") {
+                CHECK(strcmp(expected, out) == 0);
+            }
+
+            JFree(out);
+        }
+
+        JDelete(obj);
+    }
+
+    GIVEN("A JSON object with a numeric field with the max value of JINTEGER "
+          "plus one") {
+        const char expected[] = "{\"" FIELD "\":" JINTEGER_MAX_STR "}";
+        obj = JCreateObject();
+        REQUIRE(obj != NULL);
+        REQUIRE(JAddNumberToObject(obj, FIELD, JINTEGER_MAX_PLUS_ONE) != NULL);
+
+        WHEN("JPrintUnformatted is called on that object") {
+            char *out = JPrintUnformatted(obj);
+            REQUIRE(out != NULL);
+
+            THEN("The value printed is the max value of JINTEGER (saturation") {
+                CHECK(strcmp(expected, out) == 0);
+            }
+
+            JFree(out);
+        }
+
+        JDelete(obj);
+    }
+
+    GIVEN("A JSON object with a numeric field with the max value of JINTEGER "
+          "plus 4096") {
+        const char expected[] = "{\"" FIELD "\":" \
+                                JINTEGER_MAX_PLUS_4096_ROUNDED_STR "}";
+        obj = JCreateObject();
+        REQUIRE(obj != NULL);
+        REQUIRE(JAddNumberToObject(obj, FIELD, JINTEGER_MAX_PLUS_4096) != NULL);
+
+        WHEN("JPrintUnformatted is called on that object") {
+            char *out = JPrintUnformatted(obj);
+            REQUIRE(out != NULL);
+
+            THEN("The value printed is the max value of JINTEGER plus 4096 "
+                 "rounded to the expected power of 2") {
+                CHECK(strcmp(expected, out) == 0);
+            }
+
+            JFree(out);
+        }
+
+        JDelete(obj);
+    }
+
+    GIVEN("A JSON object with a numeric field with the min value of JINTEGER") {
+        const char expected[] = "{\"" FIELD "\":" JINTEGER_MIN_STR "}";
+        obj = JCreateObject();
+        REQUIRE(obj != NULL);
+        REQUIRE(JAddNumberToObject(obj, FIELD, JINTEGER_MIN) != NULL);
+
+
+        WHEN("JPrintUnformatted is called on that object") {
+            char *out = JPrintUnformatted(obj);
+            REQUIRE(out != NULL);
+
+            THEN("The value printed is the min value of JINTEGER") {
+                CHECK(strcmp(expected, out) == 0);
+            }
+
+            JFree(out);
+        }
+
+        JDelete(obj);
+    }
+
+    GIVEN("A JSON object with a numeric field with the min value of JINTEGER "
+          "minus one") {
+        const char expected[] = "{\"" FIELD "\":" JINTEGER_MIN_STR "}";
+        obj = JCreateObject();
+        REQUIRE(obj != NULL);
+        REQUIRE(JAddNumberToObject(obj, FIELD, JINTEGER_MIN) != NULL);
+
+
+        WHEN("JPrintUnformatted is called on that object") {
+            char *out = JPrintUnformatted(obj);
+            REQUIRE(out != NULL);
+
+            THEN("The value printed is the min value of JINTEGER "
+                 "(saturation)") {
+                CHECK(strcmp(expected, out) == 0);
+            }
+
+            JFree(out);
+        }
+
+        JDelete(obj);
+    }
+
+    GIVEN("A J object with a numeric field with the min value of JINTEGER minus"
+          " 4096") {
+        const char expected[] = "{\"" FIELD "\":" \
+                                JINTEGER_MIN_MINUS_4096_ROUNDED_STR "}";
+        obj = JCreateObject();
+        REQUIRE(obj != NULL);
+        REQUIRE(JAddNumberToObject(obj, FIELD, JINTEGER_MIN_MINUS_4096) != NULL);
+
+        WHEN("JPrintUnformatted is called on that object") {
+            char *out = JPrintUnformatted(obj);
+            REQUIRE(out != NULL);
+
+            THEN("The value printed is the value rounded to the expected power "
+                 "of 2") {
+                CHECK(strcmp(expected, out) == 0);
+            }
+
+            JFree(out);
+        }
+
+        JDelete(obj);
+    }
+
+    GIVEN("A J object with a numeric field with a small floating point value") {
+        const char expected[] = "{\"" FIELD "\":" SMALL_FLOAT_STR "}";
+        obj = JCreateObject();
+        REQUIRE(obj != NULL);
+        REQUIRE(JAddNumberToObject(obj, FIELD, SMALL_FLOAT) != NULL);
+
+        WHEN("JPrintUnformatted is called on that object") {
+            char *out = JPrintUnformatted(obj);
+            REQUIRE(out != NULL);
+            // Replace closing '}' with null-terminator so we only pick out the
+            // number when using sccanf.
+            out[strlen(out) - 1] = '\0';
+            const char prefix[] = "\"num\":";
+            const char *numStart = strstr(out, prefix);
+            numStart += strlen(prefix);
+            double numValue;
+            sscanf(numStart, "%lf", &numValue);
+
+            THEN("The value printed is (approximately) the small floating point"
+                 "value") {
+                // If the two values are within 1e-11 of each other, call that
+                // equal.
+                CHECK((numValue - SMALL_FLOAT) < 1e-11);
+            }
+
+            JFree(out);
+        }
+
+        JDelete(obj);
+    }
+
+    GIVEN("A J object with a numeric field with a number that's accurately "
+          "represented by an 32-bit int but not a single precision float (e.g."
+          "a Unix timestamp") {
+        const char expected[] = "{\"" FIELD "\":" UNIX_TIMESTAMP_STR "}";
+        obj = JCreateObject();
+        REQUIRE(obj != NULL);
+        REQUIRE(JAddIntToObject(obj, FIELD, UNIX_TIMESTAMP) != NULL);
+
+        WHEN("JPrintUnformatted is called on that object") {
+            char *out = JPrintUnformatted(obj);
+            REQUIRE(out != NULL);
+
+            THEN("The timestamp is printed accurately") {
+                CHECK(strcmp(expected, out) == 0);
+            }
+
+            JFree(out);
+        }
+
+        JDelete(obj);
+    }
+}
+
+}


### PR DESCRIPTION
- Get rid of CJSON_NO_CLIB and its associated code paths, per Ray's request.
- Change the type of the J object's valueint member. It should be int32_t if NOTE_LOWMEM and int64_t otherwise. Capture this in a new #define for the type, JINTEGER.
- When parsing a JSON number from a JSON string, if the number is within the bounds of the JINTEGER type, convert it to an integer using JAtoI rather than simply casting valuenumber to JINTEGER, which can lose precision (e.g. for a Unix timestamp). If the number is outside the bounds of a JINTEGER, saturate, which is the same behavior as before this commit.
- When printing a JSON number, print it as an integer if possible. Otherwise, print it as floating point.
- Fix an issue where JItoA would fail to convert the minimum long int value (i.e. LONG_MIN) to a string.