### PR TITLE
refactor: polish NotePing response handling

### DIFF
--- a/n_request.c
+++ b/n_request.c
@@ -899,6 +899,7 @@ bool NotePing(void)
     // are doing exactly one attempt.
     char *rspJson = NULL;
     const char *err = _Transaction(json, jsonLen + 1, &rspJson, pingTimeoutMs);
+    json[jsonLen] = '\0';
 
     _UnlockNote();
     _TransactionStop();
@@ -925,7 +926,7 @@ bool NotePing(void)
     }
 
     bool ok = JIsNullString(rsp, c_err)
-              && (strcmp(JGetString(rsp, "text"), nonce) == 0);
+              && JIsExactString(rsp, "text", nonce);
 
     JDelete(rsp);
     return ok;

--- a/test/src/NotePing_test.cpp
+++ b/test/src/NotePing_test.cpp
@@ -102,23 +102,7 @@ const char *pingTransaction(const char *request, size_t reqLen, char **response,
     lastRequestLength = reqLen;
     lastTransactionTimeoutMs = timeoutMs;
     lastRequestEndedWithNewline = (reqLen > 0 && request[reqLen - 1] == '\n');
-    lastRequestHadCrc = (strstr(request, "\"crc\"") != NULL);
     serialBytesRemainingAtTransaction = serialBytesRemaining;
-
-    if (pingResponse == PingResponse::TransactionError) {
-        return ERRSTR("transaction failed {io}", c_ioerr);
-    }
-    if (response == NULL || pingResponse == PingResponse::NoResponse) {
-        return NULL;
-    }
-    if (pingResponse == PingResponse::InvalidJson) {
-        *response = copyString("not-json");
-        return NULL;
-    }
-    if (pingResponse == PingResponse::Error) {
-        *response = copyString("{\"err\":\"failed\"}");
-        return NULL;
-    }
 
     char *requestCopy = static_cast<char *>(malloc(reqLen + 1));
     if (requestCopy == NULL) {
@@ -126,6 +110,27 @@ const char *pingTransaction(const char *request, size_t reqLen, char **response,
     }
     memcpy(requestCopy, request, reqLen);
     requestCopy[reqLen] = '\0';
+    lastRequestHadCrc = (strstr(requestCopy, "\"crc\"") != NULL);
+
+    if (pingResponse == PingResponse::TransactionError) {
+        free(requestCopy);
+        return ERRSTR("transaction failed {io}", c_ioerr);
+    }
+    if (response == NULL || pingResponse == PingResponse::NoResponse) {
+        free(requestCopy);
+        return NULL;
+    }
+    if (pingResponse == PingResponse::InvalidJson) {
+        *response = copyString("not-json");
+        free(requestCopy);
+        return NULL;
+    }
+    if (pingResponse == PingResponse::Error) {
+        *response = copyString("{\"err\":\"failed\"}");
+        free(requestCopy);
+        return NULL;
+    }
+
     if (reqLen > 0 && requestCopy[reqLen - 1] == '\n') {
         requestCopy[reqLen - 1] = '\0';
     }


### PR DESCRIPTION
## Summary

- restore the JSON buffer's NUL terminator after the length-delimited transaction
- use `JIsExactString` for nonce response validation

## Stack note

This branch includes #244 as its first commit so CI can run cleanly while both PRs target `ray/autobaud`. After #244 merges, this PR should reduce to the `n_request.c` polish commit only.

## Verification

- `docker run --rm -v /home/ubuntu/.openclaw/workspace/note-c:/note-c -w /note-c ghcr.io/blues/note_c_ci:latest bash -lc 'rm -rf build && cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build --target NotePing_test -j2 && cd build && valgrind --track-origins=yes --leak-check=full ./test/NotePing_test "Scenario: NotePing"'`\n\nValgrind result: `ERROR SUMMARY: 0 errors from 0 contexts`.\n\n## Architecture docs\n\nConsidered; no update needed because this is an implementation-level cleanup of behavior already introduced by #239.