### PR TITLE
fix: unbreak macOS CI on AppleClang int→double limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,9 @@ jobs:
           docker run --rm --volume $(pwd):/note-c/ --workdir /note-c/ --entrypoint ./scripts/run_cppcheck.sh ghcr.io/blues/note_c_ci:latest
 
   run_macos_unit_tests:
+    # Stay on macos-latest (currently macOS 26 / Xcode 26.5). Integer limit
+    # comparisons in n_cjson.c / n_ftoa.c use explicit (JNUMBER) casts so
+    # AppleClang -Wimplicit-const-int-float-conversion does not fail -Werror.
     runs-on: macos-latest
 
     steps:

--- a/n_cjson.c
+++ b/n_cjson.c
@@ -304,9 +304,11 @@ loop_end:
     item->valuenumber = number;
 
     // Saturate valueint in the case of overflow.
-    if (number >= JINTEGER_MAX) {
+    // Cast integer limits to JNUMBER: INT64_MAX is not exactly representable as
+    // double, and newer AppleClang rejects the implicit conversion under -Werror.
+    if (number >= (JNUMBER)JINTEGER_MAX) {
         item->valueint = JINTEGER_MAX;
-    } else if (number <= JINTEGER_MIN) {
+    } else if (number <= (JNUMBER)JINTEGER_MIN) {
         item->valueint = JINTEGER_MIN;
     } else {
         item->valueint = JAtoI((const char*)number_c_string);
@@ -326,9 +328,11 @@ N_CJSON_PUBLIC(JNUMBER) JSetNumberHelper(J *object, JNUMBER number)
     }
 
     // Saturate valueint in the case of overflow.
-    if (number >= JINTEGER_MAX) {
+    // Cast integer limits to JNUMBER: INT64_MAX is not exactly representable as
+    // double, and newer AppleClang rejects the implicit conversion under -Werror.
+    if (number >= (JNUMBER)JINTEGER_MAX) {
         object->valueint = JINTEGER_MAX;
-    } else if (number <= JINTEGER_MIN) {
+    } else if (number <= (JNUMBER)JINTEGER_MIN) {
         object->valueint = JINTEGER_MIN;
     } else {
         object->valueint = (JINTEGER)number;
@@ -2335,9 +2339,11 @@ N_CJSON_PUBLIC(J *) JCreateNumber(JNUMBER num)
         item->valuenumber = num;
 
         // Saturate valueint in the case of overflow.
-        if (num >= JINTEGER_MAX) {
+        // Cast integer limits to JNUMBER: INT64_MAX is not exactly representable as
+        // double, and newer AppleClang rejects the implicit conversion under -Werror.
+        if (num >= (JNUMBER)JINTEGER_MAX) {
             item->valueint = JINTEGER_MAX;
-        } else if (num <= JINTEGER_MIN) {
+        } else if (num <= (JNUMBER)JINTEGER_MIN) {
             item->valueint = JINTEGER_MIN;
         } else {
             item->valueint = (JINTEGER)num;

--- a/n_ftoa.c
+++ b/n_ftoa.c
@@ -469,8 +469,12 @@ static uintmax_t cast(JNUMBER value)
      * it may be increased to the nearest higher representable value for the
      * comparison (cf. C99: 6.3.1.4, 2).  It might then equal the JNUMBER
      * value although converting the latter to uintmax_t would overflow.
+     *
+     * Cast UINTMAX_MAX to JNUMBER so the conversion is explicit. Newer
+     * AppleClang rejects the implicit const int→float conversion under
+     * -Werror (-Wimplicit-const-int-float-conversion).
      */
-    if (value >= UINTMAX_MAX) {
+    if (value >= (JNUMBER)UINTMAX_MAX) {
         return UINTMAX_MAX;
     }
 


### PR DESCRIPTION
## Summary

- `macos-latest` now resolves to **macOS 26 / Xcode 26.5**. The `run_macos_unit_tests` job builds the shared `note_c` test library with `-Werror`, and AppleClang started failing on long-standing saturation comparisons that implicitly convert `INT64_MAX` / `UINTMAX_MAX` to `JNUMBER` (`double`).
- This is independent of application changes (e.g. time-sync defaults). The last green macOS job ran on `macos-15-arm64` (2026-07-03); the first red one on `macos-26-arm64` (2026-07-15).
- **Fix:** cast the integer limits to `JNUMBER` at the comparison sites in `n_cjson.c` and `n_ftoa.c` so the conversion is explicit. Behavior remains the same approximate float-range saturation already documented in `n_ftoa.c`.
- **CI:** leave `run_macos_unit_tests` on `macos-latest` and document why the build stays green.

Companion: PR #250 temporarily pins that job to `macos-15` so the time-sync change is not blocked by this toolchain shift.

## Test plan

- [x] Local host: `cmake -B build -DNOTE_C_BUILD_TESTS=ON && cmake --build build --target note_c` succeeds on AppleClang **without** `-Wno-implicit-const-int-float-conversion`
- [x] CI: `run_macos_unit_tests` green on `macos-latest` (macOS 26)
- [x] CI: Linux unit-test jobs still green