### PR TITLE
card.binary HIL improvements.

### DIFF
--- a/.github/workflows/notecard-binary-tests.yml
+++ b/.github/workflows/notecard-binary-tests.yml
@@ -274,6 +274,7 @@ jobs:
               if [ $elapsed -ge $timeout ]; then
                   echo "Timeout reached: $READY_FILE did not appear."
                   kill $PID 2>/dev/null
+                  echo "$(cat card_client.log)"
                   exit 1
               fi
           done

--- a/test/hitl/card.binary/after_upload.py
+++ b/test/hitl/card.binary/after_upload.py
@@ -41,7 +41,7 @@ def after_upload(source, target, env):
     # test step: "device reports readiness to read but returned no data (device
     # disconnected or multiple access # on port?)" Not totally sure why, but
     # maybe this gives the OS a chance to cleanup anything using the test port.
-    time.sleep(0.3)
+    time.sleep(3)
 
 
 env.AddPostAction("upload", after_upload)


### PR DESCRIPTION
- Wait longer at the end of `after_upload`. I was seeing the dreaded "device reports readiness to read but returned no data" error again. This seems to have cleared it.
- I was seeing intermittent failures due to the Notestation reservation never creating the ready file. I added code to the workflow to print the Notestation client log in the event of a ready file timeout.