### PR TITLE
Remove ERRDBG.

### DIFF
--- a/n_i2c.c
+++ b/n_i2c.c
@@ -58,18 +58,14 @@ NOTE_C_STATIC const char * i2cNoteQueryLength(uint32_t * available,
         // Send a dummy I2C transaction to prime the Notecard
         const char *err = _I2CReceive(_I2CAddress(), &dummy_buffer, 0, available);
         if (err) {
-#ifdef ERRDBG
             NOTE_C_LOG_ERROR(err);
-#endif
             return err;
         }
 
         // If we've timed out, return an error
         if (timeoutMs && _GetMs() - startMs >= timeoutMs) {
             const char *err = ERRSTR("timeout: no response from Notecard {io}", c_iotimeout);
-#ifdef ERRDBG
             NOTE_C_LOG_ERROR(err);
-#endif
             return err;
         }
     }
@@ -119,9 +115,7 @@ const char *i2cNoteTransaction(const char *request, size_t reqLen, char **respon
     uint32_t available = 0;
     err = i2cNoteQueryLength(&available, timeoutMs);
     if (err) {
-#ifdef ERRDBG
         NOTE_C_LOG_ERROR(ERRSTR("failed to query Notecard", c_err));
-#endif
         _UnlockI2C();
         return err;
     }
@@ -131,9 +125,7 @@ const char *i2cNoteTransaction(const char *request, size_t reqLen, char **respon
         jsonbuf = (uint8_t *)_Malloc(jsonbufAllocLen + 1);
         if (jsonbuf == NULL) {
             const char *err = ERRSTR("transaction: jsonbuf malloc failed", c_mem);
-#ifdef ERRDBG
             NOTE_C_LOG_ERROR(err);
-#endif
             _UnlockI2C();
             return err;
         }
@@ -150,9 +142,7 @@ const char *i2cNoteTransaction(const char *request, size_t reqLen, char **respon
             if (jsonbuf) {
                 _Free(jsonbuf);
             }
-#ifdef ERRDBG
             NOTE_C_LOG_ERROR(ERRSTR("error occured during receive", c_iobad));
-#endif
             _UnlockI2C();
             return err;
         }
@@ -169,9 +159,7 @@ const char *i2cNoteTransaction(const char *request, size_t reqLen, char **respon
             uint8_t *jsonbufNew = (uint8_t *)_Malloc(jsonbufAllocLen + 1);
             if (jsonbufNew == NULL) {
                 const char *err = ERRSTR("transaction: jsonbuf grow malloc failed", c_mem);
-#ifdef ERRDBG
                 NOTE_C_LOG_ERROR(err);
-#endif
                 if (jsonbuf) {
                     _Free(jsonbuf);
                 }
@@ -368,9 +356,7 @@ const char *i2cChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay, uint3
         const char *err = _I2CReceive(_I2CAddress(), (buffer + received), requested, available);
         if (err) {
             *size = received;
-#ifdef ERRDBG
             NOTE_C_LOG_ERROR(err);
-#endif
             return err;
         }
 
@@ -414,11 +400,9 @@ const char *i2cChunkedReceive(uint8_t *buffer, uint32_t *size, bool delay, uint3
         // Exit on timeout
         if (timeoutMs && (_GetMs() - startMs >= timeoutMs)) {
             *size = received;
-#ifdef ERRDBG
             if (received) {
                 NOTE_C_LOG_ERROR(ERRSTR("received only partial reply before timeout", c_iobad));
             }
-#endif
             return ERRSTR("timeout: transaction incomplete {io}", c_iotimeout);
         }
 
@@ -461,9 +445,7 @@ const char *i2cChunkedTransmit(uint8_t *buffer, uint32_t size, bool delay)
         estr = _I2CTransmit(_I2CAddress(), chunk, chunkLen);
         if (estr != NULL) {
             _I2CReset(_I2CAddress());
-#ifdef ERRDBG
             NOTE_C_LOG_ERROR(estr);
-#endif
             return estr;
         }
         chunk += chunkLen;

--- a/note.h
+++ b/note.h
@@ -52,7 +52,6 @@
 #define ERRSTR(x,y) (y)
 #else
 #define ERRSTR(x,y) (x)
-#define ERRDBG
 #endif
 
 #ifdef NOTE_C_TEST_SINGLE_PRECISION


### PR DESCRIPTION
ERRDBG is a macro that's used to conditionally compile in various error logs. It's not used consistently, and we also already support log levels and NOTE_NODEBUG, which are more than enough to control the desired level of logging at compile-time.