### PR TITLE
TS-713: Fix CRC errors over AUX serial in card.binary HIL tests.

### DIFF
--- a/test/hitl/card.binary/lib/notecard_binary/NotecardComms.cpp
+++ b/test/hitl/card.binary/lib/notecard_binary/NotecardComms.cpp
@@ -21,6 +21,8 @@ bool set_aux_serial_baudrate(size_t baudrate, NotecardInterface nif)
     J* req = NoteNewRequest("card.aux.serial");
     JAddStringToObject(req, "mode", "req");
     JAddNumberToObject(req, "rate", baudrate);
+    JAddNumberToObject(req, "max", SERIAL_RX_BUFFER_SIZE-1);
+    JAddNumberToObject(req, "ms", 1);
     J* rsp = NoteRequestResponseWithRetry(req, 10);
     bool success = false;
     if (rsp==nullptr) {


### PR DESCRIPTION
In this PR, we removed code that automatically called card.aux.serial with ms
and max parameters to add flow control for AUX serial comms in note-arduino:
https://github.com/blues/note-arduino/pull/141 It turns out these tests were
relying on that behavior in order to not have Notecard responses over AUX
serial wind up corrupted. This corruption was manifesting as CRC errors on the
responses. I saw with a logic analyzer that the Notecard was sending the correct
response, but that note-c/the Swan was not receiving it correctly. So the fix
is to restore the card.aux.serial request with the old ms and max parameters by
adding it to the test.