### PR TITLE
TS-513: Add JPrintPreallocated to note-c.

### DIFF
--- a/n_cjson.c
+++ b/n_cjson.c
@@ -1102,7 +1102,7 @@ N_CJSON_PUBLIC(char *) JPrintBuffered(const J *item, int prebuffer, Jbool fmt)
     return (char*)p.buffer;
 }
 
-N_CJSON_PUBLIC(Jbool) JPrintPreallocated(J *item, char *buf, const int len, const Jbool fmt)
+static Jbool printPreallocated(J *item, char *buf, const int len, const Jbool fmt, const Jbool omit)
 {
     printbuffer p = { 0, 0, 0, 0, 0, 0, 0 };
 
@@ -1118,8 +1118,19 @@ N_CJSON_PUBLIC(Jbool) JPrintPreallocated(J *item, char *buf, const int len, cons
     p.offset = 0;
     p.noalloc = true;
     p.format = fmt;
+    p.omitempty = omit;
 
     return print_value(item, &p);
+}
+
+N_CJSON_PUBLIC(Jbool) JPrintPreallocatedOmitEmpty(J *item, char *buf, const int len, const Jbool fmt)
+{
+    return printPreallocated(item, buf, len, fmt, true);
+}
+
+N_CJSON_PUBLIC(Jbool) JPrintPreallocated(J *item, char *buf, const int len, const Jbool fmt)
+{
+    return printPreallocated(item, buf, len, fmt, false);
 }
 
 /* Parser core - when encountering text, process appropriately. */

--- a/n_cjson.h
+++ b/n_cjson.h
@@ -200,6 +200,7 @@ N_CJSON_PUBLIC(char *) JPrintBuffered(const J *item, int prebuffer, Jbool fmt);
 /* Render a J entity to text using a buffer already allocated in memory with given length. Returns 1 on success and 0 on failure. */
 /* NOTE: J is not always 100% accurate in estimating how much memory it will use, so to be safe allocate 5 bytes more than you actually need */
 N_CJSON_PUBLIC(Jbool) JPrintPreallocated(J *item, char *buffer, const int length, const Jbool format);
+N_CJSON_PUBLIC(Jbool) JPrintPreallocatedOmitEmpty(J *item, char *buffer, const int length, const Jbool format);
 /* Delete a J entity and all subentities. */
 N_CJSON_PUBLIC(void) JDelete(J *c);
 


### PR DESCRIPTION
We added this function to the note-c copy used in the NOTE-LORA firmware with NF-473.

We aim to keep the note-c used in the firmware the same as the upstream note-c we distribute as an SDK, so we need to bring this function over.