### PR TITLE
NF-613: Fix card.binary HIL tests.

### DIFF
--- a/.github/workflows/notecard-binary-tests.yml
+++ b/.github/workflows/notecard-binary-tests.yml
@@ -186,16 +186,17 @@ jobs:
           cd hil_lab/
           pip install -r requirements.txt
 
-          # Reserve a Notestation with the label "note_c_card_binary_test",
-          # which means it has everything needed to run the note-c card.binary
-          # tests.
+          # For now, we're hardcoding the Notestation to
+          # los-angeles-notestation-1, which is the only one we've set up to run
+          # these tests.
           cd notestation/
           nohup python -m core.card_client \
             --mcu-debug \
-            --labels '["note_c_card_binary_test"]' \
-            --res-file ./reservation.json &> card_client.log &
+            --notestation los-angeles-notestation-1 \
+            --work-dir /tmp &> card_client.log &
 
           PID=$!
+          RES_FILE=/tmp/ns_reservation.json
 
           timeout=600  # 10 minutes in seconds
           interval=1   # Check every second
@@ -203,7 +204,7 @@ jobs:
 
           # If we aren't able to reserve a Notestation after 10 minutes, or if
           # the card_client fails, bail.
-          while [ ! -f ./reservation.json ]; do
+          while [ ! -f $RES_FILE ]; do
               sleep $interval
               elapsed=$((elapsed + interval))
 
@@ -215,7 +216,7 @@ jobs:
               fi
 
               if [ $elapsed -ge $timeout ]; then
-                  echo "Timeout reached: reservation.json did not appear."
+                  echo "Timeout reached: $RES_FILE did not appear."
                   kill $PID 2>/dev/null
                   exit 1
               fi
@@ -225,17 +226,19 @@ jobs:
 
           # Set these environment variables, which are read in platformio.ini in
           # order to flash the Swan with the test firmware.
-          export MCU_GDB_SERVER_IP="$(jq -r '.notestation' ./reservation.json)"
-          export MCU_GDB_SERVER_PORT="$(jq -r '.mcu_openocd.gdb' ./reservation.json)"
+          export MCU_GDB_SERVER_IP="$(jq -r '.notestation' $RES_FILE)"
+          export MCU_GDB_SERVER_PORT="$(jq -r '.mcu_openocd.gdb' $RES_FILE)"
           export GDB_CMD="gdb-multiarch"
 
           if [ -z "$MCU_GDB_SERVER_IP" ] || [ "$MCU_GDB_SERVER_IP" == "null" ]; then
               echo "Error: MCU_GDB_SERVER_IP is empty or not defined."
+              kill $PID 2>/dev/null
               exit 1
           fi
 
           if [ -z "$MCU_GDB_SERVER_PORT" ] || [ "$MCU_GDB_SERVER_PORT" -eq 0 ]; then
               echo "Error: MCU_GDB_SERVER_PORT is empty or zero."
+              kill $PID 2>/dev/null
               exit 1
           fi
 
@@ -255,6 +258,8 @@ jobs:
             --no-reset \
             --json-output-path test.json \
             --junit-output-path test.xml
+
+          kill $PID 2>/dev/null
 
       - name: Publish test report
         uses: mikepenz/action-junit-report@v3

--- a/test/hitl/card.binary/platformio.ini
+++ b/test/hitl/card.binary/platformio.ini
@@ -41,5 +41,5 @@ extra_scripts = post:wait_for_test_port.py
 build_type = debug
 debug_test = *
 upload_protocol = custom
-upload_command = ${sysenv.GDB_CMD} -ex "set confirm off" -ex "set pagination off" -ex "target extended-remote ${sysenv.MCU_GDB_SERVER_IP}:${sysenv.MCU_GDB_SERVER_PORT}" -ex "monitor reset halt" -ex "file .pio/build/debug/firmware.elf" -ex "load" -ex "monitor reset" -ex "quit"
-test_port = /tmp/mcu_usb
+upload_command = ${sysenv.GDB_CMD} -ex "set confirm off" -ex "set pagination off" -ex "file .pio/build/debug/firmware.elf" -ex "target extended-remote ${sysenv.MCU_GDB_SERVER_IP}:${sysenv.MCU_GDB_SERVER_PORT}" -ex "monitor reset halt" -ex "load" -ex "monitor reset" -ex "quit"
+test_port = /tmp/ns_mcu_usb


### PR DESCRIPTION
- Hardcode Notestation to los-angeles-notestation-1. This one's known to be set up for running these tests. I have work in progress to make it so this doesn't need to be hardcoded (i.e. the Notestation client can discover which stations can run these tests), but it's not finished, yet.
- Make sure to kill the Notestation client in the GitHub Actions workflow when done with the Notestation.
- Move the `file .pio/build/debug/firmware.elf` gdb command earlier in the custom upload command for PlatformIO. This just gets rid of some warnings I was seeing in the log. No functional difference.
- Change test_port to /tmp/ns_mcu_usb from /tmp/mcu_usb. The former is the new default path for the MCU USB device with the latest Notestation client.