### PR TITLE
fix: make transaction reset best effort

### DIFF
--- a/n_request.c
+++ b/n_request.c
@@ -528,22 +528,12 @@ J *_noteTransactionShouldLock(J *req, bool lockNotecard)
         _LockNote();
     }
 
-    // If a reset of the I/O interface is required for any reason, do it now.
+    // If a reset of the I/O interface is required for any reason, make a best
+    // effort to resynchronize before continuing with the transaction.
     if (resetRequired) {
         NOTE_C_LOG_DEBUG("Resetting Notecard I/O Interface...");
-        if ((resetRequired = !_Reset())) {
-            if (lockNotecard) {
-                _UnlockNote();
-            }
-            _Free(json);
-            _TransactionStop();
-            const char *errStr = ERRSTR("failed to reset Notecard interface {io}", c_iobad);
-            if (cmdFound) {
-                NOTE_C_LOG_ERROR(errStr);
-                return NULL;
-            }
-            return _errDoc(id, errStr);
-        }
+        _Reset();
+        resetRequired = false;
     }
 
     // If we're performing retries, this is where we come back to

--- a/test/src/NoteTransaction_test.cpp
+++ b/test/src/NoteTransaction_test.cpp
@@ -505,7 +505,7 @@ SCENARIO("NoteTransaction")
         JDelete(req);
     }
 
-    SECTION("A reset is required and it fails") {
+    SECTION("A reset is required and it fails before a command") {
         J *req = NoteNewCommand("note.add");
         REQUIRE(req != NULL);
         NoteResetRequired();
@@ -515,31 +515,34 @@ SCENARIO("NoteTransaction")
         J *resp = NoteTransaction(req);
         REQUIRE(_noteHardReset_fake.call_count == 1);
 
-        // The transaction shouldn't be attempted if reset failed.
-        CHECK(_noteJSONTransaction_fake.call_count == 0);
+        // Reset is best effort; the transaction is still attempted.
+        CHECK(_noteJSONTransaction_fake.call_count == 1);
+        CHECK(resetRequired == false);
 
-        // The response should be null if reset failed.
-        CHECK(resp == NULL);
+        // Commands return an empty response object after the transaction attempt.
+        CHECK(resp != NULL);
 
         JDelete(req);
+        JDelete(resp);
     }
 
-    SECTION("A reset is required and it fails") {
+    SECTION("A reset is required and it fails before a request") {
         J *req = NoteNewRequest("note.add");
         REQUIRE(req != NULL);
         NoteResetRequired();
         // Force NoteReset failure.
         _noteHardReset_fake.return_val = false;
+        _noteJSONTransaction_fake.custom_fake = _noteJSONTransactionValid;
 
         J *resp = NoteTransaction(req);
         REQUIRE(_noteHardReset_fake.call_count == 1);
 
-        // The transaction shouldn't be attempted if reset failed.
-        CHECK(_noteJSONTransaction_fake.call_count == 0);
+        // Reset is best effort; the transaction is still attempted.
+        CHECK(_noteJSONTransaction_fake.call_count == 1);
+        CHECK(resetRequired == false);
 
-        // The response should be null if reset failed.
         CHECK(resp != NULL);
-        CHECK(NoteResponseError(resp));
+        CHECK(!NoteResponseError(resp));
 
         JDelete(req);
         JDelete(resp);


### PR DESCRIPTION
## Summary

Split out the transaction reset behavior change from PR #239 so it can be reviewed independently from the new `NotePing()` API.

This changes `_noteTransactionShouldLock()` so that when `resetRequired` is set, the transaction path makes a best-effort call to `_Reset()`, clears `resetRequired`, and proceeds with the transaction even if reset did not report success.

## Rationale

ESP32 I2C initialization can repeatedly fail in a way that prevents progress when reset is treated as a hard gate. This keeps the reset attempt, but avoids blocking the following transaction solely because the reset hook failed.

## Tests

- `docker run --rm -v "$PWD":/note-c -w /note-c ghcr.io/blues/note_c_ci:latest bash -lc 'cmake --build build --target NoteTransaction_test NoteTransactionHooks_test NoteReset_test _noteHardReset_test -j2 && ctest --test-dir build -R "(NoteTransaction|NoteReset|_noteHardReset)" --output-on-failure'`

Result: 8/8 related transaction/reset tests passed.

Note: a full `run_unit_tests.sh` pass was attempted, but this workspace's reused Docker build directory produced CMake `*_NOT_BUILT` placeholders unless individual test targets were built. The directly relevant reset/transaction targets were rebuilt and passed.
