### PR TITLE
Remove extra Null Check from NoteRequestResponse

### DIFF
--- a/n_request.c
+++ b/n_request.c
@@ -212,10 +212,6 @@ J *NoteRequestResponse(J *req)
     }
     // Execute the transaction
     J *rsp = NoteTransaction(req);
-    if (rsp == NULL) {
-        JDelete(req);
-        return NULL;
-    }
     // Free the request and exit
     JDelete(req);
     return rsp;


### PR DESCRIPTION
The NoteRequestResponse function checks the response to NoteTransaction for a NULL value.

The code in the IF branch of the check _end_ outside the branch perform the exact same operations, except for explicitly returning NULL instead of the value of the `rsp`. Except we already know `rsp` is NULL, otherwise we wouldn't be in this branch.  

Removing this check does not change behavior of NoteRequestResponse nor impact calling functions, as the return values remain the same.

