### PR TITLE
Add a new NoteRequestSetTimeout function

### DIFF
--- a/n_lib.h
+++ b/n_lib.h
@@ -40,7 +40,8 @@ extern "C" {
     @brief  How long to wait for the card for any given transaction.
 */
 /**************************************************************************/
-#define CARD_INTER_TRANSACTION_TIMEOUT_SEC 30
+extern uint32_t cardTransactionTimeoutOverrideSecs;
+#define CARD_INTER_TRANSACTION_TIMEOUT_SEC (cardTransactionTimeoutOverrideSecs == 0 ? 30 : cardTransactionTimeoutOverrideSecs)
 #define CARD_INTRA_TRANSACTION_TIMEOUT_SEC  1
 
 // The notecard is a real-time device that has a fixed size interrupt buffer.

--- a/n_request.c
+++ b/n_request.c
@@ -16,6 +16,9 @@
 
 static const int RETRY_DELAY_MS = 500;
 
+// A value that optionally overrides CARD_INTER_TRANSACTION_TIMEOUT_SEC
+static uint32_t cardTransactionTimeoutOverrideSecs = 0;
+
 // For flow tracing
 static int suppressShowTransactions = 0;
 
@@ -158,6 +161,24 @@ void NoteSuspendTransactionDebug(void)
 void NoteResumeTransactionDebug(void)
 {
     _noteResumeTransactionDebug();
+}
+
+/*!
+ @brief Set or clear a request timeout override
+
+ This is for use with transactions such as card.test where only
+ the developer knows how long the transaction should take, based
+ on the nature of the transaction being performed.
+
+ @param overrideSecsOrZeroForDefault The override value
+
+ @returns Previous value that was overriddden
+ */
+uint32_t NoteRequestSetTimeout(uint32_t overrideSecsOrZeroForDefault)
+{
+	uint32_t previous = CARD_INTER_TRANSACTION_TIMEOUT_SEC;
+	cardTransactionTimeoutOverrideSecs = overrideSecsOrZeroForDefault;
+	return previous;
 }
 
 /*!

--- a/note.h
+++ b/note.h
@@ -246,6 +246,7 @@ void NoteResetRequired(void);
 #define NoteGetBody(a) JGetObject(a, "body")
 J *NoteNewRequest(const char *request);
 J *NoteNewCommand(const char *request);
+uint32_t NoteRequestSetTimeout(uint32_t overrideSecsOrZeroForDefault);
 J *NoteRequestResponse(J *req);
 J *NoteRequestResponseWithRetry(J *req, uint32_t timeoutSeconds);
 char * NoteRequestResponseJSON(const char *reqJSON);


### PR DESCRIPTION
This is needed for a new request, card.test, that will have timeouts that vary based upon the developer's intent in using the transaction.