### PR TITLE
docs: publish architecture map in docs site

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -21,6 +21,13 @@ add_custom_target(
         ${SPHINX_OPTS}
         ${DOCS_SRC_DIR}
         ${DOCS_BUILD_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${DOCS_BUILD_DIR}/architecture
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${DOCS_SRC_DIR}/architecture/architecture.html
+        ${DOCS_BUILD_DIR}/architecture/architecture.html
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${DOCS_SRC_DIR}/architecture/architecture.json
+        ${DOCS_BUILD_DIR}/architecture/architecture.json
     USES_TERMINAL
     COMMENT "Running Sphinx HTML build..."
 )

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -11,4 +11,6 @@ Open the `interactive architecture map`_ for the visual graph, or inspect the
 .. _interactive architecture map: architecture/architecture.html
 .. _structured architecture data: architecture/architecture.json
 
-For the narrative overview, see the repository-level ``ARCHITECTURE.md`` file.
+For the narrative overview, see the repository-level `ARCHITECTURE.md`_ file.
+
+.. _ARCHITECTURE.md: https://github.com/blues/note-c/blob/master/ARCHITECTURE.md

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -5,8 +5,10 @@ The note-c architecture documentation is maintained with the repository so
 module boundaries, public contracts, runtime flow, and update triggers stay
 visible as the SDK evolves.
 
-Open the `interactive architecture map <architecture/architecture.html>`_ for
-the visual graph, or inspect the `structured architecture data
-<architecture/architecture.json>`_ used to generate the map.
+Open the `interactive architecture map`_ for the visual graph, or inspect the
+`structured architecture data`_ used to generate the map.
+
+.. _interactive architecture map: architecture/architecture.html
+.. _structured architecture data: architecture/architecture.json
 
 For the narrative overview, see the repository-level ``ARCHITECTURE.md`` file.

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -1,0 +1,12 @@
+Architecture
+============
+
+The note-c architecture documentation is maintained with the repository so
+module boundaries, public contracts, runtime flow, and update triggers stay
+visible as the SDK evolves.
+
+Open the `interactive architecture map <architecture/architecture.html>`_ for
+the visual graph, or inspect the `structured architecture data
+<architecture/architecture.json>`_ used to generate the map.
+
+For the narrative overview, see the repository-level ``ARCHITECTURE.md`` file.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -24,6 +24,7 @@ After code changes:
 - `architecture.html`: single-file visual map for humans. It embeds data from `architecture.json` so it can be opened directly from disk.
 - `architecture.json`: structured map for AI agents and tooling.
 - `embed-architecture-json.mjs`: refreshes the embedded JSON block in `architecture.html` from `architecture.json`.
+- `../architecture.rst`: Sphinx documentation page that links to the published architecture map and JSON artifact.
 - `decisions/*.md`: architecture decision records.
 - `templates/repo-architecture.md`: template for future architecture docs.
 - `../../AGENTS.md`, `../../CLAUDE.md`, `../../GEMINI.md`, `../../.github/copilot-instructions.md`, and `../../.cursor/rules/architecture-docs.mdc`: AI entrypoints that point future tools back to these docs.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,9 +13,11 @@ Architecture
 
 Use the `architecture overview <architecture.html>`_ to understand note-c's
 module boundaries, public contracts, runtime flow, and update triggers. The
-overview links to the `interactive architecture map
-<architecture/architecture.html>`_ and the `structured architecture data
-<architecture/architecture.json>`_ used to render it.
+overview links to the `interactive architecture map`_ and the
+`structured architecture data`_ used to render it.
+
+.. _interactive architecture map: architecture/architecture.html
+.. _structured architecture data: architecture/architecture.json
 
 .. toctree::
    :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,15 @@ note-c
 
 note-c is the official C library for communicating with a `Blues Notecard <https://blues.com/products/notecard/>`_. The source code is open source and `available on GitHub <https://github.com/blues/note-c>`_ under the MIT license.
 
+Architecture
+------------
+
+Use the `architecture overview <architecture.html>`_ to understand note-c's
+module boundaries, public contracts, runtime flow, and update triggers. The
+overview links to the `interactive architecture map
+<architecture/architecture.html>`_ and the `structured architecture data
+<architecture/architecture.json>`_ used to render it.
+
 .. toctree::
    :maxdepth: 1
 
@@ -16,3 +25,4 @@ note-c is the official C library for communicating with a `Blues Notecard <https
    calling_the_notecard_api
    ports
    api_reference
+   architecture

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ note-c is the official C library for communicating with a `Blues Notecard <https
 Architecture
 ------------
 
-Use the `architecture overview <architecture.html>`_ to understand note-c's
+Use the :doc:`architecture overview <architecture>` to understand note-c's
 module boundaries, public contracts, runtime flow, and update triggers. The
 overview links to the `interactive architecture map`_ and the
 `structured architecture data`_ used to render it.


### PR DESCRIPTION
## Summary\n\n- Add a prominent Architecture section to the docs home page with links to the architecture overview, interactive map, and structured JSON artifact.\n- Add a Sphinx Architecture page linking to the interactive architecture map and structured JSON artifact.\n- Copy docs/architecture/architecture.html and docs/architecture/architecture.json into the generated docs site under architecture/ so GitHub Pages can serve them.\n- Document the Sphinx publishing entrypoint in the architecture docs README.\n\n## Verification\n\n- node docs/architecture/embed-architecture-json.mjs && git diff --exit-code docs/architecture/architecture.html\n- /home/ubuntu/.openclaw/workspace/scripts/check-resources.sh --label "note-c docs build" --min-ram-gb 4\n- Clean Docker docs build using ghcr.io/blues/note_c_ci:latest with a temporary CMake build directory.\n- Verified generated files exist:\n  - docs/index.html with architecture links\n  - docs/architecture.html\n  - docs/architecture/architecture.html\n  - docs/architecture/architecture.json\n- git diff --check\n