### PR TITLE
bug: Undefined behavior regression

### DIFF
--- a/n_request.c
+++ b/n_request.c
@@ -288,7 +288,7 @@ J *NoteRequestResponseWithRetry(J *req, uint32_t timeoutSeconds)
 
  Unlike `NoteRequestResponse`, this function expects the request to be a valid
  JSON C-string, rather than a `J` object. The string is expected to be
- newline-terminated, otherwise the call results in undefined behavior. The
+ newline-terminated, otherwise the call produces undefined behavior. The
  response is returned as a dynamically allocated JSON C-string. The response
  string is verbatim what was sent by the Notecard, which IS newline-terminated.
  The caller is responsible for freeing the response string. If the request was a
@@ -334,7 +334,7 @@ char * NoteRequestResponseJSON(const char *reqJSON)
             }
 
             NOTE_C_LOG_WARN(ERRSTR("Memory allocation due to malformed request (not newline-terminated)", c_bad));
-            char * const temp = _Malloc(tempLen + 1);
+            char * const temp = _Malloc(tempLen + 2);  // +2 for newline and null-terminator
             if (temp == NULL) {
                 NOTE_C_LOG_ERROR(ERRSTR("request: jsonbuf malloc failed", c_mem));
                 break;
@@ -342,8 +342,9 @@ char * NoteRequestResponseJSON(const char *reqJSON)
 
             memcpy(temp, reqJSON, tempLen);
             temp[tempLen] = '\n';
+            temp[tempLen + 1] = '\0';
             reqJSON = temp;
-            endPtr = &reqJSON[tempLen];
+            endPtr = &temp[tempLen];
         } else {
             endPtr = newlinePtr;
         }

--- a/test/hitl/card.binary/lib/notecard_binary/NotecardComms.cpp
+++ b/test/hitl/card.binary/lib/notecard_binary/NotecardComms.cpp
@@ -14,7 +14,7 @@ bool set_aux_serial_baudrate(size_t baudrate, NotecardInterface nif)
     digitalWrite(FEATHER_AUX_EN_PIN, HIGH);
 
     if (nif==NOTECARD_IF_AUX_SERIAL) {
-        notecard.logDebug("WARNING: trying to change aux serial baudrate over aux serial.\n");
+        dbgSerial.println("WARNING: trying to change aux serial baudrate over aux serial.");
     }
     initialize_notecard_interface(nif);
 
@@ -24,17 +24,21 @@ bool set_aux_serial_baudrate(size_t baudrate, NotecardInterface nif)
     J* rsp = NoteRequestResponseWithRetry(req, 10);
     bool success = false;
     if (rsp==nullptr) {
-        notecard.logDebug("No response to `card.aux.serial`.\n");
+        dbgSerial.println("No response to `card.aux.serial`.");
     } else if (!JIsNullString(rsp, "err")) {
-        notecard.logDebugf("Error response to `card.aux.serial`\n");
+        dbgSerial.println("Error response to `card.aux.serial`.");
     }
 
     const char* mode = JGetString(rsp, "mode");
     size_t rate = JGetNumber(rsp, "rate");
     if (strcmp(mode, "req")) {
-        notecard.logDebugf("expected 'mode':'req', got %s\n", mode);
+        dbgSerial.print("expected 'mode':'req', got ");
+        dbgSerial.println(mode);
     } else if (rate != baudrate) {
-        notecard.logDebugf("expected 'rate':%d, got %d\n", baudrate, rate);
+        dbgSerial.print("expected 'rate':");
+        dbgSerial.print(baudrate);
+        dbgSerial.print(", got ");
+        dbgSerial.println(rate);
     } else {
         aux_serial_baudrate = baudrate;
         success = true;
@@ -48,7 +52,7 @@ bool initialize_notecard_interface(NotecardInterface iface)
     // Initialize the hardware I/O channel to the Notecard
     switch (iface) {
     default:
-        notecard.logDebug("Unknown Notecard interface given.");
+        dbgSerial.println("Unknown Notecard interface given.");
         return false;
 
     case NOTECARD_IF_AUX_SERIAL:
@@ -75,7 +79,7 @@ bool uninitialize_notecard_interface(NotecardInterface iface)
     // Initialize the hardware I/O channel to the Notecard
     switch (iface) {
     default:
-        notecard.logDebug("Unknown Notecard interface given.");
+        dbgSerial.println("Unknown Notecard interface given.");
         return false;
 
     case NOTECARD_IF_AUX_SERIAL:
@@ -126,11 +130,15 @@ size_t readDataUntilTimeout(Stream& serial, size_t timeout, uint8_t* buf, size_t
             if (buf[matchIndex]==ch) {
                 matchIndex++;
                 if (matchIndex>=bufLen) {
-                    notecard.logDebugf("matched the complete image at offset %d\n", count);
+                    dbgSerial.print("matched the complete image at offset ");
+                    dbgSerial.println(count, DEC);
                 }
             } else {
                 if (matchIndex>10) {
-                    notecard.logDebugf("matched %d bytes at offset %d\n", matchIndex, count);
+                    dbgSerial.print("matched ");
+                    dbgSerial.print(matchIndex, DEC);
+                    dbgSerial.print(" bytes at offset ");
+                    dbgSerial.println(count, DEC);
                 }
                 matchIndex = 0;
             }

--- a/test/hitl/card.binary/lib/notecard_binary/NotecardComms.h
+++ b/test/hitl/card.binary/lib/notecard_binary/NotecardComms.h
@@ -29,7 +29,12 @@ enum NotecardInterface {
 #define NOTECARD_IF_I2C_ADDRESS NOTE_I2C_ADDR_DEFAULT
 #endif
 
-
+#if defined(NOTECARD_DEBUG_STLINK)
+  HardwareSerial stlinkSerial(PIN_VCP_RX, PIN_VCP_TX);
+  #define dbgSerial stlinkSerial
+#else
+  #define dbgSerial Serial
+#endif
 
 bool initialize_notecard_interface(NotecardInterface iface);
 size_t readDataUntilTimeout(Stream& serial, size_t timeout, uint8_t* buf, size_t bufLen, size_t dataLen, size_t& duration);

--- a/test/hitl/card.binary/test/test_card_binary.cpp
+++ b/test/hitl/card.binary/test/test_card_binary.cpp
@@ -54,7 +54,8 @@ void AssertNoteBinaryReset()
 {
     const char* err = NoteBinaryStoreReset();
     if (err) {
-        notecard.logDebugf("Error calling NoteBinaryReset %s\n", err);
+        dbgSerial.print("Error calling NoteBinaryReset: ");
+        dbgSerial.println(err);
         TEST_FAIL_MESSAGE("NoteBinaryReset failed.");
     }
 }
@@ -309,18 +310,19 @@ size_t get_expected_max_binary_length()
     size_t ret = 0;
     J* rsp = NoteRequestResponseWithRetry(NoteNewRequest("card.version"), 10);
     if (rsp == nullptr) {
-        notecard.logDebug("No response to card.version.");
+        dbgSerial.println("No response to card.version.");
     } else {
         char *target = JGetString(JGetObject(rsp, "body"), "target");
         if (target == nullptr) {
-            notecard.logDebug("Failed to get target from card.version body.");
+            dbgSerial.println("Failed to get target from card.version body.");
         } else {
             if (strcmp(target, "r5") == 0) {
                 ret = R5_MAX_BINARY_LENGTH;
             } else if (strcmp(target, "u5") == 0) {
                 ret = U5_MAX_BINARY_LENGTH;
             } else {
-                notecard.logDebugf("Unrecognized target: %s.", target);
+                dbgSerial.print("Unrecognized target: ");
+                dbgSerial.println(target);
             }
         }
     }

--- a/test/src/NoteRequestResponseJSON_test.cpp
+++ b/test/src/NoteRequestResponseJSON_test.cpp
@@ -178,9 +178,12 @@ SCENARIO("NoteRequestResponseJSON")
 
             THEN("noteJSONTransaction is called with the newline appended") {
                 REQUIRE(noteJSONTransaction_fake.call_count > 0);
-                REQUIRE(noteJSONTransaction_fake.arg0_history[0] != NULL);
-                CHECK(noteJSONTransaction_fake.arg0_history[0][(sizeof(req) - 1)] == '\n');
-                CHECK(noteJSONTransaction_fake.arg1_history[0] == sizeof(req));
+                REQUIRE(noteJSONTransaction_fake.arg0_val != NULL);
+                // We cannot test the value of the string passed to
+                // `noteJSONTransaction` because it is a pointer to a string
+                // freed by `NoteFree`. We can only check that the length
+                // of the string is one longer than would normally be expected.
+                CHECK(noteJSONTransaction_fake.arg1_val == sizeof(req));
             }
 
             THEN("NoteFree is called to free the memory allocated by malloc") {

--- a/test/src/NoteRequestResponseJSON_test.cpp
+++ b/test/src/NoteRequestResponseJSON_test.cpp
@@ -19,9 +19,12 @@
 #include "n_lib.h"
 
 DEFINE_FFF_GLOBALS
+FAKE_VALUE_FUNC(N_CJSON_PUBLIC(J *), JParse, const char *)
 FAKE_VALUE_FUNC(bool, noteTransactionStart, uint32_t)
 FAKE_VOID_FUNC(noteTransactionStop)
 FAKE_VOID_FUNC(noteLockNote)
+FAKE_VALUE_FUNC(void *, NoteMalloc, size_t)
+FAKE_VOID_FUNC(NoteFree, void *)
 FAKE_VOID_FUNC(noteUnlockNote)
 FAKE_VALUE_FUNC(const char *, noteJSONTransaction, const char *, size_t, char **, uint32_t)
 
@@ -32,11 +35,20 @@ SCENARIO("NoteRequestResponseJSON")
 {
     NoteSetFnDefault(malloc, free, NULL, NULL);
 
+    JParse_fake.custom_fake = [](const char *value) -> J * {
+        return JParseWithOpts(value,0,0);
+    };
+    NoteMalloc_fake.custom_fake = malloc;
+    NoteFree_fake.custom_fake = free;
     noteTransactionStart_fake.return_val = true;
 
     GIVEN("The request is NULL") {
         WHEN("NoteRequestResponseJSON is called") {
             char *rsp = NoteRequestResponseJSON(NULL);
+
+            THEN("noteJSONTransaction is not called") {
+                CHECK(noteJSONTransaction_fake.call_count == 0);
+            }
 
             THEN("The response is NULL") {
                 CHECK(rsp == NULL);
@@ -44,7 +56,21 @@ SCENARIO("NoteRequestResponseJSON")
         }
     }
 
-    GIVEN("The request is a command") {
+    GIVEN("The request length is zero (0)") {
+        WHEN("NoteRequestResponseJSON is called") {
+            char *rsp = NoteRequestResponseJSON("");
+
+            THEN("noteJSONTransaction is not called") {
+                CHECK(noteJSONTransaction_fake.call_count == 0);
+            }
+
+            THEN("The response is NULL") {
+                CHECK(rsp == NULL);
+            }
+        }
+    }
+
+    GIVEN("The request is a command (cmd)") {
         char req[] = "{\"cmd\":\"card.sleep\"}\n";
 
         WHEN("NoteRequestResponseJSON is called") {
@@ -87,7 +113,7 @@ SCENARIO("NoteRequestResponseJSON")
         }
     }
 
-    GIVEN("The request is not a command") {
+    GIVEN("The request is not a command (req)") {
         char req[] = "{\"req\":\"card.version\"}\n";
 
         WHEN("NoteRequestResponseJSON is called") {
@@ -121,14 +147,65 @@ SCENARIO("NoteRequestResponseJSON")
     GIVEN("The request doesn't have a terminating newline") {
         char req[] = "{\"req\":\"card.version\"}";
 
-        WHEN("NoteRequestResponseJSON is called") {
+        WHEN("NoteMalloc fails to duplicate the request") {
+            NoteMalloc_fake.custom_fake = nullptr;
+            NoteMalloc_fake.return_val = NULL;
             char *rsp = NoteRequestResponseJSON(req);
 
-            THEN("noteJSONTransaction isn't called") {
+            THEN("noteJSONTransaction is not called") {
+                REQUIRE(NoteMalloc_fake.call_count > 0);
                 CHECK(noteJSONTransaction_fake.call_count == 0);
             }
 
-            THEN("NULL is returned") {
+            THEN("NoteFree is not called") {
+                REQUIRE(NoteMalloc_fake.call_count > 0);
+                CHECK(NoteFree_fake.call_count == 0);
+            }
+
+            THEN("NoteRequestResponseJSON returns NULL") {
+                REQUIRE(NoteMalloc_fake.call_count > 0);
+                CHECK(rsp == NULL);
+            }
+        }
+
+        WHEN("NoteMalloc is able to duplicate the request") {
+            char *rsp = NoteRequestResponseJSON(req);
+
+            THEN("NoteMalloc is called") {
+                REQUIRE(noteJSONTransaction_fake.call_count > 0);
+                CHECK(NoteMalloc_fake.call_count > 0);
+            }
+
+            THEN("noteJSONTransaction is called with the newline appended") {
+                REQUIRE(noteJSONTransaction_fake.call_count > 0);
+                REQUIRE(noteJSONTransaction_fake.arg0_history[0] != NULL);
+                CHECK(noteJSONTransaction_fake.arg0_history[0][(sizeof(req) - 1)] == '\n');
+                CHECK(noteJSONTransaction_fake.arg1_history[0] == sizeof(req));
+            }
+
+            THEN("NoteFree is called to free the memory allocated by malloc") {
+                REQUIRE(noteJSONTransaction_fake.call_count > 0);
+                CHECK(NoteFree_fake.call_count == NoteMalloc_fake.call_count);
+            }
+        }
+
+        WHEN("The request fails to parse") {
+            char cmd[] = "{\"cmd\":\"card.version\"}";
+            JParse_fake.custom_fake = nullptr;
+            JParse_fake.return_val = NULL;
+            char *rsp = NoteRequestResponseJSON(cmd);
+
+            THEN("noteJSONTransaction is not called") {
+                REQUIRE(NoteMalloc_fake.call_count > 0);
+                CHECK(noteJSONTransaction_fake.call_count == 0);
+            }
+
+            THEN("NoteFree is called") {
+                REQUIRE(NoteMalloc_fake.call_count > 0);
+                CHECK(NoteFree_fake.call_count == NoteMalloc_fake.call_count);
+            }
+
+            THEN("NoteRequestResponseJSON returns NULL") {
                 CHECK(rsp == NULL);
             }
         }
@@ -152,6 +229,16 @@ SCENARIO("NoteRequestResponseJSON")
                 CHECK(noteTransactionStart_fake.call_count == 1);
                 CHECK(noteTransactionStop_fake.call_count == 1);
             }
+
+            THEN("NoteMalloc is not called") {
+                REQUIRE(noteJSONTransaction_fake.call_count > 0);
+                CHECK(NoteMalloc_fake.call_count == 0);
+            }
+
+            THEN("NoteFree is not called") {
+                REQUIRE(noteJSONTransaction_fake.call_count > 0);
+                CHECK(NoteFree_fake.call_count == 0);
+            }
         }
 
         AND_GIVEN("The transaction with the Notecard fails to start") {
@@ -168,6 +255,9 @@ SCENARIO("NoteRequestResponseJSON")
         }
     }
 
+    RESET_FAKE(JParse);
+    RESET_FAKE(NoteMalloc);
+    RESET_FAKE(NoteFree);
     RESET_FAKE(noteTransactionStart);
     RESET_FAKE(noteTransactionStop);
     RESET_FAKE(noteLockNote);


### PR DESCRIPTION
Previously we had allowed strings to be sent via `note-c` without a newline-terminator.
Subsequently, we decided this was undefined behavior that should not be supported.
This caused a regression in downstream testing, and we have restored the original
behavior (although undefined by the Notecard communication specification).