### PR TITLE
test: avoid unbounded NotePing request reads

### DIFF
--- a/test/src/NotePing_test.cpp
+++ b/test/src/NotePing_test.cpp
@@ -102,23 +102,7 @@ const char *pingTransaction(const char *request, size_t reqLen, char **response,
     lastRequestLength = reqLen;
     lastTransactionTimeoutMs = timeoutMs;
     lastRequestEndedWithNewline = (reqLen > 0 && request[reqLen - 1] == '\n');
-    lastRequestHadCrc = (strstr(request, "\"crc\"") != NULL);
     serialBytesRemainingAtTransaction = serialBytesRemaining;
-
-    if (pingResponse == PingResponse::TransactionError) {
-        return ERRSTR("transaction failed {io}", c_ioerr);
-    }
-    if (response == NULL || pingResponse == PingResponse::NoResponse) {
-        return NULL;
-    }
-    if (pingResponse == PingResponse::InvalidJson) {
-        *response = copyString("not-json");
-        return NULL;
-    }
-    if (pingResponse == PingResponse::Error) {
-        *response = copyString("{\"err\":\"failed\"}");
-        return NULL;
-    }
 
     char *requestCopy = static_cast<char *>(malloc(reqLen + 1));
     if (requestCopy == NULL) {
@@ -126,6 +110,27 @@ const char *pingTransaction(const char *request, size_t reqLen, char **response,
     }
     memcpy(requestCopy, request, reqLen);
     requestCopy[reqLen] = '\0';
+    lastRequestHadCrc = (strstr(requestCopy, "\"crc\"") != NULL);
+
+    if (pingResponse == PingResponse::TransactionError) {
+        free(requestCopy);
+        return ERRSTR("transaction failed {io}", c_ioerr);
+    }
+    if (response == NULL || pingResponse == PingResponse::NoResponse) {
+        free(requestCopy);
+        return NULL;
+    }
+    if (pingResponse == PingResponse::InvalidJson) {
+        *response = copyString("not-json");
+        free(requestCopy);
+        return NULL;
+    }
+    if (pingResponse == PingResponse::Error) {
+        *response = copyString("{\"err\":\"failed\"}");
+        free(requestCopy);
+        return NULL;
+    }
+
     if (reqLen > 0 && requestCopy[reqLen - 1] == '\n') {
         requestCopy[reqLen - 1] = '\0';
     }


### PR DESCRIPTION
## Summary

- make the `NotePing` fake treat the request as length-delimited
- avoid calling `strstr` on a newline-terminated, non-NUL-terminated request buffer
- reuse the bounded copy for JSON parsing

## Verification

- `docker run --rm -v /home/ubuntu/.openclaw/workspace/note-c:/note-c -w /note-c ghcr.io/blues/note_c_ci:latest bash -lc 'rm -rf build && cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build --target NotePing_test -j2 && cd build && valgrind --track-origins=yes --leak-check=full ./test/NotePing_test "Scenario: NotePing"'`

Valgrind result: `ERROR SUMMARY: 0 errors from 0 contexts`.

## Notes

This targets `ray/autobaud` so it can be merged into #239 without pulling in unrelated `master` changes.
