### PR TITLE
fix for `_n_htoa32`

### DIFF
--- a/n_hooks.c
+++ b/n_hooks.c
@@ -520,7 +520,7 @@ void NoteDelayMs(uint32_t ms)
     }
 }
 
-#if NOTE_C_SHOW_MALLOC || !defined(NOTE_C_LOW_MEM)
+#if NOTE_C_SHOW_MALLOC
 //**************************************************************************/
 /*!
   @brief  Convert number to a hex string

--- a/n_hooks.c
+++ b/n_hooks.c
@@ -520,7 +520,6 @@ void NoteDelayMs(uint32_t ms)
     }
 }
 
-#if NOTE_C_SHOW_MALLOC
 //**************************************************************************/
 /*!
   @brief  Convert number to a hex string
@@ -530,8 +529,6 @@ void NoteDelayMs(uint32_t ms)
 /**************************************************************************/
 void _n_htoa32(uint32_t n, char *p)
 {
-    static_assert(sizeof(void *) == sizeof(uint32_t), "Pointer size mismatch");
-
     for (int i=0; i<8; i++) {
         uint32_t nibble = (n >> 28) & 0xff;
         n = n << 4;
@@ -543,7 +540,14 @@ void _n_htoa32(uint32_t n, char *p)
     }
     *p = '\0';
 }
+
+#if NOTE_C_SHOW_MALLOC
+void _n_ptoa32(void* ptr, char* p) {
+    static_assert(sizeof(void *) == sizeof(uint32_t), "Pointer size mismatch");
+    _n_htoa32((uint32_t)ptr);
+}
 #endif
+
 
 //**************************************************************************/
 /*!
@@ -566,7 +570,7 @@ void *NoteMalloc(size_t size)
         if (p == NULL) {
             hookDebugOutput("FAIL");
         } else {
-            _n_htoa32((uint32_t)p, str);
+            _n_ptoa32(p, str);
             hookDebugOutput(str);
         }
     }
@@ -586,7 +590,7 @@ void NoteFree(void *p)
 #if NOTE_C_SHOW_MALLOC
         if (_noteIsDebugOutputActive()) {
             char str[16];
-            _n_htoa32((uint32_t)p, str);
+            _n_ptoa32(p, str);
             hookDebugOutput("free");
             hookDebugOutput(str);
         }

--- a/n_hooks.c
+++ b/n_hooks.c
@@ -520,6 +520,10 @@ void NoteDelayMs(uint32_t ms)
     }
 }
 
+// _n_htoa32 is used in this file when showing malloc/free activity (NOTE_C_SHOW_MALLOC==1),
+// and also in request.c, _addCrc, when NOTE_C_LOW_MEM is undefined
+
+#if NOTE_C_SHOW_MALLOC || !defined(NOTE_C_LOW_MEM)
 //**************************************************************************/
 /*!
   @brief  Convert number to a hex string
@@ -540,6 +544,7 @@ void _n_htoa32(uint32_t n, char *p)
     }
     *p = '\0';
 }
+#endif
 
 #if NOTE_C_SHOW_MALLOC
 void _n_ptoa32(void* ptr, char* p) {


### PR DESCRIPTION
fix: remove unused conditional define, which was causing the build to fail on 64-bit systems with `NOTE_C_SHOW_MALLOC` left undefined.  ~The `_n_htoa32` function isn't used unless `NOTE_C_SHOW_MALLOC` is defined, but it was being compiled because of the `!NOTE_C_LOW_MEM` part of the conditional, which evaluates to true by default.~

EDIT: Had to rework the code further - `_n_htoa32` is used in `n_request.c` when `NOTE_C_LOW_MEM` is not defined.  Moved the pointer to 32-bit ascii conversion to its own function, so that particular use case doesn't impact usage outside of reporting memory activity (`NOTE_C_SHOW_MALLOC`).

