### PR TITLE
Remove strtod from allowed libc functions.

### DIFF
--- a/scripts/check_libc_dependencies.sh
+++ b/scripts/check_libc_dependencies.sh
@@ -32,10 +32,6 @@ PERMITTED_FNS=(
     "strlen"
     "strncmp"
     "strstr"
-    # TODO: The only explicit usage of strtod is in the cJSON code if
-    # CJSON_NO_CLIB is NOT true. It's true by default, so we need to figure out
-    # why strtod is still being brought in.
-    "strtod"
     # strtol comes from us using atoi in NoteGetEnvInt.
     "strtol"
     # Used by NotePrintf.


### PR DESCRIPTION
The code path that used this function was recently removed, so we no longer need to whitelist it in the script that checks for libc dependencies.