### PR TITLE
Add documentation for a few additional cJSON functions.

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -146,6 +146,12 @@ Functions
 
 .. doxygenfunction:: JParse
 
+.. doxygenfunction:: JPrintUnformatted
+
+.. doxygenfunction:: JMalloc
+
+.. doxygenfunction:: JFree
+
 Types
 -----
 

--- a/n_cjson.c
+++ b/n_cjson.c
@@ -168,10 +168,29 @@ static unsigned char* Jstrdup(const unsigned char* string)
     return copy;
 }
 
+/*!
+ @brief Dynamically allocate a block of memory of the given size.
+
+ This is simply a wrapper around the memory allocation function provided by the
+ user via `NoteSetFn`.
+
+ @param size The number of bytes to allocate.
+
+ @returns A pointer to the first byte of the allocated memory or NULL on error.
+ */
 N_CJSON_PUBLIC(void *) JMalloc(size_t size)
 {
     return _Malloc(size);
 }
+
+/*!
+ @brief Free a block of dynamically allocated memory.
+
+ This is simply a wrapper around the memory free function provided by the user
+ via `NoteSetFn`.
+
+ @param p A pointer to the block of memory to free.
+ */
 N_CJSON_PUBLIC(void) JFree(void *p)
 {
     _Free(p);
@@ -1026,6 +1045,17 @@ N_CJSON_PUBLIC(char *) JPrint(const J *item)
     return (char*)print(item, true, false);
 }
 
+/*!
+ @brief Get the unformatted string representation of a `J` object.
+
+ The string returned by this function is dynamically allocated and MUST be freed
+ by the caller with `JFree`. Unformatted means that the minimum JSON string
+ is produced, without any additional whitespace.
+
+ @param item The JSON object to get the unformatted string representation of.
+
+ @returns The string or NULL on error.
+ */
 N_CJSON_PUBLIC(char *) JPrintUnformatted(const J *item)
 {
     if (item == NULL) {


### PR DESCRIPTION
`JPrintUnformatted` is particularly important because it's what allows the user to convert a `J *` to a string. We already document `JParse`, which does the reverse, so we should document `JPrintUnformatted`, too.

Because the function dynamically allocates memory, we need to tell the user how to free it. So, I also added documentation for `JFree`. And while I was at it, I added documentation for `JMalloc`.